### PR TITLE
[EC-32] Classic Chain Check 

### DIFF
--- a/src/main/scala/io/iohk/ethereum/network/PeerActor.scala
+++ b/src/main/scala/io/iohk/ethereum/network/PeerActor.scala
@@ -122,7 +122,7 @@ class PeerActor(nodeInfo: NodeInfo) extends Actor with ActorLogging {
         log.warning("Peer is not running the ETC fork, disconnecting")
         disconnectFromPeer(rlpxConnection, Disconnect.Reasons.UselessPeer)
       }
-    case DaoHeaderReceiveTimeout =>
+    case MessageReceived(BlockHeaders(Nil)) =>
       // FIXME We need to do some checking related to our blockchain. If we haven't arrived to the DAO block we might
       // take advantage of this peer and grab as much blocks as we can until DAO.
       // ATM we will only check by DaoBlockTotalDifficulty
@@ -130,10 +130,7 @@ class PeerActor(nodeInfo: NodeInfo) extends Actor with ActorLogging {
         log.info("Peer probably hasn't arrived to DAO yet")
         context become new HandshakedHandler(rlpxConnection).receive
       }
-      else {
-        log.info("Peer probably has arrived to DAO, so we will disconnect")
-        disconnectFromPeer(rlpxConnection, Disconnect.Reasons.UselessPeer)
-      }
+    case DaoHeaderReceiveTimeout => disconnectFromPeer(rlpxConnection, Disconnect.Reasons.TimeoutOnReceivingAMessage)
   }
 
   private def disconnectFromPeer(rlpxConnection: ActorRef, reason: Int): Unit = {

--- a/src/main/scala/io/iohk/ethereum/network/PeerActor.scala
+++ b/src/main/scala/io/iohk/ethereum/network/PeerActor.scala
@@ -102,7 +102,7 @@ class PeerActor(nodeInfo: NodeInfo) extends Actor with ActorLogging {
       rlpxConnection ! RLPxConnectionHandler.SendMessage(
         GetBlockHeaders(Left(DaoBlockNumber), maxHeaders = 1, skip = 0, reverse = 0)
       )
-      val waitingForDaoTimeout = system.scheduler.scheduleOnce(waitForStatusInterval, self, DaoHeaderReceiveTimeout)
+      val waitingForDaoTimeout = system.scheduler.scheduleOnce(waitForChainCheck, self, DaoHeaderReceiveTimeout)
       context become waitingForChainForkCheck(rlpxConnection, status, waitingForDaoTimeout)
     case StatusReceiveTimeout =>
       log.warning("Timeout while waiting status")

--- a/src/main/scala/io/iohk/ethereum/network/PeerActor.scala
+++ b/src/main/scala/io/iohk/ethereum/network/PeerActor.scala
@@ -1,25 +1,26 @@
 package io.iohk.ethereum.network
 
-import java.math.BigInteger
 import java.net.URI
 
-import io.iohk.ethereum.network.p2p.messages.CommonMessages
+import akka.actor._
+import akka.util.ByteString
+import io.iohk.ethereum.network.p2p._
+import io.iohk.ethereum.network.p2p.messages.CommonMessages.Status
+import io.iohk.ethereum.network.p2p.messages.PV62.{BlockHeaders, GetBlockHeaders}
 import io.iohk.ethereum.network.p2p.messages.WireProtocol._
+import io.iohk.ethereum.network.p2p.validators.ForkValidator
 import io.iohk.ethereum.network.rlpx.RLPxConnectionHandler
+import io.iohk.ethereum.network.rlpx.RLPxConnectionHandler.MessageReceived
 import io.iohk.ethereum.rlp.RLPEncoder
 import org.spongycastle.util.encoders.Hex
 
 import scala.concurrent.duration._
 
-import akka.actor._
-import akka.util.ByteString
-import RLPxConnectionHandler.MessageReceived
-import io.iohk.ethereum.network.p2p._
-
 /**
   * Peer actor is responsible for initiating and handling high-level connection with peer.
   * It creates child RLPxConnectionActor for handling underlying RLPx communication.
-  * Once RLPx connection is established it proceeds with protocol handshake (i.e `Hello` exchange).
+  * Once RLPx connection is established it proceeds with protocol handshake (i.e `Hello`
+  * and `Status` exchange).
   * Once that's done it can send/receive messages with peer (HandshakedHandler.receive).
   */
 class PeerActor(nodeInfo: NodeInfo) extends Actor with ActorLogging {
@@ -30,6 +31,14 @@ class PeerActor(nodeInfo: NodeInfo) extends Actor with ActorLogging {
   val P2pVersion = 4
 
   val peerId = self.path.name
+
+  val waitForStatusInterval = 30.seconds
+  val waitForChainCheck = 15.seconds
+
+  //FIXME move this to props
+  lazy val DaoBlockNumber = 1920000
+  lazy val DaoBlockTotalDifficulty = BigInt("39490964433395682584")
+  lazy val daoForkValidator = ForkValidator(DaoBlockNumber, Hex.decode("94365e3a8c0b35089c1d1195081fe7489b528a84b22199c916180db8b28ade7f"))
 
   override def receive: Receive = waitingForInitialCommand
 
@@ -71,35 +80,91 @@ class PeerActor(nodeInfo: NodeInfo) extends Actor with ActorLogging {
 
   def waitingForHello(rlpxConnection: ActorRef, timeout: Cancellable): Receive = handleTerminated orElse {
     case MessageReceived(d: Disconnect) =>
-      log.info("Received {}. Closing connection", d)
+      log.info("Received {} from peer {}. Closing connection", d, peerId)
       context stop self
-
     case MessageReceived(hello: Hello) =>
-      log.info("Received {}. Protocol handshake finished", hello)
+      log.info("Protocol handshake finished with peer {} ({})", peerId, hello)
       timeout.cancel()
-
       if (hello.capabilities.contains(Capability("eth", Message.PV63.toByte))) {
+        rlpxConnection ! RLPxConnectionHandler.SendMessage(ourStatus) // atm we will send the same message
+        val statusTimeout = system.scheduler.scheduleOnce(waitForStatusInterval, self, StatusReceiveTimeout)
+        context become waitingForNodeStatus(rlpxConnection, statusTimeout)
+      } else {
+        log.info("Connected peer does not support eth {} protocol. Disconnecting.", Message.PV63.toByte)
+        disconnectFromPeer(rlpxConnection, Disconnect.Reasons.IncompatibleP2pProtocolVersion)
+      }
+  }
 
-        rlpxConnection ! RLPxConnectionHandler.SendMessage(
-          CommonMessages.Status(
-            protocolVersion = Message.PV63,
-            networkId = 1,
-            totalDifficulty = new BigInteger("17179869184"),
-            bestHash = ByteString(Hex.decode("d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3")),
-            genesisHash = ByteString(Hex.decode("d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3"))))
+  def waitingForNodeStatus(rlpxConnection: ActorRef, timeout: Cancellable): Receive = handleTerminated orElse
+    handlePing(rlpxConnection) orElse {
+    case MessageReceived(status: Status) =>
+      timeout.cancel()
+      log.info("Peer {} returned status ({})", peerId, status)
+      rlpxConnection ! RLPxConnectionHandler.SendMessage(
+        GetBlockHeaders(Left(DaoBlockNumber), maxHeaders = 1, skip = 0, reverse = 0)
+      )
+      val waitingForDaoTimeout = system.scheduler.scheduleOnce(waitForStatusInterval, self, NoDaoHeaderReceived)
+      context become waitingForChainForkCheck(rlpxConnection, status, waitingForDaoTimeout)
+    case StatusReceiveTimeout =>
+      log.warning("Timeout while waiting for peer {} status", peerId)
+      disconnectFromPeer(rlpxConnection, Disconnect.Reasons.TimeoutOnReceivingAMessage)
+    case MessageReceived(d: Disconnect) =>
+      log.info("Received {} from peer {}. Closing connection", d, peerId)
+      context stop self
+  }
 
+  def waitingForChainForkCheck(rlpxConnection: ActorRef, status: Status, timeout: Cancellable): Receive = handleTerminated orElse
+    handlePing(rlpxConnection) orElse {
+    case MessageReceived(msg@BlockHeaders(blockHeader +: Nil)) if blockHeader.number == DaoBlockNumber =>
+      timeout.cancel()
+      log.info("DAO Fork header received from peer {} - {}", peerId, Hex.toHexString(blockHeader.hash))
+      if (daoForkValidator.validate(msg).isEmpty) {
+        log.warning("Peer {} is running the ETC chain", peerId)
         context become new HandshakedHandler(rlpxConnection).receive
       } else {
-        log.info("Peer does not support eth {} protocol. Disconnecting.", Message.PV63.toByte)
-        rlpxConnection ! SendMessage(Disconnect(Disconnect.Reasons.IncompatibleP2pProtocolVersion))
-        context.system.scheduler.scheduleOnce(5.seconds, self, PoisonPill)
+        log.warning("Peer {} is not running the ETC fork, disconnecting", peerId)
+        disconnectFromPeer(rlpxConnection, Disconnect.Reasons.UselessPeer)
       }
+    case MessageReceived(d: Disconnect) =>
+      log.info("Received {} from peer {}. Closing connection", d, peerId)
+      disconnectFromPeer(rlpxConnection, Disconnect.Reasons.UselessPeer)
+    case NoDaoHeaderReceived =>
+      // FIXME We need to do some checking related to our blockchain. If we haven't arrived to the DAO block we might
+      // take advantage of this peer and grab as much blocks as we can until DAO.
+      // ATM we will only check by DaoBlockTotalDifficulty
+      if (status.totalDifficulty < DaoBlockTotalDifficulty) {
+        log.info("Peer {} probably hasn't arrived to DAO yet, so we will wait")
+        context become new HandshakedHandler(rlpxConnection).receive
+      }
+      else {
+        log.info("Peer {} probably hasn't arrived to DAO yet, so we will wait")
+        disconnectFromPeer(rlpxConnection, Disconnect.Reasons.UselessPeer)
+      }
+  }
+
+  private def disconnectFromPeer(rlpxConnection: ActorRef, reason: Int): Unit = {
+    rlpxConnection ! SendMessage(Disconnect(Disconnect.Reasons.TimeoutOnReceivingAMessage))
+    context.system.scheduler.scheduleOnce(5.seconds, self, PoisonPill)
+  }
+
+  // FIXME This is a temporal function until we start keeping our status
+  private def ourStatus: Status = {
+    val totalDifficulty = 34351349760L
+    Status(
+      protocolVersion = Message.PV63, 1, totalDifficulty,
+      ByteString(Hex.decode("88e96d4537bea4d9c05d12549907b32561d3bf31f45aae734cdc119f13406cb6")),
+      ByteString(Hex.decode("d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3"))
+    )
   }
 
   def handleTerminated: Receive = {
     case _: Terminated =>
       log.info("RLPx connection actor terminated")
       context stop self
+  }
+
+  def handlePing(rlpxConnection: ActorRef): Receive = {
+    case MessageReceived(ping: Ping) => rlpxConnection ! RLPxConnectionHandler.SendMessage(Pong())
   }
 
   class HandshakedHandler(rlpxConnection: ActorRef) {
@@ -126,6 +191,7 @@ class PeerActor(nodeInfo: NodeInfo) extends Actor with ActorLogging {
     }
 
   }
+
 }
 
 object PeerActor {
@@ -133,9 +199,15 @@ object PeerActor {
     Props(new PeerActor(nodeInfo))
 
   case class HandleConnection(connection: ActorRef)
+
   case class ConnectTo(uri: URI)
 
   case class SendMessage[M <: Message](message: M)(implicit val enc: RLPEncoder[M])
 
+  private case object NoDaoHeaderReceived
+
   private case object ProtocolHandshakeTimeout
+
+  private case object StatusReceiveTimeout
+
 }

--- a/src/main/scala/io/iohk/ethereum/network/PeerActor.scala
+++ b/src/main/scala/io/iohk/ethereum/network/PeerActor.scala
@@ -38,7 +38,7 @@ class PeerActor(nodeInfo: NodeInfo) extends Actor with ActorLogging {
   //FIXME move this to props
   lazy val DaoBlockNumber = 1920000
   lazy val DaoBlockTotalDifficulty = BigInt("39490964433395682584")
-  lazy val daoForkValidator = ForkValidator(DaoBlockNumber, Hex.decode("94365e3a8c0b35089c1d1195081fe7489b528a84b22199c916180db8b28ade7f"))
+  lazy val daoForkValidator = ForkValidator(DaoBlockNumber, ByteString(Hex.decode("94365e3a8c0b35089c1d1195081fe7489b528a84b22199c916180db8b28ade7f")))
 
   override def receive: Receive = waitingForInitialCommand
 

--- a/src/main/scala/io/iohk/ethereum/network/PeerActor.scala
+++ b/src/main/scala/io/iohk/ethereum/network/PeerActor.scala
@@ -36,6 +36,7 @@ class PeerActor(nodeInfo: NodeInfo) extends Actor with ActorLogging {
   val waitForChainCheck = 15.seconds
 
   //FIXME move this to props
+  // Doc: https://blog.ethereum.org/2016/07/20/hard-fork-completed/
   lazy val DaoBlockNumber = 1920000
   lazy val DaoBlockTotalDifficulty = BigInt("39490964433395682584")
   lazy val daoForkValidator = ForkValidator(DaoBlockNumber, ByteString(Hex.decode("94365e3a8c0b35089c1d1195081fe7489b528a84b22199c916180db8b28ade7f")))

--- a/src/main/scala/io/iohk/ethereum/network/p2p/messages/PV62.scala
+++ b/src/main/scala/io/iohk/ethereum/network/p2p/messages/PV62.scala
@@ -101,11 +101,6 @@ object PV62 {
     """.stripMargin
   }
 
-
-
-
-
-
   object BlockHash {
     implicit val rlpEndDec = new RLPEncoder[BlockHash] with RLPDecoder[BlockHash] {
       override def encode(obj: BlockHash): RLPEncodeable = {
@@ -167,6 +162,7 @@ object PV62 {
   }
 
   object BlockHeader {
+
     implicit val rlpEndDec = new RLPEncoder[BlockHeader] with RLPDecoder[BlockHeader] {
       override def encode(obj: BlockHeader): RLPEncodeable = {
         import obj._
@@ -228,6 +224,8 @@ object PV62 {
     extraData: ByteString,
     mixHash: ByteString,
     nonce: ByteString) {
+
+    import BlockHeader._
 
     lazy val hash: Array[Byte] = sha3(encode[BlockHeader](this))
 

--- a/src/main/scala/io/iohk/ethereum/network/p2p/validators/ForkValidator.scala
+++ b/src/main/scala/io/iohk/ethereum/network/p2p/validators/ForkValidator.scala
@@ -1,0 +1,31 @@
+package io.iohk.ethereum.network.p2p.validators
+
+import io.iohk.ethereum.network.p2p.messages.PV62.{BlockHeader, BlockHeaders}
+import org.spongycastle.util.encoders.Hex
+
+/**
+  * This Validator checks if a given `BlockHeaders` contains a `BlockHeader` having a specific block number and hash
+  *
+  * This will be usually used to check if we are dealing with DAO Forked block (number = 1920000 and hash distinct of
+  * 94365e3a8c0b35089c1d1195081fe7489b528a84b22199c916180db8b28ade7f)
+  *
+  * @param blockNumber BlockNumber to check
+  * @param blockHash Hash of the block whose number is `blockNumber`
+  */
+case class ForkValidator(blockNumber: BigInt, blockHash: Array[Byte]) extends MessageValidator[BlockHeaders, ForkValidatorError] {
+
+  /**
+    * Validates the header
+    *
+    * @param message Message to be validate
+    * @return an object containing the list of invalid headers found
+    */
+  override def validate(message: BlockHeaders): Option[ForkValidatorError] = {
+    val errors = message.headers.filter { header =>
+      header.number == blockNumber && !(header.hash sameElements blockHash)
+    }
+    errors.headOption.map(_ => ForkValidatorError(errors))
+  }
+}
+
+case class ForkValidatorError(invalidHeaders: Seq[BlockHeader]) extends MessageValidatorError

--- a/src/main/scala/io/iohk/ethereum/network/p2p/validators/ForkValidator.scala
+++ b/src/main/scala/io/iohk/ethereum/network/p2p/validators/ForkValidator.scala
@@ -1,5 +1,6 @@
 package io.iohk.ethereum.network.p2p.validators
 
+import akka.util.ByteString
 import io.iohk.ethereum.network.p2p.messages.PV62.{BlockHeader, BlockHeaders}
 import org.spongycastle.util.encoders.Hex
 
@@ -12,7 +13,7 @@ import org.spongycastle.util.encoders.Hex
   * @param blockNumber BlockNumber to check
   * @param blockHash Hash of the block whose number is `blockNumber`
   */
-case class ForkValidator(blockNumber: BigInt, blockHash: Array[Byte]) extends MessageValidator[BlockHeaders, ForkValidatorError] {
+case class ForkValidator(blockNumber: BigInt, blockHash: ByteString) extends MessageValidator[BlockHeaders, ForkValidatorError] {
 
   /**
     * Validates the header

--- a/src/main/scala/io/iohk/ethereum/network/p2p/validators/MessageValidator.scala
+++ b/src/main/scala/io/iohk/ethereum/network/p2p/validators/MessageValidator.scala
@@ -1,0 +1,14 @@
+package io.iohk.ethereum.network.p2p.validators
+
+import io.iohk.ethereum.network.p2p.Message
+
+/**
+  * Trait to be used to validate messages received from other peers
+  * @tparam M Messate to validate
+  * @tparam E Error to be returned if message isn't valid
+  */
+trait MessageValidator[M <: Message, E <: MessageValidatorError] {
+  def validate(message: M): Option[E]
+}
+
+trait MessageValidatorError

--- a/src/test/scala/io/iohk/ethereum/network/p2p/validators/ForkValidatorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/network/p2p/validators/ForkValidatorSpec.scala
@@ -1,0 +1,85 @@
+package io.iohk.ethereum.network.p2p.validators
+
+import akka.util.ByteString
+import io.iohk.ethereum.network.p2p.messages.PV62.{BlockHeader, BlockHeaders}
+import org.scalatest.{FlatSpec, Matchers}
+import org.spongycastle.util.encoders.Hex
+
+class ForkValidatorSpec extends FlatSpec with Matchers {
+
+  val daoForkValidator = ForkValidator(1920000, Hex.decode("94365e3a8c0b35089c1d1195081fe7489b528a84b22199c916180db8b28ade7f"))
+
+  "DaoForkValidator" should "determine if it's ETH fork" in {
+    assert(Hex.toHexString(daoForkHeader.hash) == "4985f5ca3d2afbec36529aa96f74de3cc10a2a4a6c44f2157a57d2c6059a11bb")
+    val validationResult = daoForkValidator.validate(BlockHeaders(Seq(daoForkHeader)))
+    assert(validationResult.isDefined)
+    assert(validationResult.get.invalidHeaders.size == 1)
+    assert(validationResult.get.invalidHeaders.head.hash sameElements daoForkHeader.hash)
+  }
+
+  "DaoForkValidator" should "determine if it's ETC fork" in {
+    assert(Hex.toHexString(etcForkHeader.hash) == "94365e3a8c0b35089c1d1195081fe7489b528a84b22199c916180db8b28ade7f")
+    assert(daoForkValidator.validate(BlockHeaders(Seq(etcForkHeader))).isEmpty)
+  }
+
+  "DaoForkValidator" should "detect invalid fork amongst other headers" in {
+    val validationResult = daoForkValidator.validate(BlockHeaders(Seq(etcForkHeader, daoForkHeader, someHeader)))
+    assert(validationResult.isDefined)
+    assert(validationResult.get.invalidHeaders.size == 1)
+    assert(validationResult.get.invalidHeaders.head.hash sameElements daoForkHeader.hash)
+  }
+
+  val someHeader: BlockHeader = BlockHeader(
+    parentHash = ByteString(Hex.decode("322c6d0946950a85673b71c5a9a536ebb1d9498ad81df1a90e8b72251752ada6")),
+    ommersHash = ByteString(Hex.decode("143f89e81f6319fcd4f460b28a035376dc4b7cb1cd4c9b2036a53cd6d9e47933")),
+    beneficiary = ByteString(Hex.decode("bcdfc35b86bedf72f0cda046a3c16829a2ef41d1")),
+    stateRoot = ByteString(Hex.decode("de32eda1f31bb9412ed4563c8392a9bbba76bc876dd5b98218b64266dd8238fd")),
+    transactionsRoot = ByteString(Hex.decode("7701df8e07169452554d14aadd7bfa256d4a1d0355c1d174ab373e3e2d0a3743")),
+    receiptsRoot = ByteString(Hex.decode("26cf9d9422e9dd95aedc7914db690b92bab6902f5221d62694a2fa5d065f534b")),
+    logsBloom = ByteString(Hex.decode("00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000")),
+    difficulty = BigInt(62452008773236L),
+    number = BigInt(1910000),
+    gasLimit = BigInt(4700000),
+    gasUsed = BigInt(0),
+    unixTimestamp = 1468877583L,
+    extraData = ByteString(Hex.decode("4477617266506f6f6c")),
+    mixHash = ByteString(Hex.decode("7d1f1c34e6ab26c4a28923363c238c21299aafd44ac42a775ed1fb2834126b3f")),
+    nonce = ByteString(Hex.decode("493fb58c01b25f6f"))
+  )
+
+  val daoForkHeader: BlockHeader = BlockHeader(
+    parentHash = ByteString(Hex.decode("a218e2c611f21232d857e3c8cecdcdf1f65f25a4477f98f6f47e4063807f2308")),
+    ommersHash = ByteString(Hex.decode("1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347")),
+    beneficiary = ByteString(Hex.decode("bcdfc35b86bedf72f0cda046a3c16829a2ef41d1")),
+    stateRoot = ByteString(Hex.decode("c5e389416116e3696cce82ec4533cce33efccb24ce245ae9546a4b8f0d5e9a75")),
+    transactionsRoot = ByteString(Hex.decode("7701df8e07169452554d14aadd7bfa256d4a1d0355c1d174ab373e3e2d0a3743")),
+    receiptsRoot = ByteString(Hex.decode("26cf9d9422e9dd95aedc7914db690b92bab6902f5221d62694a2fa5d065f534b")),
+    logsBloom = ByteString(Hex.decode("00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000")),
+    difficulty = BigInt(62413376722602L),
+    number = BigInt(1920000),
+    gasLimit = BigInt(4712384),
+    gasUsed = BigInt(84000),
+    unixTimestamp = 1469020840L,
+    extraData = ByteString(Hex.decode("64616f2d686172642d666f726b")),
+    mixHash = ByteString(Hex.decode("5b5acbf4bf305f948bd7be176047b20623e1417f75597341a059729165b92397")),
+    nonce = ByteString(Hex.decode("bede87201de42426"))
+  )
+
+  val etcForkHeader = BlockHeader(
+    parentHash = ByteString(Hex.decode("a218e2c611f21232d857e3c8cecdcdf1f65f25a4477f98f6f47e4063807f2308")),
+    ommersHash = ByteString(Hex.decode("1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347")),
+    beneficiary = ByteString(Hex.decode("61c808d82a3ac53231750dadc13c777b59310bd9")),
+    stateRoot = ByteString(Hex.decode("614d7d358b03cbdaf0343529673be20ad45809d02487f023e047efdce9da8aff")),
+    transactionsRoot = ByteString(Hex.decode("d33068a7f21bff5018a00ca08a3566a06be4196dfe9e39f96e431565a619d455")),
+    receiptsRoot = ByteString(Hex.decode("7bda9aa65977800376129148cbfe89d35a016dd51c95d6e6dc1e76307d315468")),
+    logsBloom = ByteString(Hex.decode("00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000")),
+    difficulty = BigInt(62413376722602L),
+    number = BigInt(1920000),
+    gasLimit = BigInt(4712384),
+    gasUsed = BigInt(84000),
+    unixTimestamp = 1469020839L,
+    extraData = ByteString(Hex.decode("e4b883e5bda9e7a59ee4bb99e9b1bc")),
+    mixHash = ByteString(Hex.decode("c52daa7054babe515b17ee98540c0889cf5e1595c5dd77496997ca84a68c8da1")),
+    nonce = ByteString(Hex.decode("05276a600980199d"))
+  )
+}

--- a/src/test/scala/io/iohk/ethereum/network/p2p/validators/ForkValidatorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/network/p2p/validators/ForkValidatorSpec.scala
@@ -7,7 +7,7 @@ import org.spongycastle.util.encoders.Hex
 
 class ForkValidatorSpec extends FlatSpec with Matchers {
 
-  val daoForkValidator = ForkValidator(1920000, Hex.decode("94365e3a8c0b35089c1d1195081fe7489b528a84b22199c916180db8b28ade7f"))
+  val daoForkValidator = ForkValidator(1920000, ByteString(Hex.decode("94365e3a8c0b35089c1d1195081fe7489b528a84b22199c916180db8b28ade7f")))
 
   "DaoForkValidator" should "determine if it's ETH fork" in {
     assert(Hex.toHexString(daoForkHeader.hash) == "4985f5ca3d2afbec36529aa96f74de3cc10a2a4a6c44f2157a57d2c6059a11bb")


### PR DESCRIPTION
## Description

The client will connect only to an ETC supporting client. In order to do so, after handshake Dao BlockHeaders is requested in order to compare it's hash with the ETC fork one.

If the other peer does not return the block we have a simplification about the one stated [here](https://github.com/ethereum/go-ethereum/pull/2795). We are not currently checking our blockchain but comparing DaoBlock total difficulty (TD) against other node TD as this is and indicator for the longest chain. That being said, this tweak should not break thingsbecause the node sync process will disconnect from that peer if DAO block is found.

Note1: our client node status is hardcoded and needs to be changed during the next sprints

Note: BlockHeader validation logic was encapsulated in order to be re-used by @adamsmo (not approved by him yet :stuck_out_tongue:) while block downloading / sync is in progress. Also, it's ment to be used in a some sort of _validators chain_ to apply several checks to different message responses. Feel free to leave any suggestions / changes on this.

### Test

You can check an ETH node running this `sbt 'run-main io.iohk.ethereum.App enode://a979fb575495b8d6db44f750317d0f4622bf4c2aa3365d6af7c284339968eef29b69ad0dce72a4d8db5ebb4968de0e3bec910127f134779fbcb0cb6d3331163c@52.16.188.185:30303'`
