### PR TITLE
[EC-42] Store downloaded receipts

### DIFF
--- a/src/main/scala/io/iohk/ethereum/db/ReceiptStorage.scala
+++ b/src/main/scala/io/iohk/ethereum/db/ReceiptStorage.scala
@@ -1,0 +1,22 @@
+package io.iohk.ethereum.db
+
+import io.iohk.ethereum.mpt.DataSource
+import io.iohk.ethereum.network.p2p.messages.PV63.Receipt
+import io.iohk.ethereum.rlp.RLPImplicits._
+import io.iohk.ethereum.rlp.{decode => rlpDecode, encode => rlpEncode}
+
+object ReceiptStorage {
+  def put(blockHash: Array[Byte], blockReceipts: Seq[Receipt], dataSource: DataSource): DataSource = {
+    val encodedReceipts = rlpEncode(blockReceipts)(seqEncDec[Receipt])
+    dataSource.update(blockHash, Seq(), Seq(blockHash -> encodedReceipts))
+  }
+
+  def get(blockHash: Array[Byte], dataSource: DataSource): Option[Seq[Receipt]] = {
+    val encodedReceipts = dataSource.get(blockHash)
+    encodedReceipts.map(rlpDecode[Seq[Receipt]](_)(seqEncDec[Receipt]))
+  }
+
+  def remove(blockHash: Array[Byte], dataSource: DataSource): DataSource = {
+    dataSource.update(blockHash, Seq(blockHash), Seq())
+  }
+}

--- a/src/test/scala/io/iohk/ethereum/ObjectGenerators.scala
+++ b/src/test/scala/io/iohk/ethereum/ObjectGenerators.scala
@@ -1,6 +1,9 @@
 package io.iohk.ethereum
 
 import java.math.BigInteger
+
+import akka.util.ByteString
+import io.iohk.ethereum.network.p2p.messages.PV63.Receipt
 import org.scalacheck.{Arbitrary, Gen}
 
 trait ObjectGenerators {
@@ -24,4 +27,16 @@ trait ObjectGenerators {
     aKeyList <- Gen.nonEmptyListOf(Arbitrary.arbitrary[Int]).map(_.distinct)
   } yield aKeyList.zip(aKeyList)
 
+  def receiptGen(): Gen[Receipt] = for {
+    postTransactionStateHash <- anyArrayGen
+    cumulativeGasUsed <- bigIntGen
+    logsBloomFilter <- anyArrayGen
+  } yield Receipt(
+    postTransactionStateHash = ByteString(postTransactionStateHash),
+    cumulativeGasUsed = cumulativeGasUsed,
+    logsBloomFilter = ByteString(logsBloomFilter),
+    logs = Seq()
+  )
+
+  def receiptsGen(n: Int): Gen[Seq[Seq[Receipt]]] = Gen.listOfN(n, Gen.listOf(receiptGen()))
 }

--- a/src/test/scala/io/iohk/ethereum/db/ReceiptStorageSuite.scala
+++ b/src/test/scala/io/iohk/ethereum/db/ReceiptStorageSuite.scala
@@ -1,0 +1,57 @@
+package io.iohk.ethereum.db
+
+import io.iohk.ethereum.ObjectGenerators
+import io.iohk.ethereum.mpt.{DataSource, EphemDataSource}
+import io.iohk.ethereum.network.p2p.messages.PV63.Receipt
+import org.scalacheck.Gen
+import org.scalatest.FunSuite
+import org.scalatest.prop.PropertyChecks
+
+import scala.util.Random
+
+class ReceiptStorageSuite extends FunSuite with PropertyChecks with ObjectGenerators{
+  test("ReceiptStorage insert") {
+    forAll(Gen.listOf(anyArrayGen)){ blockByteArrayHashes =>
+      val blockHashes = blockByteArrayHashes.distinct
+      val receipts = receiptsGen(blockHashes.length).sample.get
+      val blockHashesReceiptsPair = receipts.zip(blockHashes)
+
+      val dataSource = blockHashesReceiptsPair.foldLeft(EphemDataSource(): DataSource){
+        case (recDataSource, (receiptList, blockHash)) =>
+          ReceiptStorage.put(blockHash, receiptList, recDataSource)
+      }
+
+      blockHashesReceiptsPair.foreach{case (rs, bh) =>
+        val obtainedReceipts: Option[Seq[Receipt]] = ReceiptStorage.get(bh, dataSource)
+        assert(obtainedReceipts.isDefined && (obtainedReceipts.get equals rs))
+      }
+    }
+  }
+
+  test("ReceiptStorage delete") {
+    forAll(Gen.listOf(anyArrayGen)){ blockByteArrayHashes =>
+      val blockHashes = blockByteArrayHashes.distinct
+      val receipts = receiptsGen(blockHashes.length).sample.get
+      val blockHashesReceiptsPair = receipts.zip(blockHashes)
+
+      //Receipts are inserted
+      val dataSource = blockHashesReceiptsPair.foldLeft(EphemDataSource(): DataSource){
+        case (recDataSource, (receiptList, blockHash)) =>
+          ReceiptStorage.put(blockHash, receiptList, recDataSource)
+      }
+
+      //Receipts are deleted
+      val (toDelete, toLeave) = Random.shuffle(blockHashesReceiptsPair).splitAt(Gen.choose(0, blockHashesReceiptsPair.size).sample.get)
+      val dataSourceAfterDelete = toDelete.foldLeft(dataSource: DataSource){
+        case (recDataSource, (_, blockHash)) =>
+          ReceiptStorage.remove(blockHash, recDataSource)
+      }
+
+      toLeave.foreach{case (rs, bh) =>
+        val obtainedReceipts = ReceiptStorage.get(bh, dataSourceAfterDelete)
+        assert(obtainedReceipts.isDefined && (obtainedReceipts.get equals rs))
+      }
+      toDelete.foreach{ case (_, bh) => assert(ReceiptStorage.get(bh, dataSourceAfterDelete).isEmpty) }
+    }
+  }
+}


### PR DESCRIPTION
Included functions for storing receipts on IODB, this DataSource will store the `block hash -> block receipts (encoded with RLP)` relation.