### PR TITLE
[EC-45] Add dao fork check

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -26,6 +26,11 @@ etc-client {
   blockchain {
     genesis-difficulty = 17179869184
     genesis-hash = "d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3"
+
+    // Doc: https://blog.ethereum.org/2016/07/20/hard-fork-completed/
+    dao-fork-block-number = "1920000"
+    dao-fork-block-total-difficulty = "39490964433395682584"
+    dao-fork-block-hash = "94365e3a8c0b35089c1d1195081fe7489b528a84b22199c916180db8b28ade7f"
   }
 
 }

--- a/src/main/scala/io/iohk/ethereum/network/PeerActor.scala
+++ b/src/main/scala/io/iohk/ethereum/network/PeerActor.scala
@@ -16,7 +16,6 @@ import io.iohk.ethereum.network.p2p.validators.ForkValidator
 import io.iohk.ethereum.network.rlpx.RLPxConnectionHandler
 import io.iohk.ethereum.rlp.RLPEncoder
 import io.iohk.ethereum.utils.{ServerStatus, NodeStatus, Config}
-import org.spongycastle.util.encoders.Hex
 
 /**
   * Peer actor is responsible for initiating and handling high-level connection with peer.
@@ -32,6 +31,7 @@ class PeerActor(
 
   import PeerActor._
   import Config.Network.Peer._
+  import Config.Blockchain._
   import context.{dispatcher, system}
 
   val P2pVersion = 4
@@ -43,11 +43,7 @@ class PeerActor(
   val waitForStatusInterval = 30.seconds
   val waitForChainCheck = 15.seconds
 
-  //FIXME move this to props
-  // Doc: https://blog.ethereum.org/2016/07/20/hard-fork-completed/
-  lazy val DaoBlockNumber = 1920000
-  lazy val DaoBlockTotalDifficulty = BigInt("39490964433395682584")
-  lazy val daoForkValidator = ForkValidator(DaoBlockNumber, ByteString(Hex.decode("94365e3a8c0b35089c1d1195081fe7489b528a84b22199c916180db8b28ade7f")))
+  val daoForkValidator = ForkValidator(daoForkBlockNumber, daoForkBlockHash)
 
   private var messageSubscribers: Seq[Subscriber] = Nil
 
@@ -150,7 +146,7 @@ class PeerActor(
       networkId = Config.Network.networkId,
       totalDifficulty = nodeStatus.blockchainStatus.totalDifficulty,
       bestHash = nodeStatus.blockchainStatus.bestHash,
-      genesisHash = Config.Blockchain.genesisHash)
+      genesisHash = genesisHash)
   }
 
   def waitingForNodeStatus(rlpxConnection: RLPxConnection, timeout: Cancellable): Receive =
@@ -159,7 +155,7 @@ class PeerActor(
     case RLPxConnectionHandler.MessageReceived(status: msg.Status) =>
       timeout.cancel()
       log.info("Peer returned status ({})", status)
-      rlpxConnection.sendMessage(GetBlockHeaders(Left(DaoBlockNumber), maxHeaders = 1, skip = 0, reverse = 0))
+      rlpxConnection.sendMessage(GetBlockHeaders(Left(daoForkBlockNumber), maxHeaders = 1, skip = 0, reverse = 0))
       val waitingForDaoTimeout = system.scheduler.scheduleOnce(waitForChainCheck, self, DaoHeaderReceiveTimeout)
       context become waitingForChainForkCheck(rlpxConnection, status, waitingForDaoTimeout)
 
@@ -170,27 +166,35 @@ class PeerActor(
     case GetStatus => sender() ! StatusResponse(Handshaking)
   }
 
-  def waitingForChainForkCheck(rlpxConnection: RLPxConnection, status: msg.Status, timeout: Cancellable): Receive =
+  def waitingForChainForkCheck(rlpxConnection: RLPxConnection, remoteStatus: msg.Status, timeout: Cancellable): Receive =
     handleSubscriptions orElse handleTerminated(rlpxConnection) orElse
     handleDisconnectMsg orElse handlePingMsg(rlpxConnection) orElse {
-    case RLPxConnectionHandler.MessageReceived(msg@BlockHeaders(blockHeader +: Nil)) if blockHeader.number == DaoBlockNumber =>
-      timeout.cancel()
-      log.info("DAO Fork header received from peer - {}", Hex.toHexString(blockHeader.hash.toArray))
-      if (daoForkValidator.validate(msg).isEmpty) {
-        log.warning("Peer is running the ETC chain")
-        context become new HandshakedHandler(rlpxConnection).receive
-      } else {
-        log.warning("Peer is not running the ETC fork, disconnecting")
-        disconnectFromPeer(rlpxConnection, Disconnect.Reasons.UselessPeer)
-      }
 
-    case RLPxConnectionHandler.MessageReceived(BlockHeaders(Nil)) =>
-      // FIXME We need to do some checking related to our blockchain. If we haven't arrived to the DAO block we might
-      // take advantage of this peer and grab as much blocks as we can until DAO.
-      // ATM we will only check by DaoBlockTotalDifficulty
-      if (status.totalDifficulty < DaoBlockTotalDifficulty) {
-        log.info("Peer probably hasn't arrived to DAO yet")
-        context become new HandshakedHandler(rlpxConnection).receive
+    case RLPxConnectionHandler.MessageReceived(msg @ BlockHeaders(blockHeaders)) =>
+      timeout.cancel()
+
+      val daoBlockHeaderOpt = blockHeaders.find(_.number == daoForkBlockNumber)
+
+      daoBlockHeaderOpt match {
+        case Some(daoBlockHeader) if daoForkValidator.validate(msg).isEmpty =>
+          log.info("Peer is running the ETC chain")
+          context become new HandshakedHandler(rlpxConnection).receive
+
+        case Some(_) if nodeStatusHolder().blockchainStatus.totalDifficulty < daoForkBlockTotalDifficulty =>
+          log.info("Peer is not running the ETC fork, but we're not there yet. Keeping the connection until then.")
+          context become new HandshakedHandler(rlpxConnection).receive
+
+        case Some(_) =>
+          log.info("Peer is not running the ETC fork, disconnecting")
+          disconnectFromPeer(rlpxConnection, Disconnect.Reasons.UselessPeer)
+
+        case None if remoteStatus.totalDifficulty < daoForkBlockTotalDifficulty =>
+          log.info("Peer is not at ETC fork yet. Keeping the connection until then.")
+          context become new HandshakedHandler(rlpxConnection).receive
+
+        case None =>
+          log.info("Peer did not respond with ETC fork block header")
+          disconnectFromPeer(rlpxConnection, Disconnect.Reasons.UselessPeer)
       }
 
     case DaoHeaderReceiveTimeout => disconnectFromPeer(rlpxConnection, Disconnect.Reasons.TimeoutOnReceivingAMessage)
@@ -251,6 +255,7 @@ class PeerActor(
     def receive: Receive =
       handleSubscriptions orElse handleTerminated(rlpxConnection) orElse {
       case RLPxConnectionHandler.MessageReceived(message) =>
+        log.info("Received message: {}", message)
         notifySubscribers(message)
         processMessage(message)
 
@@ -275,8 +280,18 @@ class PeerActor(
         log.info("Received {}. Closing connection", d)
         context stop self
 
-      case msg =>
-        log.info("Received message: {}", msg)
+      case msg @ BlockHeaders(blockHeaders) =>
+        val daoBlockHeaderOpt = blockHeaders.find(_.number == daoForkBlockNumber)
+
+        daoBlockHeaderOpt foreach { daoBlockHeader =>
+          log.info("Reached the ETC fork block header")
+          if (daoForkValidator.validate(msg).nonEmpty) {
+            log.info("Peer is not running the ETC fork, disconnecting")
+            disconnectFromPeer(rlpxConnection, Disconnect.Reasons.UselessPeer)
+          }
+        }
+
+      case _ => // nothing
     }
 
   }

--- a/src/main/scala/io/iohk/ethereum/network/p2p/validators/ForkValidator.scala
+++ b/src/main/scala/io/iohk/ethereum/network/p2p/validators/ForkValidator.scala
@@ -23,7 +23,7 @@ case class ForkValidator(blockNumber: BigInt, blockHash: ByteString) extends Mes
     */
   override def validate(message: BlockHeaders): Option[ForkValidatorError] = {
     val errors = message.headers.filter { header =>
-      header.number == blockNumber && !(header.hash sameElements blockHash)
+      header.number == blockNumber && !(header.hash == blockHash)
     }
     errors.headOption.map(_ => ForkValidatorError(errors))
   }

--- a/src/main/scala/io/iohk/ethereum/utils/Config.scala
+++ b/src/main/scala/io/iohk/ethereum/utils/Config.scala
@@ -47,6 +47,10 @@ object Config {
 
     val genesisDifficulty = blockchainConfig.getLong("genesis-difficulty")
     val genesisHash = ByteString(Hex.decode(blockchainConfig.getString("genesis-hash")))
+
+    val daoForkBlockNumber = BigInt(blockchainConfig.getString("dao-fork-block-number"))
+    val daoForkBlockTotalDifficulty = BigInt(blockchainConfig.getString("dao-fork-block-total-difficulty"))
+    val daoForkBlockHash = ByteString(Hex.decode(blockchainConfig.getString("dao-fork-block-hash")))
   }
 
 }

--- a/src/test/scala/io/iohk/ethereum/network/p2p/PeerActorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/network/p2p/PeerActorSpec.scala
@@ -2,6 +2,11 @@ package io.iohk.ethereum.network.p2p
 
 import java.net.URI
 
+import io.iohk.ethereum.network.p2p.messages.CommonMessages.Status
+import io.iohk.ethereum.network.p2p.messages.PV62.{GetBlockHeaders, BlockHeader, BlockHeaders}
+import org.spongycastle.util.encoders.Hex
+
+import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
 
 import akka.actor.{PoisonPill, Terminated, ActorSystem}
@@ -9,11 +14,13 @@ import akka.agent.Agent
 import akka.testkit.{TestProbe, TestActorRef}
 import akka.util.ByteString
 import io.iohk.ethereum.crypto
-import io.iohk.ethereum.network.p2p.messages.WireProtocol.Hello
+import io.iohk.ethereum.network.p2p.messages.WireProtocol._
 import io.iohk.ethereum.network.rlpx.RLPxConnectionHandler
 import io.iohk.ethereum.network.PeerActor
-import io.iohk.ethereum.utils.{BlockchainStatus, ServerStatus, NodeStatus}
+import io.iohk.ethereum.utils.{Config, BlockchainStatus, ServerStatus, NodeStatus}
 import org.scalatest.{FlatSpec, Matchers}
+
+import scala.util.Random
 
 class PeerActorSpec extends FlatSpec with Matchers {
 
@@ -62,6 +69,173 @@ class PeerActorSpec extends FlatSpec with Matchers {
     rlpxConnection.ref ! PoisonPill
     peer.unwatch(rlpxConnection.ref)
     rlpxConnection.expectMsgClass(classOf[RLPxConnectionHandler.ConnectTo])
+  }
+
+  it should "successfully connect to ETC peer" in new TestSetup with BlockUtils {
+    nodeStatusHolder.send(_.copy(blockchainStatus = BlockchainStatus(
+      Config.Blockchain.daoForkBlockTotalDifficulty + 10000000, // we're at some block, after the fork
+      ByteString("unused"))))
+
+    peer ! PeerActor.ConnectTo(new URI("encode://localhost:9000"))
+
+    rlpxConnection.expectMsgClass(classOf[RLPxConnectionHandler.ConnectTo])
+    rlpxConnection.reply(RLPxConnectionHandler.ConnectionEstablished)
+
+    val remoteHello = Hello(4, "test-client", Seq(Capability("eth", Message.PV63.toByte)), 9000, ByteString("unused"))
+    rlpxConnection.expectMsgPF() { case RLPxConnectionHandler.SendMessage(_: Hello) => () }
+    rlpxConnection.send(peer, RLPxConnectionHandler.MessageReceived(remoteHello))
+
+    val remoteStatus = Status(
+      protocolVersion = Message.PV63,
+      networkId = 0,
+      totalDifficulty = Config.Blockchain.daoForkBlockTotalDifficulty + 100000, // remote is after the fork
+      bestHash = ByteString("blockhash"),
+      genesisHash = Config.Blockchain.genesisHash)
+
+    rlpxConnection.expectMsgPF() { case RLPxConnectionHandler.SendMessage(_: Status) => () }
+    rlpxConnection.send(peer, RLPxConnectionHandler.MessageReceived(remoteStatus))
+
+    rlpxConnection.expectMsgPF() { case RLPxConnectionHandler.SendMessage(_: GetBlockHeaders) => () }
+    rlpxConnection.send(peer, RLPxConnectionHandler.MessageReceived(BlockHeaders(Seq(etcForkBlockHeader))))
+
+    rlpxConnection.send(peer, RLPxConnectionHandler.MessageReceived(Ping()))
+    rlpxConnection.expectMsg(RLPxConnectionHandler.SendMessage(Pong()))
+  }
+
+  it should "disconnect from non-ETC peer" in new TestSetup with BlockUtils {
+    nodeStatusHolder.send(_.copy(blockchainStatus = BlockchainStatus(
+      Config.Blockchain.daoForkBlockTotalDifficulty + 10000000, // we're at some block, after the fork
+      ByteString("unused"))))
+
+    peer ! PeerActor.ConnectTo(new URI("encode://localhost:9000"))
+
+    rlpxConnection.expectMsgClass(classOf[RLPxConnectionHandler.ConnectTo])
+    rlpxConnection.reply(RLPxConnectionHandler.ConnectionEstablished)
+
+    val remoteHello = Hello(4, "test-client", Seq(Capability("eth", Message.PV63.toByte)), 9000, ByteString("unused"))
+    rlpxConnection.expectMsgPF() { case RLPxConnectionHandler.SendMessage(_: Hello) => () }
+    rlpxConnection.send(peer, RLPxConnectionHandler.MessageReceived(remoteHello))
+
+    val remoteStatus = Status(
+      protocolVersion = Message.PV63,
+      networkId = 0,
+      totalDifficulty = Config.Blockchain.daoForkBlockTotalDifficulty + 100000, // remote is after the fork
+      bestHash = ByteString("blockhash"),
+      genesisHash = Config.Blockchain.genesisHash)
+
+    rlpxConnection.expectMsgPF() { case RLPxConnectionHandler.SendMessage(_: Status) => () }
+    rlpxConnection.send(peer, RLPxConnectionHandler.MessageReceived(remoteStatus))
+
+    rlpxConnection.expectMsgPF() { case RLPxConnectionHandler.SendMessage(_: GetBlockHeaders) => () }
+    rlpxConnection.send(peer, RLPxConnectionHandler.MessageReceived(BlockHeaders(Seq(nonEtcForkBlockHeader))))
+    rlpxConnection.expectMsg(RLPxConnectionHandler.SendMessage(Disconnect(Disconnect.Reasons.UselessPeer)))
+  }
+
+  it should "stay connected to non-ETC peer until reaching the fork" in new TestSetup with BlockUtils {
+    nodeStatusHolder.send(_.copy(blockchainStatus = BlockchainStatus(
+      Config.Blockchain.daoForkBlockTotalDifficulty - 10000000, // we're at some block, before the fork
+      ByteString("unused"))))
+
+    peer ! PeerActor.ConnectTo(new URI("encode://localhost:9000"))
+
+    rlpxConnection.expectMsgClass(classOf[RLPxConnectionHandler.ConnectTo])
+    rlpxConnection.reply(RLPxConnectionHandler.ConnectionEstablished)
+
+    val remoteHello = Hello(4, "test-client", Seq(Capability("eth", Message.PV63.toByte)), 9000, ByteString("unused"))
+    rlpxConnection.expectMsgPF() { case RLPxConnectionHandler.SendMessage(_: Hello) => () }
+    rlpxConnection.send(peer, RLPxConnectionHandler.MessageReceived(remoteHello))
+
+    val remoteStatus = Status(
+      protocolVersion = Message.PV63,
+      networkId = 0,
+      totalDifficulty = Config.Blockchain.daoForkBlockTotalDifficulty + 100000, // remote is after the fork
+      bestHash = ByteString("blockhash"),
+      genesisHash = Config.Blockchain.genesisHash)
+
+    rlpxConnection.expectMsgPF() { case RLPxConnectionHandler.SendMessage(_: Status) => () }
+    rlpxConnection.send(peer, RLPxConnectionHandler.MessageReceived(remoteStatus))
+
+    rlpxConnection.expectMsgPF() { case RLPxConnectionHandler.SendMessage(_: GetBlockHeaders) => () }
+    rlpxConnection.send(peer, RLPxConnectionHandler.MessageReceived(BlockHeaders(Seq(nonEtcForkBlockHeader))))
+
+    rlpxConnection.send(peer, RLPxConnectionHandler.MessageReceived(Ping()))
+    rlpxConnection.expectMsgPF() { case RLPxConnectionHandler.SendMessage(_: Pong) => () }
+
+    rlpxConnection.send(peer, RLPxConnectionHandler.MessageReceived(BlockHeaders(Seq(nonEtcForkBlockHeader))))
+    rlpxConnection.expectMsg(RLPxConnectionHandler.SendMessage(Disconnect(Disconnect.Reasons.UselessPeer)))
+  }
+
+  it should "stay connected to pre fork peer until reaching the fork" in new TestSetup with BlockUtils {
+    nodeStatusHolder.send(_.copy(blockchainStatus = BlockchainStatus(
+      Config.Blockchain.daoForkBlockTotalDifficulty - 10000000, // we're at some block, before the fork
+      ByteString("unused"))))
+
+    peer ! PeerActor.ConnectTo(new URI("encode://localhost:9000"))
+
+    rlpxConnection.expectMsgClass(classOf[RLPxConnectionHandler.ConnectTo])
+    rlpxConnection.reply(RLPxConnectionHandler.ConnectionEstablished)
+
+    val remoteHello = Hello(4, "test-client", Seq(Capability("eth", Message.PV63.toByte)), 9000, ByteString("unused"))
+    rlpxConnection.expectMsgPF() { case RLPxConnectionHandler.SendMessage(_: Hello) => () }
+    rlpxConnection.send(peer, RLPxConnectionHandler.MessageReceived(remoteHello))
+
+    val remoteStatus = Status(
+      protocolVersion = Message.PV63,
+      networkId = 0,
+      totalDifficulty = Config.Blockchain.daoForkBlockTotalDifficulty - 2000000, // remote is before the fork
+      bestHash = ByteString("blockhash"),
+      genesisHash = Config.Blockchain.genesisHash)
+
+    rlpxConnection.expectMsgPF() { case RLPxConnectionHandler.SendMessage(_: Status) => () }
+    rlpxConnection.send(peer, RLPxConnectionHandler.MessageReceived(remoteStatus))
+
+    rlpxConnection.expectMsgPF() { case RLPxConnectionHandler.SendMessage(_: GetBlockHeaders) => () }
+    rlpxConnection.send(peer, RLPxConnectionHandler.MessageReceived(BlockHeaders(Nil)))
+
+    rlpxConnection.send(peer, RLPxConnectionHandler.MessageReceived(Ping()))
+    rlpxConnection.expectMsgPF() { case RLPxConnectionHandler.SendMessage(_: Pong) => () }
+
+    rlpxConnection.send(peer, RLPxConnectionHandler.MessageReceived(BlockHeaders(Seq(nonEtcForkBlockHeader))))
+    rlpxConnection.expectMsg(RLPxConnectionHandler.SendMessage(Disconnect(Disconnect.Reasons.UselessPeer)))
+  }
+
+  trait BlockUtils {
+
+    val etcForkBlockHeader =
+      BlockHeader(
+        parentHash = ByteString(Hex.decode("a218e2c611f21232d857e3c8cecdcdf1f65f25a4477f98f6f47e4063807f2308")),
+        ommersHash = ByteString(Hex.decode("1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347")),
+        beneficiary = ByteString(Hex.decode("61c808d82a3ac53231750dadc13c777b59310bd9")),
+        stateRoot = ByteString(Hex.decode("614d7d358b03cbdaf0343529673be20ad45809d02487f023e047efdce9da8aff")),
+        transactionsRoot = ByteString(Hex.decode("d33068a7f21bff5018a00ca08a3566a06be4196dfe9e39f96e431565a619d455")),
+        receiptsRoot = ByteString(Hex.decode("7bda9aa65977800376129148cbfe89d35a016dd51c95d6e6dc1e76307d315468")),
+        logsBloom = ByteString(Hex.decode("00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000")),
+        difficulty = BigInt("62413376722602"),
+        number = BigInt(1920000),
+        gasLimit = BigInt(4712384),
+        gasUsed = BigInt(84000),
+        unixTimestamp = 1469020839L,
+        extraData = ByteString(Hex.decode("e4b883e5bda9e7a59ee4bb99e9b1bc")),
+        mixHash = ByteString(Hex.decode("c52daa7054babe515b17ee98540c0889cf5e1595c5dd77496997ca84a68c8da1")),
+        nonce = ByteString(Hex.decode("05276a600980199d")))
+
+    val nonEtcForkBlockHeader =
+      BlockHeader(
+        parentHash = ByteString("this"),
+        ommersHash = ByteString("is"),
+        beneficiary = ByteString("not"),
+        stateRoot = ByteString("an"),
+        transactionsRoot = ByteString("ETC"),
+        receiptsRoot = ByteString("fork"),
+        logsBloom = ByteString("block"),
+        difficulty = BigInt("62413376722602"),
+        number = BigInt(1920000),
+        gasLimit = BigInt(4712384),
+        gasUsed = BigInt(84000),
+        unixTimestamp = 1469020839L,
+        extraData = ByteString("unused"),
+        mixHash = ByteString("unused"),
+        nonce = ByteString("unused"))
   }
 
   trait NodeStatusSetup {


### PR DESCRIPTION
When connection is initiated we try to check if peer is running ETC fork.
* it is - we keep connection
* it is not, but we're not at a fork yet - we can download some blocks until fork, thus we keep connection
* it is not at the fork yet - we keep the connection
* it is not running ETC (and we're after the fork) - disconnect

Then, when connected, we check if received block header is a fork header, if so, we validate it and if it's not ETC fork we disconnect. Hope that makes sense.