### PR TITLE
[EC-60] Remove all data from DataSource

### DIFF
--- a/src/it/scala/io/iohk/ethereum/db/IodbDataSourceIntegrationSuite.scala
+++ b/src/it/scala/io/iohk/ethereum/db/IodbDataSourceIntegrationSuite.scala
@@ -31,7 +31,7 @@ class IodbDataSourceIntegrationSuite extends FunSuite
     forAll(seqByteStringOfNItemsGen(KeySizeWithoutPrefix)) { unFilteredKeyList: Seq[ByteString] =>
       val keyList = unFilteredKeyList.take(KeyNumberLimit)
       val db = updateInSeparateCalls(
-        dataSource = IodbDataSource(path = "/tmp/iodbInsert", keySize = KeySize, createNew = true),
+        dataSource = IodbDataSource(path = "/tmp/iodbInsert", keySize = KeySize, recreate = true),
         toUpsert = keyList.zip(keyList)
       )
       keyList.foreach { key => assert(db.get(OtherNamespace, key).contains(key)) }
@@ -43,7 +43,7 @@ class IodbDataSourceIntegrationSuite extends FunSuite
   test("IodbDataSource insert keys in a single update"){
     forAll(seqByteStringOfNItemsGen(KeySizeWithoutPrefix)) { unFilteredKeyList: Seq[ByteString] =>
       val keyList = unFilteredKeyList.take(KeyNumberLimit)
-      val db = IodbDataSource(path = "/tmp/iodbInsert", keySize = KeySize, createNew = true)
+      val db = IodbDataSource(path = "/tmp/iodbInsert", keySize = KeySize, recreate = true)
         .update(OtherNamespace, Seq(), keyList.zip(keyList))
 
       keyList.foreach { key => assert(db.get(OtherNamespace, key).contains(key)) }
@@ -55,7 +55,7 @@ class IodbDataSourceIntegrationSuite extends FunSuite
   test("IodbDataSource update keys in separate updates"){
     forAll(seqByteStringOfNItemsGen(KeySizeWithoutPrefix)) { unFilteredKeyList: Seq[ByteString] =>
       val keyList = unFilteredKeyList.take(KeyNumberLimit)
-      val db = IodbDataSource(path = "/tmp/iodbUpdate", keySize = KeySize, createNew = true)
+      val db = IodbDataSource(path = "/tmp/iodbUpdate", keySize = KeySize, recreate = true)
         .update(OtherNamespace, Seq(), keyList.zip(keyList))
 
       val keyListWithExtraByte = keyList.map(1.toByte +: _)
@@ -71,7 +71,7 @@ class IodbDataSourceIntegrationSuite extends FunSuite
   test("IodbDataSource update keys in a single update"){
     forAll(seqByteStringOfNItemsGen(KeySizeWithoutPrefix)) { unFilteredKeyList: Seq[ByteString] =>
       val keyList = unFilteredKeyList.take(KeyNumberLimit)
-      val db = IodbDataSource(path = "/tmp/iodbUpdate", keySize = KeySize, createNew = true)
+      val db = IodbDataSource(path = "/tmp/iodbUpdate", keySize = KeySize, recreate = true)
         .update(OtherNamespace, Seq(), keyList.zip(keyList))
 
       val keyListWithExtraByte = keyList.map(1.toByte +: _)
@@ -89,7 +89,7 @@ class IodbDataSourceIntegrationSuite extends FunSuite
     forAll(seqByteStringOfNItemsGen(KeySizeWithoutPrefix)) { unFilteredKeyList: Seq[ByteString] =>
       val keyList = unFilteredKeyList.take(KeyNumberLimit)
       val (keysLeft, keysToInsert) = keyList.splitAt(Gen.choose(0, keyList.size/2).sample.get)
-      val db = IodbDataSource(path = "/tmp/iodbInvalidLength", keySize = KeySize, createNew = true)
+      val db = IodbDataSource(path = "/tmp/iodbInvalidLength", keySize = KeySize, recreate = true)
         .update(OtherNamespace, Seq(), keysToInsert.zip(keysToInsert))
 
       val keyListWithExtraByte = keyList.map(1.toByte +: _)
@@ -109,7 +109,7 @@ class IodbDataSourceIntegrationSuite extends FunSuite
     forAll(seqByteStringOfNItemsGen(KeySizeWithoutPrefix)) { unFilteredKeyList: Seq[ByteString] =>
       val keyList = unFilteredKeyList.take(KeyNumberLimit)
       val (keysLeft, keysToInsert) = keyList.splitAt(Gen.choose(0, keyList.size / 2).sample.get)
-      val db = IodbDataSource(path = "/tmp/iodbInvalidLength", keySize = KeySize, createNew = true)
+      val db = IodbDataSource(path = "/tmp/iodbInvalidLength", keySize = KeySize, recreate = true)
         .update(OtherNamespace, Seq(), keysToInsert.zip(keysToInsert))
 
       val keyListWithExtraByte = keyList.map(1.toByte +: _)
@@ -128,7 +128,7 @@ class IodbDataSourceIntegrationSuite extends FunSuite
   test("IodbDataSource clear"){
     forAll(seqByteStringOfNItemsGen(KeySizeWithoutPrefix)) { unFilteredKeyList: Seq[ByteString] =>
       val keyList = unFilteredKeyList.take(KeyNumberLimit)
-      val db = IodbDataSource(path = "/tmp/iodbClean", keySize = KeySize, createNew = true)
+      val db = IodbDataSource(path = "/tmp/iodbClean", keySize = KeySize, recreate = true)
         .update(namespace = OtherNamespace, toRemove = Seq(), toUpsert = keyList.zip(keyList))
         .clear
 
@@ -141,11 +141,11 @@ class IodbDataSourceIntegrationSuite extends FunSuite
   test("IodbDataSource close and creation of new one before using it again") {
     forAll(seqByteStringOfNItemsGen(KeySizeWithoutPrefix)) { unFilteredKeyList: Seq[ByteString] =>
       val keyList = unFilteredKeyList.take(KeyNumberLimit)
-      val db = IodbDataSource(path = "/tmp/iodbClose", keySize = KeySize, createNew = true)
+      val db = IodbDataSource(path = "/tmp/iodbClose", keySize = KeySize, recreate = true)
         .update(namespace = OtherNamespace, toRemove = Seq(), toUpsert = keyList.zip(keyList))
       db.close()
 
-      val dbAfterClose = IodbDataSource(path = "/tmp/iodbClose", keySize = KeySize, createNew = true)
+      val dbAfterClose = IodbDataSource(path = "/tmp/iodbClose", keySize = KeySize, recreate = true)
       keyList.foreach { key => assert(dbAfterClose.get(OtherNamespace, key).isEmpty) }
 
       dbAfterClose.destroy()
@@ -155,11 +155,11 @@ class IodbDataSourceIntegrationSuite extends FunSuite
   test("IodbDataSource close and then continuing using it") {
     forAll(seqByteStringOfNItemsGen(KeySizeWithoutPrefix)) { unFilteredKeyList: Seq[ByteString] =>
       val keyList = unFilteredKeyList.take(KeyNumberLimit)
-      val db = IodbDataSource(path = "/tmp/iodbClose", keySize = KeySize, createNew = true)
+      val db = IodbDataSource(path = "/tmp/iodbClose", keySize = KeySize, recreate = true)
         .update(namespace = OtherNamespace, toRemove = Seq(), toUpsert = keyList.zip(keyList))
       db.close()
 
-      val dbAfterClose = IodbDataSource(path = "/tmp/iodbClose", keySize = KeySize, createNew = false)
+      val dbAfterClose = IodbDataSource(path = "/tmp/iodbClose", keySize = KeySize, recreate = false)
       keyList.foreach { key => assert(dbAfterClose.get(OtherNamespace, key).contains(key)) }
 
       dbAfterClose.destroy()
@@ -169,13 +169,13 @@ class IodbDataSourceIntegrationSuite extends FunSuite
   test("IodbDataSource destroy") {
     forAll(seqByteStringOfNItemsGen(KeySizeWithoutPrefix)) { unFilteredKeyList: Seq[ByteString] =>
       val keyList = unFilteredKeyList.take(KeyNumberLimit)
-      val db = IodbDataSource(path = "/tmp/iodbDestroy", keySize = KeySize, createNew = true)
+      val db = IodbDataSource(path = "/tmp/iodbDestroy", keySize = KeySize, recreate = true)
         .update(namespace = OtherNamespace, toRemove = Seq(), toUpsert = keyList.zip(keyList))
       db.destroy()
 
       assert(!new File("/tmp/iodbDestroy").exists())
 
-      val dbAfterDestroy = IodbDataSource(path = "/tmp/iodbDestroy", keySize = KeySize, createNew = true)
+      val dbAfterDestroy = IodbDataSource(path = "/tmp/iodbDestroy", keySize = KeySize, recreate = true)
       keyList.foreach { key => assert(dbAfterDestroy.get(OtherNamespace, key).isEmpty) }
 
       dbAfterDestroy.destroy()

--- a/src/it/scala/io/iohk/ethereum/db/IodbDataSourceIntegrationSuite.scala
+++ b/src/it/scala/io/iohk/ethereum/db/IodbDataSourceIntegrationSuite.scala
@@ -6,8 +6,7 @@ import io.iohk.ethereum.ObjectGenerators
 import akka.util.ByteString
 import io.iohk.ethereum.db.dataSource.{DataSource, IodbDataSource}
 import org.scalacheck.Gen
-
-import scala.util.{Random, Try}
+import scala.util.Try
 import java.io.File
 
 //FIXME: Add IodbDataSource delete tests (currently not implemented as they failed in previous IODB implementation)
@@ -37,7 +36,7 @@ class IodbDataSourceIntegrationSuite extends FunSuite
       )
       keyList.foreach { key => assert(db.get(OtherNamespace, key).contains(key)) }
 
-      db.close()
+      db.destroy()
     }
   }
 
@@ -49,7 +48,7 @@ class IodbDataSourceIntegrationSuite extends FunSuite
 
       keyList.foreach { key => assert(db.get(OtherNamespace, key).contains(key)) }
 
-      db.close()
+      db.destroy()
     }
   }
 
@@ -65,7 +64,7 @@ class IodbDataSourceIntegrationSuite extends FunSuite
       keyList.zip(keyListWithExtraByte).foreach { case (key, value) =>
         assert(dbAfterUpdate.get(OtherNamespace, key).contains(value)) }
 
-      dbAfterUpdate.close()
+      dbAfterUpdate.destroy()
     }
   }
 
@@ -82,14 +81,14 @@ class IodbDataSourceIntegrationSuite extends FunSuite
         assert(dbAfterUpdate.get(OtherNamespace, key).contains(value))
       }
 
-      dbAfterUpdate.close()
+      dbAfterUpdate.destroy()
     }
   }
 
   test("IodbDataSource insert/update with invalid length") {
     forAll(seqByteStringOfNItemsGen(KeySizeWithoutPrefix)) { unFilteredKeyList: Seq[ByteString] =>
       val keyList = unFilteredKeyList.take(KeyNumberLimit)
-      val (keysLeft, keysToInsert) = Random.shuffle(keyList).splitAt(Gen.choose(0, keyList.size/2).sample.get)
+      val (keysLeft, keysToInsert) = keyList.splitAt(Gen.choose(0, keyList.size/2).sample.get)
       val db = IodbDataSource(path = "/tmp/iodbInvalidLength", keySize = KeySize)
         .update(OtherNamespace, Seq(), keysToInsert.zip(keysToInsert))
 
@@ -102,14 +101,14 @@ class IodbDataSourceIntegrationSuite extends FunSuite
 
       invalidKeyList.foreach { key => assert( Try{db.update(OtherNamespace, Seq(), Seq(key->key))}.isFailure) }
 
-      db.close()
+      db.destroy()
     }
   }
 
   test("IodbDataSource get with invalid length") {
     forAll(seqByteStringOfNItemsGen(KeySizeWithoutPrefix)) { unFilteredKeyList: Seq[ByteString] =>
       val keyList = unFilteredKeyList.take(KeyNumberLimit)
-      val (keysLeft, keysToInsert) = Random.shuffle(keyList).splitAt(Gen.choose(0, keyList.size / 2).sample.get)
+      val (keysLeft, keysToInsert) = keyList.splitAt(Gen.choose(0, keyList.size / 2).sample.get)
       val db = IodbDataSource(path = "/tmp/iodbInvalidLength", keySize = KeySize)
         .update(OtherNamespace, Seq(), keysToInsert.zip(keysToInsert))
 
@@ -122,7 +121,7 @@ class IodbDataSourceIntegrationSuite extends FunSuite
 
       invalidKeyList.foreach { key => assert( Try{db.get(OtherNamespace, key)}.isFailure) }
 
-      db.close()
+      db.destroy()
     }
   }
 
@@ -135,7 +134,7 @@ class IodbDataSourceIntegrationSuite extends FunSuite
 
       keyList.foreach { key => assert(db.get(OtherNamespace, key).isEmpty) }
 
-      db.close()
+      db.destroy()
     }
   }
 
@@ -146,10 +145,26 @@ class IodbDataSourceIntegrationSuite extends FunSuite
         .update(namespace = OtherNamespace, toRemove = Seq(), toUpsert = keyList.zip(keyList))
       db.close()
 
-      assert(Option(new File("/tmp/iodbClose").listFiles()).getOrElse(Array()).isEmpty)
-
       val dbAfterClose = IodbDataSource(path = "/tmp/iodbClose", keySize = KeySize)
       keyList.foreach { key => assert(dbAfterClose.get(OtherNamespace, key).isEmpty) }
+
+      dbAfterClose.destroy()
+    }
+  }
+
+  test("IodbDataSource destroy") {
+    forAll(seqByteStringOfNItemsGen(KeySizeWithoutPrefix)) { unFilteredKeyList: Seq[ByteString] =>
+      val keyList = unFilteredKeyList.take(KeyNumberLimit)
+      val db = IodbDataSource(path = "/tmp/iodbDestroy", keySize = KeySize)
+        .update(namespace = OtherNamespace, toRemove = Seq(), toUpsert = keyList.zip(keyList))
+      db.destroy()
+
+      assert(!new File("/tmp/iodbDestroy").exists())
+
+      val dbAfterDestroy = IodbDataSource(path = "/tmp/iodbDestroy", keySize = KeySize)
+      keyList.foreach { key => assert(dbAfterDestroy.get(OtherNamespace, key).isEmpty) }
+
+      dbAfterDestroy.destroy()
     }
   }
 }

--- a/src/it/scala/io/iohk/ethereum/db/IodbDataSourceIntegrationSuite.scala
+++ b/src/it/scala/io/iohk/ethereum/db/IodbDataSourceIntegrationSuite.scala
@@ -138,7 +138,7 @@ class IodbDataSourceIntegrationSuite extends FunSuite
     }
   }
 
-  test("IodbDataSource close and clear before using it again") {
+  test("IodbDataSource close and creation of new one before using it again") {
     forAll(seqByteStringOfNItemsGen(KeySizeWithoutPrefix)) { unFilteredKeyList: Seq[ByteString] =>
       val keyList = unFilteredKeyList.take(KeyNumberLimit)
       val db = IodbDataSource(path = "/tmp/iodbClose", keySize = KeySize, createNew = true)

--- a/src/it/scala/io/iohk/ethereum/mpt/MerklePatriciaTreeIntegrationSuite.scala
+++ b/src/it/scala/io/iohk/ethereum/mpt/MerklePatriciaTreeIntegrationSuite.scala
@@ -44,7 +44,7 @@ class MerklePatriciaTreeIntegrationSuite extends FunSuite
 
 
   test("IODB test - Insert of the first 5000 numbers hashed and then remove half of them"){
-    val dataSource = IodbDataSource(path = "/tmp/iodb", keySize = KeySize)
+    val dataSource = IodbDataSource(path = "/tmp/iodb", keySize = KeySize, createNew = true)
     val emptyTrie = MerklePatriciaTrie[Array[Byte], Array[Byte]](new NodeStorage(dataSource), hashFn)
 
     val keys = (0 to 100).map(intByteArraySerializable.toBytes)
@@ -62,7 +62,7 @@ class MerklePatriciaTreeIntegrationSuite extends FunSuite
 
   test("IODB Test - PatriciaTrie insert and get") {
     forAll(keyValueListGen()) { keyValueList: Seq[(Int, Int)] =>
-      val dataSource = IodbDataSource(path = "/tmp/iodb", keySize = KeySize)
+      val dataSource = IodbDataSource(path = "/tmp/iodb", keySize = KeySize, createNew = true)
       val trie = keyValueList.foldLeft(MerklePatriciaTrie[Int, Int](new NodeStorage(dataSource), hashFn)) {
         case (recTrie, (key, value)) => recTrie.put(key, value)
       }
@@ -78,7 +78,7 @@ class MerklePatriciaTreeIntegrationSuite extends FunSuite
 
   test("IODB Test - PatriciaTrie delete") {
     forAll(Gen.nonEmptyListOf(Arbitrary.arbitrary[Int])) { keyList: List[Int] =>
-      val dataSourceWithDelete = IodbDataSource(path = "/tmp/iodb1", keySize = KeySize)
+      val dataSourceWithDelete = IodbDataSource(path = "/tmp/iodb1", keySize = KeySize, createNew = true)
 
       val keyValueList = keyList.distinct.zipWithIndex
       val trieAfterInsert = keyValueList.foldLeft(MerklePatriciaTrie[Int, Int](new NodeStorage(dataSourceWithDelete), hashFn)) {
@@ -99,7 +99,7 @@ class MerklePatriciaTreeIntegrationSuite extends FunSuite
         assert(obtained.isEmpty)
       }
 
-      val dataSourceOnlyInsert = IodbDataSource(path = "/tmp/iodb", keySize = KeySize)
+      val dataSourceOnlyInsert = IodbDataSource(path = "/tmp/iodb", keySize = KeySize, createNew = true)
 
       val trieWithKeyValueLeft = keyValueLeft.foldLeft(MerklePatriciaTrie[Int, Int](new NodeStorage(dataSourceOnlyInsert), hashFn)) {
         case (recTrie, (key, value)) => recTrie.put(key, value)

--- a/src/it/scala/io/iohk/ethereum/mpt/MerklePatriciaTreeIntegrationSuite.scala
+++ b/src/it/scala/io/iohk/ethereum/mpt/MerklePatriciaTreeIntegrationSuite.scala
@@ -57,7 +57,7 @@ class MerklePatriciaTreeIntegrationSuite extends FunSuite
     val trieAfterDeleteNoEffect = keys.take(100/2).foldLeft(trieAfterDelete) { case (recTrie, key) => recTrie.remove(md5(key)) }
     assert(Hex.toHexString(trieAfterDeleteNoEffect.getRootHash) == "b0bfbf4d2d6f3c9863c27f41a087208131f775edd9de2cb66242d1e0981aa94c")
 
-    dataSource.close()
+    dataSource.destroy()
   }
 
   test("IODB Test - PatriciaTrie insert and get") {
@@ -72,7 +72,7 @@ class MerklePatriciaTreeIntegrationSuite extends FunSuite
         assert(obtained.get == value)
       }
 
-      dataSource.close()
+      dataSource.destroy()
     }
   }
 
@@ -84,7 +84,7 @@ class MerklePatriciaTreeIntegrationSuite extends FunSuite
       val trieAfterInsert = keyValueList.foldLeft(MerklePatriciaTrie[Int, Int](new NodeStorage(dataSourceWithDelete), hashFn)) {
         case (recTrie, (key, value)) => recTrie.put(key, value)
       }
-      val (keyValueToDelete, keyValueLeft) = Random.shuffle(keyValueList).splitAt(Gen.choose(0, keyValueList.size).sample.get)
+      val (keyValueToDelete, keyValueLeft) = keyValueList.splitAt(Gen.choose(0, keyValueList.size).sample.get)
       val trieAfterDelete = keyValueToDelete.foldLeft(trieAfterInsert) {
         case (recTrie, (key, value)) => recTrie.remove(key)
       }
@@ -106,8 +106,8 @@ class MerklePatriciaTreeIntegrationSuite extends FunSuite
       }
       assert(trieAfterDelete.getRootHash sameElements trieWithKeyValueLeft.getRootHash)
 
-      dataSourceWithDelete.close()
-      dataSourceOnlyInsert.close()
+      dataSourceWithDelete.destroy()
+      dataSourceOnlyInsert.destroy()
     }
   }
 

--- a/src/it/scala/io/iohk/ethereum/mpt/MerklePatriciaTreeIntegrationSuite.scala
+++ b/src/it/scala/io/iohk/ethereum/mpt/MerklePatriciaTreeIntegrationSuite.scala
@@ -44,7 +44,7 @@ class MerklePatriciaTreeIntegrationSuite extends FunSuite
 
 
   test("IODB test - Insert of the first 5000 numbers hashed and then remove half of them"){
-    val dataSource = IodbDataSource(path = "/tmp/iodb", keySize = KeySize, createNew = true)
+    val dataSource = IodbDataSource(path = "/tmp/iodb", keySize = KeySize, recreate = true)
     val emptyTrie = MerklePatriciaTrie[Array[Byte], Array[Byte]](new NodeStorage(dataSource), hashFn)
 
     val keys = (0 to 100).map(intByteArraySerializable.toBytes)
@@ -62,7 +62,7 @@ class MerklePatriciaTreeIntegrationSuite extends FunSuite
 
   test("IODB Test - PatriciaTrie insert and get") {
     forAll(keyValueListGen()) { keyValueList: Seq[(Int, Int)] =>
-      val dataSource = IodbDataSource(path = "/tmp/iodb", keySize = KeySize, createNew = true)
+      val dataSource = IodbDataSource(path = "/tmp/iodb", keySize = KeySize, recreate = true)
       val trie = keyValueList.foldLeft(MerklePatriciaTrie[Int, Int](new NodeStorage(dataSource), hashFn)) {
         case (recTrie, (key, value)) => recTrie.put(key, value)
       }
@@ -78,7 +78,7 @@ class MerklePatriciaTreeIntegrationSuite extends FunSuite
 
   test("IODB Test - PatriciaTrie delete") {
     forAll(Gen.nonEmptyListOf(Arbitrary.arbitrary[Int])) { keyList: List[Int] =>
-      val dataSourceWithDelete = IodbDataSource(path = "/tmp/iodb1", keySize = KeySize, createNew = true)
+      val dataSourceWithDelete = IodbDataSource(path = "/tmp/iodb1", keySize = KeySize, recreate = true)
 
       val keyValueList = keyList.distinct.zipWithIndex
       val trieAfterInsert = keyValueList.foldLeft(MerklePatriciaTrie[Int, Int](new NodeStorage(dataSourceWithDelete), hashFn)) {
@@ -99,7 +99,7 @@ class MerklePatriciaTreeIntegrationSuite extends FunSuite
         assert(obtained.isEmpty)
       }
 
-      val dataSourceOnlyInsert = IodbDataSource(path = "/tmp/iodb", keySize = KeySize, createNew = true)
+      val dataSourceOnlyInsert = IodbDataSource(path = "/tmp/iodb", keySize = KeySize, recreate = true)
 
       val trieWithKeyValueLeft = keyValueLeft.foldLeft(MerklePatriciaTrie[Int, Int](new NodeStorage(dataSourceOnlyInsert), hashFn)) {
         case (recTrie, (key, value)) => recTrie.put(key, value)

--- a/src/main/scala/io/iohk/ethereum/db/dataSource/DataSource.scala
+++ b/src/main/scala/io/iohk/ethereum/db/dataSource/DataSource.scala
@@ -44,13 +44,11 @@ trait DataSource {
 
   /**
     * This function closes the DataSource, without deleting data from it.
-    * Any attempt to access/update a closed DataSource will raise an exception
     */
   def close(): Unit
 
   /**
-    * This function closes the DataSource, if it is not yet closed, and and deletes all the data from it.
-    * Any attempt to access/update a destroyed DataSource will raise an exception
+    * This function closes the DataSource, if it is not yet closed, and deletes all the data from it.
     */
   def destroy(): Unit
 }

--- a/src/main/scala/io/iohk/ethereum/db/dataSource/DataSource.scala
+++ b/src/main/scala/io/iohk/ethereum/db/dataSource/DataSource.scala
@@ -43,12 +43,12 @@ trait DataSource {
   def clear: DataSource
 
   /**
-    * This function closes the DataSource, without deleting data from it.
+    * This function closes the DataSource, without deleting the files used by it.
     */
   def close(): Unit
 
   /**
-    * This function closes the DataSource, if it is not yet closed, and deletes all the data from it.
+    * This function closes the DataSource, if it is not yet closed, and deletes all the files used by it.
     */
   def destroy(): Unit
 }

--- a/src/main/scala/io/iohk/ethereum/db/dataSource/DataSource.scala
+++ b/src/main/scala/io/iohk/ethereum/db/dataSource/DataSource.scala
@@ -34,4 +34,16 @@ trait DataSource {
     * @return the new DataSource after the removals and insertions were done.
     */
   def update(namespace: Namespace, toRemove: Seq[Key], toUpsert: Seq[(Key, Value)]): DataSource
+
+  /**
+    * This function updates the DataSource by deleting all the (key-value) pairs in it.
+    *
+    * @return the new DataSource after all the data was removed.
+    */
+  def clear: DataSource
+
+  /**
+    * This function closes the DataSource, removing any allocated resources to it.
+    */
+  def close(): Unit
 }

--- a/src/main/scala/io/iohk/ethereum/db/dataSource/DataSource.scala
+++ b/src/main/scala/io/iohk/ethereum/db/dataSource/DataSource.scala
@@ -43,7 +43,14 @@ trait DataSource {
   def clear: DataSource
 
   /**
-    * This function closes the DataSource, removing any allocated resources to it.
+    * This function closes the DataSource, without deleting data from it.
+    * Any attempt to access/update a closed DataSource will raise an exception
     */
   def close(): Unit
+
+  /**
+    * This function closes the DataSource, if it is not yet closed, and and deletes all the data from it.
+    * Any attempt to access/update a destroyed DataSource will raise an exception
+    */
+  def destroy(): Unit
 }

--- a/src/main/scala/io/iohk/ethereum/db/dataSource/EphemDataSource.scala
+++ b/src/main/scala/io/iohk/ethereum/db/dataSource/EphemDataSource.scala
@@ -14,6 +14,8 @@ case class EphemDataSource(storage: Map[IndexedSeq[Byte], IndexedSeq[Byte]]) ext
   override def clear: DataSource = EphemDataSource(Map())
 
   override def close(): Unit = Unit
+
+  override def destroy(): Unit = Unit
 }
 
 object EphemDataSource {

--- a/src/main/scala/io/iohk/ethereum/db/dataSource/EphemDataSource.scala
+++ b/src/main/scala/io/iohk/ethereum/db/dataSource/EphemDataSource.scala
@@ -13,9 +13,9 @@ case class EphemDataSource(storage: Map[IndexedSeq[Byte], IndexedSeq[Byte]]) ext
 
   override def clear: DataSource = EphemDataSource(Map())
 
-  override def close(): Unit = Unit
+  override def close(): Unit = ()
 
-  override def destroy(): Unit = Unit
+  override def destroy(): Unit = ()
 }
 
 object EphemDataSource {

--- a/src/main/scala/io/iohk/ethereum/db/dataSource/EphemDataSource.scala
+++ b/src/main/scala/io/iohk/ethereum/db/dataSource/EphemDataSource.scala
@@ -10,6 +10,10 @@ case class EphemDataSource(storage: Map[IndexedSeq[Byte], IndexedSeq[Byte]]) ext
       storage + ((namespace ++ toUpdate._1) -> toUpdate._2))
     EphemDataSource(afterUpdate)
   }
+
+  override def clear: DataSource = EphemDataSource(Map())
+
+  override def close(): Unit = Unit
 }
 
 object EphemDataSource {

--- a/src/main/scala/io/iohk/ethereum/db/dataSource/IodbDataSource.scala
+++ b/src/main/scala/io/iohk/ethereum/db/dataSource/IodbDataSource.scala
@@ -1,23 +1,44 @@
 package io.iohk.ethereum.db.dataSource
 
+import java.io.File
 import java.nio.ByteBuffer
 import java.util.concurrent.atomic.AtomicLong
 
 import io.iohk.iodb.{ByteArrayWrapper, LSMStore}
 
-class IodbDataSource(lSMStore: LSMStore) extends DataSource {
+class IodbDataSource private (lSMStore: LSMStore,
+                              keySize: Int,
+                              firstVersion: ByteArrayWrapper,
+                              dir: File) extends DataSource {
 
   import IodbDataSource._
 
-  override def get(namespace: Namespace, key: Key): Option[Value] =
+  override def get(namespace: Namespace, key: Key): Option[Value] = {
+    require(namespace.length + key.length == keySize, "Wrong key size in IODB get")
     lSMStore.get(ByteArrayWrapper((namespace ++ key).toArray)).map(v => v.data.toIndexedSeq)
+  }
 
   override def update(namespace: Namespace, toRemove: Seq[Key], toUpsert: Seq[(Key, Value)]): DataSource = {
+    require(
+      toRemove.forall{ keyToRemove => namespace.length + keyToRemove.length == keySize } &&
+        toUpsert.forall{ case (keyToUpSert, _) => namespace.length + keyToUpSert.length == keySize },
+      "Wrong key size in IODB update"
+    )
     lSMStore.update(
       ByteArrayWrapper(storageVersionGen()),
       toRemove.map(key => ByteArrayWrapper((namespace ++ key).toArray)),
       asStorables(namespace, toUpsert))
-    new IodbDataSource(lSMStore)
+    new IodbDataSource(lSMStore, keySize, firstVersion, dir)
+  }
+
+  override def clear: DataSource = {
+    lSMStore.rollback(firstVersion)
+    new IodbDataSource(lSMStore, keySize, firstVersion, dir)
+  }
+
+  override def close(): Unit = {
+    lSMStore.close()
+    deleteDirectory(dir)
   }
 
   private def asStorables(namespace: Namespace,
@@ -31,5 +52,30 @@ object IodbDataSource {
 
   private def storageVersionGen(): Array[Byte] = {
     ByteBuffer.allocate(java.lang.Long.SIZE / java.lang.Byte.SIZE).putLong(updateCounter.incrementAndGet()).array()
+  }
+
+  def apply(path: String, keySize: Int): IodbDataSource = {
+    //Delete directory if it existed and create a new one
+    val dir: File = new File(path)
+    val dirCreationSuccess = (!dir.exists() || deleteDirectory(dir)) && dir.mkdir()
+    assert(dirCreationSuccess, "Iodb folder creation failed")
+
+    val lSMStore: LSMStore = new LSMStore(dir = dir, keySize = keySize, keepSingleVersion = true)
+
+    //Obtain first LSMStore version
+    lSMStore.update(ByteArrayWrapper(storageVersionGen()), Seq(), Seq())
+    val firstVersion: ByteArrayWrapper = lSMStore.lastVersionID
+      .getOrElse(throw new Exception("Iodb obtaining of first version failed"))
+
+    new IodbDataSource(lSMStore, keySize, firstVersion, dir)
+  }
+
+  private def deleteDirectory(dir: File): Boolean = {
+    require(dir.isDirectory, "Called on a file that is not a directory")
+    val files = Option(dir.listFiles()).getOrElse(Array())
+    val filesDeletionSuccess: Boolean = files.map { f =>
+      if(f.isDirectory) deleteDirectory(f) else f.delete()
+    }.forall(identity)
+    filesDeletionSuccess && dir.delete()
   }
 }

--- a/src/main/scala/io/iohk/ethereum/db/dataSource/IodbDataSource.scala
+++ b/src/main/scala/io/iohk/ethereum/db/dataSource/IodbDataSource.scala
@@ -32,7 +32,7 @@ class IodbDataSource private (lSMStore: LSMStore,
 
   override def clear: DataSource = {
     destroy()
-    IodbDataSource(path, keySize, createNew = true)
+    IodbDataSource(path, keySize, recreate = true)
   }
 
   override def close(): Unit = lSMStore.close()
@@ -55,10 +55,10 @@ object IodbDataSource {
     ByteBuffer.allocate(java.lang.Long.SIZE / java.lang.Byte.SIZE).putLong(updateCounter.incrementAndGet()).array()
   }
 
-  def apply(path: String, keySize: Int, createNew: Boolean): IodbDataSource = {
+  def apply(path: String, keySize: Int, recreate: Boolean): IodbDataSource = {
     val dir: File = new File(path)
     val dirSetupSuccess =
-      if(createNew) (!dir.exists() || deleteDirectory(dir)) && dir.mkdirs()
+      if(recreate) (!dir.exists() || deleteDirectory(dir)) && dir.mkdirs()
       else dir.exists() && dir.isDirectory
     assert(dirSetupSuccess, "Iodb folder creation failed")
 

--- a/src/main/scala/io/iohk/ethereum/db/dataSource/IodbDataSource.scala
+++ b/src/main/scala/io/iohk/ethereum/db/dataSource/IodbDataSource.scala
@@ -39,7 +39,8 @@ class IodbDataSource private (lSMStore: LSMStore,
 
   override def destroy(): Unit = {
     close()
-    deleteDirectory(new File(path))
+    val directoryDeletionSuccess = deleteDirectory(new File(path))
+    assert(directoryDeletionSuccess, "Iodb folder destruction failed")
   }
 
   private def asStorables(namespace: Namespace,

--- a/src/main/scala/io/iohk/ethereum/db/dataSource/IodbDataSource.scala
+++ b/src/main/scala/io/iohk/ethereum/db/dataSource/IodbDataSource.scala
@@ -80,10 +80,11 @@ object IodbDataSource {
 
   private def deleteDirectory(dir: File): Boolean = {
     require(dir.exists() && dir.isDirectory, "Trying to delete a file thats not a folder")
-    val files = Option(dir.listFiles()).getOrElse(Array())
-    val filesDeletionSuccess: Boolean = files.map { f =>
-      if(f.isDirectory) deleteDirectory(f) else f.delete()
-    }.forall(identity)
+    val files = dir.listFiles()
+    val filesDeletionSuccess = files.forall { f =>
+      val deleted = if (f.isDirectory) deleteDirectory(f) else f.delete()
+      deleted
+    }
     filesDeletionSuccess && dir.delete()
   }
 }

--- a/src/main/scala/io/iohk/ethereum/db/dataSource/IodbDataSource.scala
+++ b/src/main/scala/io/iohk/ethereum/db/dataSource/IodbDataSource.scala
@@ -36,9 +36,12 @@ class IodbDataSource private (lSMStore: LSMStore, keySize: Int, path: String) ex
   override def close(): Unit = lSMStore.close()
 
   override def destroy(): Unit = {
-    close()
-    val directoryDeletionSuccess = deleteDirectory(new File(path))
-    assert(directoryDeletionSuccess, "Iodb folder destruction failed")
+    try {
+      close()
+    } finally {
+      val directoryDeletionSuccess = deleteDirectory(new File(path))
+      assert(directoryDeletionSuccess, "Iodb folder destruction failed")
+    }
   }
 
   private def asStorables(namespace: Namespace,

--- a/src/main/scala/io/iohk/ethereum/db/dataSource/IodbDataSource.scala
+++ b/src/main/scala/io/iohk/ethereum/db/dataSource/IodbDataSource.scala
@@ -6,9 +6,7 @@ import java.util.concurrent.atomic.AtomicLong
 
 import io.iohk.iodb.{ByteArrayWrapper, LSMStore}
 
-class IodbDataSource private (lSMStore: LSMStore,
-                              keySize: Int,
-                              path: String) extends DataSource {
+class IodbDataSource private (lSMStore: LSMStore, keySize: Int, path: String) extends DataSource {
 
   import IodbDataSource._
 
@@ -56,6 +54,16 @@ object IodbDataSource {
     ByteBuffer.allocate(java.lang.Long.SIZE / java.lang.Byte.SIZE).putLong(updateCounter.incrementAndGet()).array()
   }
 
+  /**
+    * This function constructs an IodbDataSource.
+    *
+    * @param path of the folder where the DataSource files will be stored.
+    * @param keySize of the keys to be stored in the DataSource.
+    *                This length includes the length of the namespace and the length of the keys inside this namespace
+    * @param recreate boolean that, if set to true, this function will return a DataSource with no data in it.
+    *                 If set to false the returned DataSource will continue to use previously built DataSource files.
+    * @return an IodbDataSource.
+    */
   def apply(path: String, keySize: Int, recreate: Boolean): IodbDataSource = {
     val dir: File = new File(path)
     val dirSetupSuccess =

--- a/src/test/scala/io/iohk/ethereum/db/dataSource/EphemDataSourceSuite.scala
+++ b/src/test/scala/io/iohk/ethereum/db/dataSource/EphemDataSourceSuite.scala
@@ -40,8 +40,7 @@ class EphemDataSourceSuite extends FunSuite
   }
 
   test("EphemDataSource delete"){
-    forAll(seqByteStringOfNItemsGen(KeySize)) { unFilteredKeyList: Seq[ByteString] =>
-      val keyList = unFilteredKeyList.filter(_.length == KeySize)
+    forAll(seqByteStringOfNItemsGen(KeySize)) { keyList: Seq[ByteString] =>
       val (keysToDelete, keyValueLeft) = Random.shuffle(keyList).splitAt(Gen.choose(0, keyList.size).sample.get)
 
       val dbAfterInsert = putMultiple(dataSource = EphemDataSource(), toInsert = keyList.zip(keyList))
@@ -52,6 +51,16 @@ class EphemDataSourceSuite extends FunSuite
         assert(obtained.get sameElements key)
       }
       keysToDelete.foreach { key => assert(db.get(OtherNamespace, key).isEmpty) }
+    }
+  }
+
+  test("EphemDataSource clear") {
+    forAll(seqByteStringOfNItemsGen(KeySize)) { keyList: Seq[ByteString] =>
+      val db = EphemDataSource()
+        .update(OtherNamespace, toRemove = Seq(), toUpsert = keyList.zip(keyList))
+        .clear
+
+      keyList.foreach { key => assert(db.get(OtherNamespace, key).isEmpty) }
     }
   }
 }

--- a/src/test/scala/io/iohk/ethereum/db/dataSource/EphemDataSourceSuite.scala
+++ b/src/test/scala/io/iohk/ethereum/db/dataSource/EphemDataSourceSuite.scala
@@ -5,8 +5,7 @@ import io.iohk.ethereum.ObjectGenerators
 import org.scalacheck.Gen
 import org.scalatest.FunSuite
 import org.scalatest.prop.PropertyChecks
-
-import scala.util.Random
+import scala.util.Try
 
 class EphemDataSourceSuite extends FunSuite
   with PropertyChecks
@@ -41,7 +40,7 @@ class EphemDataSourceSuite extends FunSuite
 
   test("EphemDataSource delete"){
     forAll(seqByteStringOfNItemsGen(KeySize)) { keyList: Seq[ByteString] =>
-      val (keysToDelete, keyValueLeft) = Random.shuffle(keyList).splitAt(Gen.choose(0, keyList.size).sample.get)
+      val (keysToDelete, keyValueLeft) = keyList.splitAt(Gen.choose(0, keyList.size).sample.get)
 
       val dbAfterInsert = putMultiple(dataSource = EphemDataSource(), toInsert = keyList.zip(keyList))
       val db = removeMultiple(dataSource = dbAfterInsert, toDelete = keysToDelete)

--- a/src/test/scala/io/iohk/ethereum/db/storage/CodeStorageSuite.scala
+++ b/src/test/scala/io/iohk/ethereum/db/storage/CodeStorageSuite.scala
@@ -7,8 +7,6 @@ import org.scalacheck.Gen
 import org.scalatest.FunSuite
 import org.scalatest.prop.PropertyChecks
 
-import scala.util.Random
-
 class CodeStorageSuite extends FunSuite with PropertyChecks with ObjectGenerators {
   val LimitCodeSize = 100
 
@@ -41,7 +39,7 @@ class CodeStorageSuite extends FunSuite with PropertyChecks with ObjectGenerator
       }
 
       //EVM codes are deleted
-      val (toDelete, toLeave) = Random.shuffle(codeHashes.zip(codes))
+      val (toDelete, toLeave) = codeHashes.zip(codes)
         .splitAt(Gen.choose(0, codeHashes.size).sample.get)
       val codeStorageAfterDelete = toDelete.foldLeft(codeStorage){
         case (recCodeStorage, (codeHash, _)) =>

--- a/src/test/scala/io/iohk/ethereum/db/storage/KeyValueStorageSuite.scala
+++ b/src/test/scala/io/iohk/ethereum/db/storage/KeyValueStorageSuite.scala
@@ -8,8 +8,6 @@ import org.scalacheck.Gen
 import org.scalatest.FunSuite
 import org.scalatest.prop.PropertyChecks
 
-import scala.util.Random
-
 class KeyValueStorageSuite extends FunSuite with PropertyChecks with ObjectGenerators {
   val iterationsNumber = 100
 
@@ -67,7 +65,7 @@ class KeyValueStorageSuite extends FunSuite with PropertyChecks with ObjectGener
       val intStorage = initialIntStorage.update(Seq(), listOfInt.zip(listOfInt))
 
       //Delete of ints
-      val (toDelete, toLeave) = Random.shuffle(listOfInt).splitAt(Gen.choose(0, listOfInt.size).sample.get)
+      val (toDelete, toLeave) = listOfInt.splitAt(Gen.choose(0, listOfInt.size).sample.get)
       val keyValueStorage = intStorage.update(toDelete, Seq())
 
       toDelete.foreach{ i =>
@@ -97,7 +95,7 @@ class KeyValueStorageSuite extends FunSuite with PropertyChecks with ObjectGener
       val intStorage = initialIntStorage.update(Seq(), listOfInt.zip(listOfInt))
 
       //Delete of ints
-      val (toDelete, toLeave) = Random.shuffle(listOfInt).splitAt(Gen.choose(0, listOfInt.size).sample.get)
+      val (toDelete, toLeave) = listOfInt.splitAt(Gen.choose(0, listOfInt.size).sample.get)
       val keyValueStorage = toDelete.foldLeft(intStorage){ case (recKeyValueStorage, i) =>
         recKeyValueStorage.remove(i)
       }

--- a/src/test/scala/io/iohk/ethereum/db/storage/MptNodeStorageSuite.scala
+++ b/src/test/scala/io/iohk/ethereum/db/storage/MptNodeStorageSuite.scala
@@ -6,8 +6,6 @@ import org.scalacheck.Gen
 import org.scalatest.FunSuite
 import org.scalatest.prop.PropertyChecks
 
-import scala.util.Random
-
 class MptNodeStorageSuite extends FunSuite with PropertyChecks with ObjectGenerators {
   test("MptNodeStorage put") {
     forAll(Gen.listOf(nodeGen)){ unfilteredMptNodes =>
@@ -48,8 +46,7 @@ class MptNodeStorageSuite extends FunSuite with PropertyChecks with ObjectGenera
       }
 
       //Nodes are deleted
-      val (toDelete, toLeave) = Random.shuffle(mptNodes)
-        .splitAt(Gen.choose(0, mptNodes.size).sample.get)
+      val (toDelete, toLeave) = mptNodes.splitAt(Gen.choose(0, mptNodes.size).sample.get)
       val nodeStorageAfterDelete = toDelete.foldLeft(nodeStorage){
         case (recNodeStorage, node) =>
           recNodeStorage.remove(node.hash)

--- a/src/test/scala/io/iohk/ethereum/db/storage/NodeStorageSuite.scala
+++ b/src/test/scala/io/iohk/ethereum/db/storage/NodeStorageSuite.scala
@@ -8,8 +8,6 @@ import org.scalatest.prop.PropertyChecks
 import io.iohk.ethereum.rlp.{encode => rlpEncode, decode => rlpDecode}
 import io.iohk.ethereum.network.p2p.messages.PV63.MptNode
 
-import scala.util.Random
-
 class NodeStorageSuite extends FunSuite with PropertyChecks with ObjectGenerators {
   test("NodeStorage insert") {
     forAll(Gen.listOf(nodeGen)){ unfilteredMptNodes =>
@@ -39,8 +37,7 @@ class NodeStorageSuite extends FunSuite with PropertyChecks with ObjectGenerator
       }
 
       //Nodes are deleted
-      val (toDelete, toLeave) = Random.shuffle(mptNodes)
-        .splitAt(Gen.choose(0, mptNodes.size).sample.get)
+      val (toDelete, toLeave) = mptNodes.splitAt(Gen.choose(0, mptNodes.size).sample.get)
       val nodeStorageAfterDelete = toDelete.foldLeft(nodeStorage){
         case (recNodeStorage, node) =>
           recNodeStorage.remove(node.hash.toArray)

--- a/src/test/scala/io/iohk/ethereum/db/storage/ReceiptStorageSuite.scala
+++ b/src/test/scala/io/iohk/ethereum/db/storage/ReceiptStorageSuite.scala
@@ -7,8 +7,6 @@ import org.scalacheck.Gen
 import org.scalatest.FunSuite
 import org.scalatest.prop.PropertyChecks
 
-import scala.util.Random
-
 class ReceiptStorageSuite extends FunSuite with PropertyChecks with ObjectGenerators {
 
   test("ReceiptStorage insert") {
@@ -44,8 +42,7 @@ class ReceiptStorageSuite extends FunSuite with PropertyChecks with ObjectGenera
       }
 
       //Receipts are deleted
-      val (toDelete, toLeave) = Random.shuffle(blockHashesReceiptsPair)
-        .splitAt(Gen.choose(0, blockHashesReceiptsPair.size).sample.get)
+      val (toDelete, toLeave) = blockHashesReceiptsPair.splitAt(Gen.choose(0, blockHashesReceiptsPair.size).sample.get)
       val receiptStorageAfterDelete = toDelete.foldLeft(receiptStorage){
         case (recReceiptStorage, (_, blockHash)) =>
           recReceiptStorage.remove(blockHash)

--- a/src/test/scala/io/iohk/ethereum/mpt/MerklePatriciaTrieSuite.scala
+++ b/src/test/scala/io/iohk/ethereum/mpt/MerklePatriciaTrieSuite.scala
@@ -61,7 +61,7 @@ class MerklePatriciaTrieSuite extends FunSuite
       val trieAfterInsert = keyValueList.foldLeft(MerklePatriciaTrie[Int, Int](EmptyEphemNodeStorage, hashFn)) {
         case (recTrie, (key, value)) => recTrie.put(key, value)
       }
-      val (keyValueToDelete, keyValueLeft) = Random.shuffle(keyValueList).splitAt(Gen.choose(0, keyValueList.size).sample.get)
+      val (keyValueToDelete, keyValueLeft) = keyValueList.splitAt(Gen.choose(0, keyValueList.size).sample.get)
       val trieAfterDelete = keyValueToDelete.foldLeft(trieAfterInsert) {
         case (recTrie, (key, value)) => recTrie.remove(key)
       }
@@ -365,7 +365,7 @@ class MerklePatriciaTrieSuite extends FunSuite
     val obtainedAfterDelete = trieAfterDelete.get(1)
     assert(obtainedAfterDelete.isEmpty)
 
-    nodeStorage.close()
+    nodeStorage.destroy()
   }
 
   /* EthereumJ tests */

--- a/src/test/scala/io/iohk/ethereum/mpt/MerklePatriciaTrieSuite.scala
+++ b/src/test/scala/io/iohk/ethereum/mpt/MerklePatriciaTrieSuite.scala
@@ -1,7 +1,7 @@
 package io.iohk.ethereum.mpt
 
-import java.io.File
 import java.nio.ByteBuffer
+import java.nio.file.Files
 import java.security.MessageDigest
 
 import akka.util.ByteString
@@ -10,7 +10,6 @@ import io.iohk.ethereum.crypto.sha3
 import io.iohk.ethereum.db.dataSource.{EphemDataSource, IodbDataSource}
 import io.iohk.ethereum.db.storage.NodeStorage
 import io.iohk.ethereum.mpt.MerklePatriciaTrie.defaultByteArraySerializable
-import io.iohk.iodb.LSMStore
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest.FunSuite
 import org.scalatest.prop.PropertyChecks
@@ -355,7 +354,11 @@ class MerklePatriciaTrieSuite extends FunSuite
   /* IODB tests */
   test("Simple test with IODB as Source") {
     //open new store
-    val nodeStorage = IodbDataSource(path = "/tmp/iodb", keySize = 33, recreate = true)
+    val nodeStorage = IodbDataSource(
+      path = Files.createTempDirectory("MPT").getFileName.toString,
+      keySize = 33,
+      recreate = true
+    )
     val emptyTrie = MerklePatriciaTrie[Int, Int](new NodeStorage(nodeStorage), hashFn)
     val trieWithOneElement = emptyTrie.put(1, 5)
     val obtained = trieWithOneElement.get(1)

--- a/src/test/scala/io/iohk/ethereum/mpt/MerklePatriciaTrieSuite.scala
+++ b/src/test/scala/io/iohk/ethereum/mpt/MerklePatriciaTrieSuite.scala
@@ -354,13 +354,8 @@ class MerklePatriciaTrieSuite extends FunSuite
 
   /* IODB tests */
   test("Simple test with IODB as Source") {
-    //create temporary dir
-    val dir = File.createTempFile("iodb", "iodb")
-    dir.delete()
-    dir.mkdir()
-
     //open new store
-    val nodeStorage = new IodbDataSource(new LSMStore(dir = dir, keySize = 33))
+    val nodeStorage = IodbDataSource(path = "/tmp/iodb", keySize = 33)
     val emptyTrie = MerklePatriciaTrie[Int, Int](new NodeStorage(nodeStorage), hashFn)
     val trieWithOneElement = emptyTrie.put(1, 5)
     val obtained = trieWithOneElement.get(1)
@@ -369,6 +364,8 @@ class MerklePatriciaTrieSuite extends FunSuite
     val trieAfterDelete = trieWithOneElement.remove(1)
     val obtainedAfterDelete = trieAfterDelete.get(1)
     assert(obtainedAfterDelete.isEmpty)
+
+    nodeStorage.close()
   }
 
   /* EthereumJ tests */

--- a/src/test/scala/io/iohk/ethereum/mpt/MerklePatriciaTrieSuite.scala
+++ b/src/test/scala/io/iohk/ethereum/mpt/MerklePatriciaTrieSuite.scala
@@ -355,7 +355,7 @@ class MerklePatriciaTrieSuite extends FunSuite
   /* IODB tests */
   test("Simple test with IODB as Source") {
     //open new store
-    val nodeStorage = IodbDataSource(path = "/tmp/iodb", keySize = 33)
+    val nodeStorage = IodbDataSource(path = "/tmp/iodb", keySize = 33, createNew = true)
     val emptyTrie = MerklePatriciaTrie[Int, Int](new NodeStorage(nodeStorage), hashFn)
     val trieWithOneElement = emptyTrie.put(1, 5)
     val obtained = trieWithOneElement.get(1)

--- a/src/test/scala/io/iohk/ethereum/mpt/MerklePatriciaTrieSuite.scala
+++ b/src/test/scala/io/iohk/ethereum/mpt/MerklePatriciaTrieSuite.scala
@@ -355,7 +355,7 @@ class MerklePatriciaTrieSuite extends FunSuite
   /* IODB tests */
   test("Simple test with IODB as Source") {
     //open new store
-    val nodeStorage = IodbDataSource(path = "/tmp/iodb", keySize = 33, createNew = true)
+    val nodeStorage = IodbDataSource(path = "/tmp/iodb", keySize = 33, recreate = true)
     val emptyTrie = MerklePatriciaTrie[Int, Int](new NodeStorage(nodeStorage), hashFn)
     val trieWithOneElement = emptyTrie.put(1, 5)
     val obtained = trieWithOneElement.get(1)


### PR DESCRIPTION
## Description

- Added `clear` function to DataSource, to remove all the data from it.
- Added `close` function to DataSource, to close the DataSource.
- Added `destroy` function to DataSource, that closes it and deletes all the data from it.
- Added checking of the keys length in the `get` and `update` functions of IODB (as discussed in #31 ).
- Added option to use a previously closed (but not destroyed) `IodbDataSource` when creating one. This is now done instead of deleting the folder by default.

## Design choices
- As IODB doesn't yet provide functionality to easily clear it, the DataSource is destroyed and created again.