### PR TITLE
Bugfix in Storage and updates of docs.

### DIFF
--- a/src/main/scala/io/iohk/ethereum/vm/OpCode.scala
+++ b/src/main/scala/io/iohk/ethereum/vm/OpCode.scala
@@ -156,12 +156,12 @@ object OpCode {
 }
 
 /**
-  * Base class for all the opcodes of the EVM
-  *
-  * @param code Opcode byte representation
-  * @param delta number of words to be popped from stack
-  * @param alpha number of words to be pushed to stack
-  */
+ * Base class for all the opcodes of the EVM
+ *
+ * @param code Opcode byte representation
+ * @param delta number of words to be popped from stack
+ * @param alpha number of words to be pushed to stack
+ */
 sealed abstract class OpCode(val code: Byte, val delta: Int, val alpha: Int) {
   def this(code: Int, pop: Int, push: Int) = this(code.toByte, pop, push)
 
@@ -236,7 +236,7 @@ case object SHA3 extends OpCode(0x20, 2, 1) {
 
 case object CALLVALUE extends OpCode(0x34, 0, 1) {
   def execute(state: ProgramState): ProgramState =
-    state.stack.push(DataWord(state.context.callValue))
+    state.stack.push(DataWord(state.env.value))
       .map(state.withStack(_).step())
       .valueOr(state.withError)
 }
@@ -246,10 +246,8 @@ case object CALLDATALOAD extends OpCode(0x35, 1, 1) {
     val updatedState = for {
       popped <- state.stack.pop
       (offset, stack1) = popped
-
       i = offset.intValue
-      data = state.context.callData.slice(i, i + 32).padTo(32, 0.toByte)
-
+      data = state.inputData.slice(i, i + 32).padTo(32, 0.toByte)
       stack2 <- stack1.push(DataWord(data))
     } yield state.withStack(stack2).step()
 
@@ -490,7 +488,6 @@ case object LOG2 extends LogOp(0xa2)
 case object LOG3 extends LogOp(0xa3)
 case object LOG4 extends LogOp(0xa4)
 
-
 case object RETURN extends OpCode(0xf3, 2, 0) {
   def execute(state: ProgramState): ProgramState = {
     val updatedState = for {
@@ -498,7 +495,6 @@ case object RETURN extends OpCode(0xf3, 2, 0) {
       (Seq(offset, size), stack1) = popped
       (ret, mem1) = state.memory.load(offset, size)
     } yield state.withStack(stack1).withReturnData(ret).withMemory(mem1).halt
-
     updatedState.valueOr(state.withError)
   }
 }

--- a/src/main/scala/io/iohk/ethereum/vm/OpCode.scala
+++ b/src/main/scala/io/iohk/ethereum/vm/OpCode.scala
@@ -365,6 +365,10 @@ case object JUMPI extends OpCode(0x57, 2, 0) {
 }
 
 case object JUMPDEST extends OpCode(0x5b, 0, 0) {
+  // TODO To correctly implement this opcode EVM has to scan whole bytecode of a program
+  // to find all valid JUMP destinations.
+  // We will also have to scan for SSTORE and SSLOAD opcodes and if they are not found
+  // then there's no sense in loading Storage of a transaction from MPT
   def execute(state: ProgramState): ProgramState = {
     state.step()
   }

--- a/src/main/scala/io/iohk/ethereum/vm/Storage.scala
+++ b/src/main/scala/io/iohk/ethereum/vm/Storage.scala
@@ -10,16 +10,16 @@ object Storage {
   val Empty: Storage = new Storage()
 }
 
-/* Persistent storage of a transaction. May be viewed as a map of 256 bit keys
- * to 256 bit values.
- * This is just a representation of storage changes occuring during program execution. The
- * actual persistence is not this class's resposibility.
- */
+/** Persistent storage of a transaction. May be viewed as a map of 256 bit keys
+  * to 256 bit values.
+  * This is just a representation of storage changes occuring during program execution. The
+  * actual persistence is not this class's resposibility.
+  */
 class Storage private(private val underlying: Map[DataWord, DataWord] = Map()) {
 
-  /* Stores new value in an underlying hashmap.
-   * If DataWord.Zero is passed as a value then a corresponding key is removed from the hashmap
-   */
+  /** Stores new value in an underlying hashmap.
+    * If DataWord.Zero is passed as a value then a corresponding key is removed from the hashmap
+    */
   def store(addr: DataWord, value: DataWord): Storage = {
     val newUnderlying: Map[DataWord, DataWord] = value match {
       case DataWord.Zero => underlying - addr
@@ -28,9 +28,9 @@ class Storage private(private val underlying: Map[DataWord, DataWord] = Map()) {
     new Storage(newUnderlying)
   }
 
-  /* Retrieves a value from an underlying hashmap for a given key.
-   * Returns a DataWord.Zero if a value for given key does not exist
-   */
+  /** Retrieves a value from an underlying hashmap for a given key.
+    * Returns a DataWord.Zero if a value for given key does not exist
+    */
   def load(addr: DataWord): DataWord = underlying.getOrElse(addr, DataWord.Zero)
 
   def toMap: Map[DataWord, DataWord] = underlying

--- a/src/main/scala/io/iohk/ethereum/vm/Storage.scala
+++ b/src/main/scala/io/iohk/ethereum/vm/Storage.scala
@@ -10,15 +10,27 @@ object Storage {
   val Empty: Storage = new Storage()
 }
 
-/** Persistent storage of a transaction. May be viewed as a map of 256 bit keys
-  * to 256 bit values.
-  * This is just a representation of storage changes occuring during program execution. The
-  * actual persistence is not this class's resposibility.
-  */
+/* Persistent storage of a transaction. May be viewed as a map of 256 bit keys
+ * to 256 bit values.
+ * This is just a representation of storage changes occuring during program execution. The
+ * actual persistence is not this class's resposibility.
+ */
 class Storage private(private val underlying: Map[DataWord, DataWord] = Map()) {
 
-  def store(addr: DataWord, value: DataWord): Storage = new Storage(underlying + (addr -> value))
+  /* Stores new value in an underlying hashmap.
+   * If DataWord.Zero is passed as a value then a corresponding key is removed from the hashmap
+   */
+  def store(addr: DataWord, value: DataWord): Storage = {
+    val newUnderlying: Map[DataWord, DataWord] = value match {
+      case DataWord.Zero => underlying - addr
+      case dw => underlying + (addr -> value)
+    }
+    new Storage(newUnderlying)
+  }
 
+  /* Retrieves a value from an underlying hashmap for a given key.
+   * Returns a DataWord.Zero if a value for given key does not exist
+   */
   def load(addr: DataWord): DataWord = underlying.getOrElse(addr, DataWord.Zero)
 
   def toMap: Map[DataWord, DataWord] = underlying

--- a/src/test/scala/io/iohk/ethereum/vm/StorageSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/vm/StorageSpec.scala
@@ -21,6 +21,18 @@ class StorageSpec extends FunSuite with PropertyChecks {
     }
   }
 
+  test("remove") {
+    forAll(getStorageGen(MaxStorageSize)) {(storage: Storage) =>
+      whenever(!storage.toMap.isEmpty) {
+        storage.toMap.headOption.foreach { case (k, v) =>
+          val updatedStorage = storage.store(k, DataWord.Zero)
+          assert(updatedStorage.load(k) == DataWord.Zero)
+          assert(updatedStorage.toMap.get(k).isEmpty)
+        }
+      }
+    }
+  }
+
   test("load") {
     forAll(getStorageGen(MaxStorageSize), getDataWordGen(), getDataWordGen()) {(storage: Storage, k: DataWord, v: DataWord) =>
         assert(storage.store(k, v).load(k) == v)


### PR DESCRIPTION
If a `DataWord.Zero` is passed as a value to a `Storage` then a corresponding key should removed from the underlying hashmap.