### PR TITLE
[EC-72] change signing scheme for chain specific transactions

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -36,6 +36,8 @@ etc-client {
     dao-fork-block-number = "1920000"
     dao-fork-block-total-difficulty = "39490964433395682584"
     dao-fork-block-hash = "94365e3a8c0b35089c1d1195081fe7489b528a84b22199c916180db8b28ade7f"
+
+    chain-id = "3d"
   }
 
 }

--- a/src/main/scala/io/iohk/ethereum/domain/SignedTransaction.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/SignedTransaction.scala
@@ -61,16 +61,17 @@ case class SignedTransaction(
     recoveredPublicKey.map(key => crypto.sha3(key).slice(FirstByteOfAddress, LastByteOfAddress))
 
   /**
-    * formula for calculating pointt sing new way
+    * new formula for calculating point sign post EIP 155 adoption
     * v = CHAIN_ID * 2 + 35 or v = CHAIN_ID * 2 + 36
     */
-  lazy val recoveredPointSign: Option[Int] = pointSign match {
-    case p if p == negativePointSign || p == (Blockchain.chainId * 2 + newNegativePointSign).toByte =>
+  lazy val recoveredPointSign: Option[Int] =
+    if (pointSign == negativePointSign || pointSign == (Blockchain.chainId * 2 + newNegativePointSign).toByte) {
       Some(negativePointSign)
-    case p if p == positivePointSign || p == (Blockchain.chainId * 2 + newPositivePointSign).toByte =>
+    } else if (pointSign == positivePointSign || pointSign == (Blockchain.chainId * 2 + newPositivePointSign).toByte) {
       Some(positivePointSign)
-    case _ => None
-  }
+    } else {
+      None
+    }
 
   lazy val recoveredPublicKey: Option[Array[Byte]] = recoveredPointSign.flatMap { p =>
     ECDSASignature.recoverPubBytes(

--- a/src/main/scala/io/iohk/ethereum/domain/SignedTransaction.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/SignedTransaction.scala
@@ -64,22 +64,21 @@ case class SignedTransaction(
     * formula for calculating pointt sing new way
     * v = CHAIN_ID * 2 + 35 or v = CHAIN_ID * 2 + 36
     */
-  lazy val recoveredPublicKey: Option[Array[Byte]] = pointSign match {
+  lazy val recoveredPointSign: Option[Int] = pointSign match {
     case p if p == negativePointSign || p == (Blockchain.chainId * 2 + newNegativePointSign).toByte =>
-      ECDSASignature.recoverPubBytes(
-        new BigInteger(1, signatureRandom.toArray[Byte]),
-        new BigInteger(1, signature.toArray[Byte]),
-        ECDSASignature.recIdFromSignatureV(negativePointSign),
-        bytesToSign
-      )
+      Some(negativePointSign)
     case p if p == positivePointSign || p == (Blockchain.chainId * 2 + newPositivePointSign).toByte =>
-      ECDSASignature.recoverPubBytes(
-        new BigInteger(1, signatureRandom.toArray[Byte]),
-        new BigInteger(1, signature.toArray[Byte]),
-        ECDSASignature.recIdFromSignatureV(positivePointSign),
-        bytesToSign
-      )
+      Some(positivePointSign)
     case _ => None
+  }
+
+  lazy val recoveredPublicKey: Option[Array[Byte]] = recoveredPointSign.flatMap { p =>
+    ECDSASignature.recoverPubBytes(
+      new BigInteger(1, signatureRandom.toArray[Byte]),
+      new BigInteger(1, signature.toArray[Byte]),
+      ECDSASignature.recIdFromSignatureV(p),
+      bytesToSign
+    )
   }
 
   lazy val syntacticValidity: Boolean = {

--- a/src/main/scala/io/iohk/ethereum/domain/SignedTransaction.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/SignedTransaction.scala
@@ -21,6 +21,8 @@ object SignedTransaction {
   val newNegativePointSign = 35
   val positivePointSign = 28
   val newPositivePointSign = 36
+  val valueForEmptyR = 0
+  val valueForEmptyS = 0
 }
 
 case class SignedTransaction(
@@ -52,8 +54,8 @@ case class SignedTransaction(
         tx.value,
         tx.payload,
         Config.Blockchain.chainId,
-        0,
-        0)))
+        valueForEmptyR,
+        valueForEmptyS)))
   }
 
 
@@ -104,7 +106,7 @@ case class SignedTransaction(
          |tx: $tx
          |pointSign: $pointSign
          |signatureRandom: ${Hex.toHexString(signatureRandom.toArray[Byte])}
-         |signature: ${Hex.toHexString(signatureRandom.toArray[Byte])}
+         |signature: ${Hex.toHexString(signature.toArray[Byte])}
          |bytesToSign: ${Hex.toHexString(bytesToSign)}
          |recoveredPublicKey: ${recoveredPublicKey.map(Hex.toHexString)}
          |recoveredAddress: ${recoveredAddress.map(Hex.toHexString)}

--- a/src/main/scala/io/iohk/ethereum/domain/SignedTransaction.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/SignedTransaction.scala
@@ -18,7 +18,9 @@ object SignedTransaction {
   val AddressLength = 20
   val LastByteOfAddress: Int = FirstByteOfAddress + AddressLength
   val negativePointSign = 27
+  val newNegativePointSign = 35
   val positivePointSign = 28
+  val newPositivePointSign = 36
 }
 
 case class SignedTransaction(
@@ -58,15 +60,19 @@ case class SignedTransaction(
   lazy val recoveredAddress: Option[Array[Byte]] =
     recoveredPublicKey.map(key => crypto.sha3(key).slice(FirstByteOfAddress, LastByteOfAddress))
 
+  /**
+    * formula for calculating pointt sing new way
+    * v = CHAIN_ID * 2 + 35 or v = CHAIN_ID * 2 + 36
+    */
   lazy val recoveredPublicKey: Option[Array[Byte]] = pointSign match {
-    case p if p == negativePointSign || p == (Blockchain.chainId * 2 + 35).toByte =>
+    case p if p == negativePointSign || p == (Blockchain.chainId * 2 + newNegativePointSign).toByte =>
       ECDSASignature.recoverPubBytes(
         new BigInteger(1, signatureRandom.toArray[Byte]),
         new BigInteger(1, signature.toArray[Byte]),
         ECDSASignature.recIdFromSignatureV(negativePointSign),
         bytesToSign
       )
-    case p if p == positivePointSign || p == (Blockchain.chainId * 2 + 36).toByte =>
+    case p if p == positivePointSign || p == (Blockchain.chainId * 2 + newPositivePointSign).toByte =>
       ECDSASignature.recoverPubBytes(
         new BigInteger(1, signatureRandom.toArray[Byte]),
         new BigInteger(1, signature.toArray[Byte]),

--- a/src/main/scala/io/iohk/ethereum/domain/SignedTransaction.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/SignedTransaction.scala
@@ -7,6 +7,8 @@ import io.iohk.ethereum.crypto
 import io.iohk.ethereum.crypto.ECDSASignature
 import io.iohk.ethereum.rlp.{encode => rlpEncode, _}
 import io.iohk.ethereum.rlp.RLPImplicits._
+import io.iohk.ethereum.utils.Config
+import io.iohk.ethereum.utils.Config.Blockchain
 import org.spongycastle.util.encoders.Hex
 
 
@@ -14,38 +16,65 @@ object SignedTransaction {
 
   val FirstByteOfAddress = 12
   val AddressLength = 20
-  val LastByteOfAddress = FirstByteOfAddress + AddressLength
-
+  val LastByteOfAddress: Int = FirstByteOfAddress + AddressLength
+  val negativePointSign = 27
+  val positivePointSign = 28
 }
 
 case class SignedTransaction(
   tx: Transaction,
-  pointSign: Byte, //v - 27 or 28 according to yellow paper, but it is 37 and 38 in ETH
+  pointSign: Byte, //v
   signatureRandom: ByteString, //r
   signature: ByteString /*s*/) {
 
   import SignedTransaction._
 
-  lazy val bytesToSign: Array[Byte] =
+  lazy val bytesToSign: Array[Byte] = if (pointSign == negativePointSign || pointSign == positivePointSign) {
+    //global transaction
     crypto.sha3(
       rlpEncode(RLPList(
-                  tx.nonce,
-                  tx.gasPrice,
-                  tx.gasLimit,
-                  tx.receivingAddress.toArray,
-                  tx.value,
-                  tx.payload)))
+        tx.nonce,
+        tx.gasPrice,
+        tx.gasLimit,
+        tx.receivingAddress.toArray,
+        tx.value,
+        tx.payload)))
+  } else {
+    //chain specific transaction
+    crypto.sha3(
+      rlpEncode(RLPList(
+        tx.nonce,
+        tx.gasPrice,
+        tx.gasLimit,
+        tx.receivingAddress.toArray,
+        tx.value,
+        tx.payload,
+        Config.Blockchain.chainId,
+        0,
+        0)))
+  }
 
 
   lazy val recoveredAddress: Option[Array[Byte]] =
     recoveredPublicKey.map(key => crypto.sha3(key).slice(FirstByteOfAddress, LastByteOfAddress))
 
-  lazy val recoveredPublicKey: Option[Array[Byte]] =
-    ECDSASignature.recoverPubBytes(
-      new BigInteger(1, signatureRandom.toArray[Byte]),
-      new BigInteger(1, signature.toArray[Byte]),
-      ECDSASignature.recIdFromSignatureV(pointSign),
-      bytesToSign)
+  lazy val recoveredPublicKey: Option[Array[Byte]] = pointSign match {
+    case p if p == negativePointSign || p == (Blockchain.chainId * 2 + 35).toByte =>
+      ECDSASignature.recoverPubBytes(
+        new BigInteger(1, signatureRandom.toArray[Byte]),
+        new BigInteger(1, signature.toArray[Byte]),
+        ECDSASignature.recIdFromSignatureV(negativePointSign),
+        bytesToSign
+      )
+    case p if p == positivePointSign || p == (Blockchain.chainId * 2 + 36).toByte =>
+      ECDSASignature.recoverPubBytes(
+        new BigInteger(1, signatureRandom.toArray[Byte]),
+        new BigInteger(1, signature.toArray[Byte]),
+        ECDSASignature.recIdFromSignatureV(positivePointSign),
+        bytesToSign
+      )
+    case _ => None
+  }
 
   lazy val syntacticValidity: Boolean = {
 

--- a/src/main/scala/io/iohk/ethereum/utils/Config.scala
+++ b/src/main/scala/io/iohk/ethereum/utils/Config.scala
@@ -56,6 +56,8 @@ object Config {
     val daoForkBlockNumber = BigInt(blockchainConfig.getString("dao-fork-block-number"))
     val daoForkBlockTotalDifficulty = BigInt(blockchainConfig.getString("dao-fork-block-total-difficulty"))
     val daoForkBlockHash = ByteString(Hex.decode(blockchainConfig.getString("dao-fork-block-hash")))
+
+    val chainId: Byte = Hex.decode(blockchainConfig.getString("chain-id")).head
   }
 
 }

--- a/src/test/scala/io/iohk/ethereum/network/p2p/messages/TransactionSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/network/p2p/messages/TransactionSpec.scala
@@ -40,7 +40,7 @@ class TransactionSpec extends FlatSpec with Matchers {
     validStx.recoveredPublicKey.map(crypto.curve.getCurve.decodePoint) shouldBe Some(publicKey)
   }
 
-  it should "recover sender public key for new sign encoding schema" in {
+  it should "not recover sender public key for new sign encoding schema if there is no chain_id in signed data" in {
     newInvalidStx.recoveredPublicKey.map(crypto.curve.getCurve.decodePoint) shouldNot be(Some(publicKey))
   }
 

--- a/src/test/scala/io/iohk/ethereum/network/p2p/messages/TransactionSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/network/p2p/messages/TransactionSpec.scala
@@ -22,31 +22,53 @@ class TransactionSpec extends FlatSpec with Matchers {
                             value = BigInt("1049756850000000000"),
                             payload = ByteString.empty)
 
-  val validStx = SignedTransaction(
+  val validTransactionSignatureOldSchema = SignedTransaction(
     validTx,
     pointSign = 28,
     signatureRandom = ByteString(Hex.decode("cfe3ad31d6612f8d787c45f115cc5b43fb22bcc210b62ae71dc7cbf0a6bea8df")),
     signature = ByteString(Hex.decode("57db8998114fae3c337e99dbd8573d4085691880f4576c6c1f6c5bbfe67d6cf0")))
 
-  val newInvalidStx = SignedTransaction(
+  val invalidTransactionSignatureNewSchema = SignedTransaction(
     validTx,
     pointSign = -98,
     signatureRandom = ByteString(Hex.decode("cfe3ad31d6612f8d787c45f115cc5b43fb22bcc210b62ae71dc7cbf0a6bea8df")),
     signature = ByteString(Hex.decode("57db8998114fae3c337e99dbd8573d4085691880f4576c6c1f6c5bbfe67d6cf0")))
 
-  val invalidStx: SignedTransaction = validStx.copy(tx = validTx.copy(gasPrice = 0))
+  val invalidStx: SignedTransaction = validTransactionSignatureOldSchema.copy(tx = validTx.copy(gasPrice = 0))
+
+  val rawPublicKeyForNewSigningScheme: Array[Byte] =
+    Hex.decode("048fc6373a74ad959fd61d10f0b35e9e0524de025cb9a2bf8e0ff60ccb3f5c5e4d566ebe3c159ad572c260719fc203d820598ee5d9c9fa8ae14ecc8d5a2d8a2af1")
+  val publicKeyForNewSigningScheme: ECPoint = crypto.curve.getCurve.decodePoint(rawPublicKeyForNewSigningScheme)
+
+  val validTransactionForNewSigningScheme = Transaction(
+    nonce = 587440,
+    gasPrice = BigInt("20000000000"),
+    gasLimit = 90000,
+    receivingAddress = Address(Hex.decode("77b95d2028c741c038735b09d8d6e99ea180d40c")),
+    value = BigInt("1552986466088074000"),
+    payload = ByteString.empty)
+
+  val validSignedTransactionForNewSigningScheme = SignedTransaction(
+    validTransactionForNewSigningScheme,
+    pointSign = -98,
+    signatureRandom = ByteString(Hex.decode("1af423b3608f3b4b35e191c26f07175331de22ed8f60d1735f03210388246ade")),
+    signature = ByteString(Hex.decode("4d5b6b9e3955a0db8feec9c518d8e1aae0e1d91a143fbbca36671c3b89b89bc3")))
 
   "Transaction" should "recover sender public key" in {
-    validStx.recoveredPublicKey.map(crypto.curve.getCurve.decodePoint) shouldBe Some(publicKey)
+    validTransactionSignatureOldSchema.recoveredPublicKey.map(crypto.curve.getCurve.decodePoint) shouldBe Some(publicKey)
   }
 
   it should "not recover sender public key for new sign encoding schema if there is no chain_id in signed data" in {
-    newInvalidStx.recoveredPublicKey.map(crypto.curve.getCurve.decodePoint) shouldNot be(Some(publicKey))
+    invalidTransactionSignatureNewSchema.recoveredPublicKey.map(crypto.curve.getCurve.decodePoint) shouldNot be(Some(publicKey))
+  }
+
+  it should "recover sender public key for new sign encoding schema if there is chain_id in signed data" in {
+    validSignedTransactionForNewSigningScheme.recoveredPublicKey.map(crypto.curve.getCurve.decodePoint) shouldBe Some(publicKeyForNewSigningScheme)
   }
 
   it should "recover sender address" in {
-    validStx.recoveredAddress.nonEmpty shouldBe true
-    validStx.recoveredAddress.get shouldEqual address
+    validTransactionSignatureOldSchema.recoveredAddress.nonEmpty shouldBe true
+    validTransactionSignatureOldSchema.recoveredAddress.get shouldEqual address
   }
 
   it should "recover false sender public key for invalid transaction" in {
@@ -59,36 +81,36 @@ class TransactionSpec extends FlatSpec with Matchers {
   }
 
   it should "report as valid the validStx" in {
-    validStx.syntacticValidity shouldBe true
+    validTransactionSignatureOldSchema.syntacticValidity shouldBe true
   }
 
   it should "report as invalid a tx with long nonce" in {
     val invalidNonce = (0 until Transaction.NonceLength + 1).map(_ => 1.toByte).toArray
-    validStx.copy(tx = validTx.copy(nonce = BigInt(invalidNonce))).syntacticValidity shouldBe false
+    validTransactionSignatureOldSchema.copy(tx = validTx.copy(nonce = BigInt(invalidNonce))).syntacticValidity shouldBe false
   }
 
   it should "report as invalid a tx with long gas limit" in {
     val invalidGasLimit = (0 until Transaction.GasLength + 1).map(_ => 1.toByte).toArray
-    validStx.copy(tx = validTx.copy(gasLimit = BigInt(invalidGasLimit))).syntacticValidity shouldBe false
+    validTransactionSignatureOldSchema.copy(tx = validTx.copy(gasLimit = BigInt(invalidGasLimit))).syntacticValidity shouldBe false
   }
 
   it should "report as invalid a tx with long gas price" in {
     val invalidGasPrice = (0 until Transaction.GasLength + 1).map(_ => 1.toByte).toArray
-    validStx.copy(tx = validTx.copy(gasPrice = BigInt(invalidGasPrice))).syntacticValidity shouldBe false
+    validTransactionSignatureOldSchema.copy(tx = validTx.copy(gasPrice = BigInt(invalidGasPrice))).syntacticValidity shouldBe false
   }
 
   it should "report as invalid a tx with long value" in {
     val invalidValue = (0 until Transaction.ValueLength + 1).map(_ => 1.toByte).toArray
-    validStx.copy(tx = validTx.copy(value = BigInt(invalidValue))).syntacticValidity shouldBe false
+    validTransactionSignatureOldSchema.copy(tx = validTx.copy(value = BigInt(invalidValue))).syntacticValidity shouldBe false
   }
 
   it should "report as invalid a tx with long signature" in {
     val invalidSignature = (0 until ECDSASignature.SLength + 1).map(_ => 1.toByte).toArray
-    validStx.copy(signature = ByteString(invalidSignature)).syntacticValidity shouldBe false
+    validTransactionSignatureOldSchema.copy(signature = ByteString(invalidSignature)).syntacticValidity shouldBe false
   }
 
   it should "report as invalid a tx with long signature random" in {
     val invalidSignatureRandom = (0 until ECDSASignature.RLength + 1).map(_ => 1.toByte).toArray
-    validStx.copy(signatureRandom = ByteString(invalidSignatureRandom)).syntacticValidity shouldBe false
+    validTransactionSignatureOldSchema.copy(signatureRandom = ByteString(invalidSignatureRandom)).syntacticValidity shouldBe false
   }
 }

--- a/src/test/scala/io/iohk/ethereum/network/p2p/messages/TransactionSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/network/p2p/messages/TransactionSpec.scala
@@ -28,10 +28,20 @@ class TransactionSpec extends FlatSpec with Matchers {
     signatureRandom = ByteString(Hex.decode("cfe3ad31d6612f8d787c45f115cc5b43fb22bcc210b62ae71dc7cbf0a6bea8df")),
     signature = ByteString(Hex.decode("57db8998114fae3c337e99dbd8573d4085691880f4576c6c1f6c5bbfe67d6cf0")))
 
+  val newInvalidStx = SignedTransaction(
+    validTx,
+    pointSign = -98,
+    signatureRandom = ByteString(Hex.decode("cfe3ad31d6612f8d787c45f115cc5b43fb22bcc210b62ae71dc7cbf0a6bea8df")),
+    signature = ByteString(Hex.decode("57db8998114fae3c337e99dbd8573d4085691880f4576c6c1f6c5bbfe67d6cf0")))
+
   val invalidStx: SignedTransaction = validStx.copy(tx = validTx.copy(gasPrice = 0))
 
   "Transaction" should "recover sender public key" in {
     validStx.recoveredPublicKey.map(crypto.curve.getCurve.decodePoint) shouldBe Some(publicKey)
+  }
+
+  it should "recover sender public key for new sign encoding schema" in {
+    newInvalidStx.recoveredPublicKey.map(crypto.curve.getCurve.decodePoint) shouldNot be(Some(publicKey))
   }
 
   it should "recover sender address" in {


### PR DESCRIPTION
This PR adds support for new signing scheme for chain specific transactions added by 
this EIP
https://github.com/ethereum/EIPs/issues/155

fork block number is not yet set but we are receiving transactions that are signed according to that proposal.

`0x3d` is blockchain id for ethereum classic