### PR TITLE
[EC-117] Resume blockchain download on app restart

### DIFF
--- a/src/main/scala/io/iohk/ethereum/App.scala
+++ b/src/main/scala/io/iohk/ethereum/App.scala
@@ -1,6 +1,7 @@
 package io.iohk.ethereum
 
 import scala.concurrent.ExecutionContext.Implicits.global
+
 import akka.actor.{Actor, ActorRef, ActorSystem, Props}
 import akka.agent._
 import io.iohk.ethereum.blockchain.sync.FastSyncController
@@ -9,9 +10,9 @@ import io.iohk.ethereum.domain.{Blockchain, BlockchainImpl}
 import io.iohk.ethereum.network.PeerManagerActor.PeersResponse
 import io.iohk.ethereum.network.{PeerActor, PeerManagerActor, ServerActor}
 import io.iohk.ethereum.rpc.JsonRpcServer
-import io.iohk.ethereum.utils.{BlockchainStatus, Config, NodeStatus, ServerStatus}
-import org.spongycastle.crypto.AsymmetricCipherKeyPair
+import io.iohk.ethereum.utils.{Config, NodeStatus, ServerStatus}
 import io.iohk.ethereum.network._
+import org.spongycastle.crypto.AsymmetricCipherKeyPair
 
 object App {
 
@@ -46,12 +47,15 @@ class AppActor(nodeKey: AsymmetricCipherKeyPair,
       val nodeStatus =
         NodeStatus(
           key = nodeKey,
-          serverStatus = ServerStatus.NotListening,
-          blockchainStatus = BlockchainStatus(Config.Blockchain.genesisDifficulty, Config.Blockchain.genesisHash, 0))
+          serverStatus = ServerStatus.NotListening)
 
       val nodeStatusHolder = Agent(nodeStatus)
 
-      val peerManager = actorSystem.actorOf(PeerManagerActor.props(nodeStatusHolder, Config.Network.peer, blockchain), "peer-manager")
+      val peerManager = actorSystem.actorOf(PeerManagerActor.props(
+        nodeStatusHolder,
+        Config.Network.peer,
+        storagesInstance.storages.appStateStorage,
+        blockchain), "peer-manager")
       val server = actorSystem.actorOf(ServerActor.props(nodeStatusHolder, peerManager), "server")
 
       server ! ServerActor.StartServer(NetworkConfig.Server.listenAddress)
@@ -62,6 +66,7 @@ class AppActor(nodeKey: AsymmetricCipherKeyPair,
         FastSyncController.props(
           peerManager,
           nodeStatusHolder,
+          storagesInstance.storages.appStateStorage,
           blockchain,
           storagesInstance.storages.mptNodeStorage),
         "fast-sync-controller")

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/FastSyncBlockBodiesRequestHandler.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/FastSyncBlockBodiesRequestHandler.scala
@@ -2,12 +2,14 @@ package io.iohk.ethereum.blockchain.sync
 
 import akka.actor.{ActorRef, Props, Scheduler}
 import akka.util.ByteString
+import io.iohk.ethereum.db.storage.AppStateStorage
 import io.iohk.ethereum.domain.Blockchain
 import io.iohk.ethereum.network.p2p.messages.PV62.{BlockBodies, GetBlockBodies}
 
 class FastSyncBlockBodiesRequestHandler(
     peer: ActorRef,
     requestedHashes: Seq[ByteString],
+    appStateStorage: AppStateStorage,
     blockchain: Blockchain)(implicit scheduler: Scheduler)
   extends FastSyncRequestHandler[GetBlockBodies, BlockBodies](peer) {
 
@@ -18,6 +20,9 @@ class FastSyncBlockBodiesRequestHandler(
     (requestedHashes zip blockBodies.bodies).foreach { case (hash, body) =>
       blockchain.save(hash, body)
     }
+
+    val receivedHashes = requestedHashes.take(blockBodies.bodies.size)
+    updateBestBlockIfNeeded(receivedHashes)
 
     if (blockBodies.bodies.isEmpty) {
       fastSyncController ! BlacklistSupport.BlacklistPeer(peer)
@@ -30,6 +35,20 @@ class FastSyncBlockBodiesRequestHandler(
 
     log.info("Received {} block bodies in {} ms", blockBodies.bodies.size, timeTakenSoFar())
     cleanupAndStop()
+  }
+
+  private def updateBestBlockIfNeeded(receivedHashes: Seq[ByteString]): Unit = {
+    val fullBlocks = receivedHashes.flatMap { hash =>
+      for {
+        header <- blockchain.getBlockHeaderByHash(hash)
+        _ <- blockchain.getReceiptsByHash(hash)
+      } yield header
+    }
+
+    if (fullBlocks.nonEmpty) {
+      val bestReceivedBlock = fullBlocks.maxBy(_.number)
+      appStateStorage.putBestBlockNumber(bestReceivedBlock.number)
+    }
   }
 
   override def handleTimeout(): Unit = {
@@ -46,7 +65,7 @@ class FastSyncBlockBodiesRequestHandler(
 }
 
 object FastSyncBlockBodiesRequestHandler {
-  def props(peer: ActorRef, requestedHashes: Seq[ByteString], blockchain: Blockchain)
+  def props(peer: ActorRef, requestedHashes: Seq[ByteString], appStateStorage: AppStateStorage, blockchain: Blockchain)
            (implicit scheduler: Scheduler): Props =
-    Props(new FastSyncBlockBodiesRequestHandler(peer, requestedHashes, blockchain))
+    Props(new FastSyncBlockBodiesRequestHandler(peer, requestedHashes, appStateStorage, blockchain))
 }

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/FastSyncBlockHeadersRequestHandler.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/FastSyncBlockHeadersRequestHandler.scala
@@ -4,7 +4,7 @@ import akka.actor.{ActorRef, Props, Scheduler}
 import akka.agent.Agent
 import io.iohk.ethereum.domain.Blockchain
 import io.iohk.ethereum.network.p2p.messages.PV62.{BlockHeaders, GetBlockHeaders}
-import io.iohk.ethereum.utils.{BlockchainStatus, NodeStatus}
+import io.iohk.ethereum.utils.NodeStatus
 
 class FastSyncBlockHeadersRequestHandler(
     peer: ActorRef,
@@ -29,14 +29,17 @@ class FastSyncBlockHeadersRequestHandler(
       parentTd.isDefined
     }.unzip
 
-    blockHeadersObtained.lastOption foreach { lastHeader =>
-      nodeStatusHolder.send(_.copy(
-        blockchainStatus = BlockchainStatus(lastHeader.difficulty, lastHeader.hash, lastHeader.number)))
-    }
-
     if (blockHashesObtained.nonEmpty) {
       fastSyncController ! FastSyncController.EnqueueBlockBodies(blockHashesObtained)
       fastSyncController ! FastSyncController.EnqueueReceipts(blockHashesObtained)
+    }
+
+    if (blockHeadersObtained.headOption.exists(_.number == block)) {
+      val lastHeader = blockHeadersObtained.foldLeft(blockHeadersObtained.head) { (currentHeader, nextHeader) =>
+        if (nextHeader.number == currentHeader.number + 1) nextHeader
+        else currentHeader
+      }
+      fastSyncController ! FastSyncController.UpdateBestBlockHeaderNumber(lastHeader.number)
     }
 
     if (blockHashesObtained.length != blockHashes.length) fastSyncController ! BlacklistSupport.BlacklistPeer(peer)
@@ -58,7 +61,8 @@ class FastSyncBlockHeadersRequestHandler(
 
 object FastSyncBlockHeadersRequestHandler {
   def props(peer: ActorRef, block: BigInt, maxHeaders: Int,
-            nodeStatusHolder: Agent[NodeStatus], blockchain: Blockchain)
+            nodeStatusHolder: Agent[NodeStatus],
+            blockchain: Blockchain)
            (implicit scheduler: Scheduler): Props =
     Props(new FastSyncBlockHeadersRequestHandler(peer, block, maxHeaders, nodeStatusHolder, blockchain))
 }

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/FastSyncController.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/FastSyncController.scala
@@ -2,6 +2,7 @@ package io.iohk.ethereum.blockchain.sync
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
+
 import akka.actor.SupervisorStrategy.Stop
 import akka.actor._
 import akka.agent.Agent
@@ -16,6 +17,7 @@ import io.iohk.ethereum.utils.{Config, NodeStatus}
 class FastSyncController(
     peerManager: ActorRef,
     nodeStatusHolder: Agent[NodeStatus],
+    appStateStorage: AppStateStorage,
     blockchain: Blockchain,
     mptNodeStorage: MptNodeStorage,
     externalSchedulerOpt: Option[Scheduler] = None)
@@ -101,7 +103,7 @@ class FastSyncController(
 
   def waitingForTargetBlock(peer: ActorRef,
                             targetBlockNumber: BigInt,
-                            timeout: Cancellable): Receive =handlePeerUpdates orElse {
+                            timeout: Cancellable): Receive = handlePeerUpdates orElse {
     case PeerActor.MessageReceived(blockHeaders: BlockHeaders) =>
       timeout.cancel()
       peer ! PeerActor.Unsubscribe
@@ -113,6 +115,7 @@ class FastSyncController(
 
           scheduler.schedule(0.seconds, printStatusInterval, self, PrintStatus)
           context become new SyncingHandler(targetBlockHeader).receive
+
           self ! EnqueueNodes(Seq(StateMptNodeHash(targetBlockHeader.stateRoot)))
           self ! ProcessSyncing
 
@@ -186,6 +189,8 @@ class FastSyncController(
 
     private var assignedHandlers: Map[ActorRef, ActorRef] = Map.empty
 
+    private var bestBlockHeaderNumber: BigInt = appStateStorage.getBestBlockNumber()
+
     def receive: Receive = handlePeerUpdates orElse {
       case EnqueueNodes(hashes) =>
         hashes.foreach {
@@ -204,6 +209,9 @@ class FastSyncController(
       case UpdateDownloadedNodesCount(num) =>
         downloadedNodesCount += num
 
+      case UpdateBestBlockHeaderNumber(num) =>
+        bestBlockHeaderNumber = num
+
       case ProcessSyncing =>
         processSyncing()
 
@@ -219,7 +227,7 @@ class FastSyncController(
       case PrintStatus =>
         val totalNodesCount = downloadedNodesCount + mptNodesQueue.size + nonMptNodesQueue.size
         log.info(
-          s"""|Block: ${nodeStatusHolder().blockchainStatus.bestNumber}/${targetBlock.number}.
+          s"""|Block: ${appStateStorage.getBestBlockNumber()}/${targetBlock.number}.
               |Peers: ${assignedHandlers.size}/${handshakedPeers.size} (${blacklistedPeers.size} blacklisted).
               |State: $downloadedNodesCount/$totalNodesCount known nodes.""".stripMargin.replace("\n", " "))
     }
@@ -259,7 +267,7 @@ class FastSyncController(
       } else if (blockBodiesQueue.nonEmpty) {
         requestBlockBodies(peer)
       } else if (context.child(blockHeadersHandlerName).isEmpty &&
-        targetBlock.number > nodeStatusHolder().blockchainStatus.bestNumber) {
+        targetBlock.number > bestBlockHeaderNumber) {
         requestBlockHeaders(peer)
       } else if (nonMptNodesQueue.nonEmpty || mptNodesQueue.nonEmpty) {
         requestNodes(peer)
@@ -268,7 +276,8 @@ class FastSyncController(
 
     def requestReceipts(peer: ActorRef): Unit = {
       val (receiptsToGet, remainingReceipts) = receiptsQueue.splitAt(receiptsPerRequest)
-      val handler = context.actorOf(FastSyncReceiptsRequestHandler.props(peer, receiptsToGet.toSeq, blockchain))
+      val handler = context.actorOf(FastSyncReceiptsRequestHandler.props(
+        peer, receiptsToGet.toSeq, appStateStorage, blockchain))
       context watch handler
       assignedHandlers += (handler -> peer)
       receiptsQueue = remainingReceipts
@@ -276,7 +285,8 @@ class FastSyncController(
 
     def requestBlockBodies(peer: ActorRef): Unit = {
       val (blockBodiesToGet, remainingBlockBodies) = blockBodiesQueue.splitAt(blockBodiesPerRequest)
-      val handler = context.actorOf(FastSyncBlockBodiesRequestHandler.props(peer, blockBodiesToGet.toSeq, blockchain))
+      val handler = context.actorOf(FastSyncBlockBodiesRequestHandler.props(
+        peer, blockBodiesToGet.toSeq, appStateStorage, blockchain))
       context watch handler
       assignedHandlers += (handler -> peer)
       blockBodiesQueue = remainingBlockBodies
@@ -284,10 +294,7 @@ class FastSyncController(
 
     def requestBlockHeaders(peer: ActorRef): Unit = {
       val handler = context.actorOf(FastSyncBlockHeadersRequestHandler.props(
-        peer,
-        nodeStatusHolder().blockchainStatus.bestNumber + 1,
-        blockHeadersPerRequest,
-        nodeStatusHolder, blockchain), blockHeadersHandlerName)
+        peer, bestBlockHeaderNumber + 1, blockHeadersPerRequest, nodeStatusHolder, blockchain), blockHeadersHandlerName)
       context watch handler
       assignedHandlers += (handler -> peer)
     }
@@ -312,7 +319,7 @@ class FastSyncController(
       receiptsQueue.nonEmpty
 
     def fullySynced: Boolean =
-      nodeStatusHolder().blockchainStatus.bestNumber >= targetBlock.number &&
+      bestBlockHeaderNumber >= targetBlock.number &&
       !anythingQueued &&
       assignedHandlers.isEmpty
   }
@@ -322,9 +329,10 @@ object FastSyncController {
   def props(
              peerManager: ActorRef,
              nodeStatusHolder: Agent[NodeStatus],
+             appStateStorage: AppStateStorage,
              blockchain: Blockchain,
              mptNodeStorage: MptNodeStorage):
-  Props = Props(new FastSyncController(peerManager, nodeStatusHolder, blockchain, mptNodeStorage))
+  Props = Props(new FastSyncController(peerManager, nodeStatusHolder, appStateStorage, blockchain, mptNodeStorage))
 
   case object StartFastSync
 
@@ -333,6 +341,7 @@ object FastSyncController {
   case class EnqueueReceipts(hashes: Seq[ByteString])
 
   case class UpdateDownloadedNodesCount(update: Int)
+  case class UpdateBestBlockHeaderNumber(bestBlockHeaderNumber: BigInt)
 
   sealed trait HashType {
     def v: ByteString

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/FastSyncReceiptsRequestHandler.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/FastSyncReceiptsRequestHandler.scala
@@ -2,12 +2,14 @@ package io.iohk.ethereum.blockchain.sync
 
 import akka.actor.{ActorRef, Props, Scheduler}
 import akka.util.ByteString
+import io.iohk.ethereum.db.storage.AppStateStorage
 import io.iohk.ethereum.domain.Blockchain
 import io.iohk.ethereum.network.p2p.messages.PV63.{GetReceipts, Receipts}
 
 class FastSyncReceiptsRequestHandler(
     peer: ActorRef,
     requestedHashes: Seq[ByteString],
+    appStateStorage: AppStateStorage,
     blockchain: Blockchain)(implicit scheduler: Scheduler)
   extends FastSyncRequestHandler[GetReceipts, Receipts](peer) {
 
@@ -18,6 +20,9 @@ class FastSyncReceiptsRequestHandler(
     (requestedHashes zip receipts.receiptsForBlocks).foreach { case (hash, receiptsForBlock) =>
       blockchain.save(hash, receiptsForBlock)
     }
+
+    val receivedHashes = requestedHashes.take(receipts.receiptsForBlocks.size)
+    updateBestBlockIfNeeded(receivedHashes)
 
     if (receipts.receiptsForBlocks.isEmpty) {
       fastSyncController ! BlacklistSupport.BlacklistPeer(peer)
@@ -30,6 +35,22 @@ class FastSyncReceiptsRequestHandler(
 
     log.info("Received {} receipts in {} ms", receipts.receiptsForBlocks.size, timeTakenSoFar())
     cleanupAndStop()
+  }
+
+  private def updateBestBlockIfNeeded(receivedHashes: Seq[ByteString]): Unit = {
+    val fullBlocks = receivedHashes.flatMap { hash =>
+      for {
+        header <- blockchain.getBlockHeaderByHash(hash)
+        _ <- blockchain.getBlockBodyByHash(hash)
+      } yield header
+    }
+
+    if (fullBlocks.nonEmpty) {
+      val bestReceivedBlock = fullBlocks.maxBy(_.number)
+      if (bestReceivedBlock.number > appStateStorage.getBestBlockNumber()) {
+        appStateStorage.putBestBlockNumber(bestReceivedBlock.number)
+      }
+    }
   }
 
   override def handleTimeout(): Unit = {
@@ -45,7 +66,7 @@ class FastSyncReceiptsRequestHandler(
 }
 
 object FastSyncReceiptsRequestHandler {
-  def props(peer: ActorRef, requestedHashes: Seq[ByteString], blockchain: Blockchain)
+  def props(peer: ActorRef, requestedHashes: Seq[ByteString], appStateStorage: AppStateStorage, blockchain: Blockchain)
            (implicit scheduler: Scheduler): Props =
-    Props(new FastSyncReceiptsRequestHandler(peer, requestedHashes, blockchain))
+    Props(new FastSyncReceiptsRequestHandler(peer, requestedHashes, appStateStorage, blockchain))
 }

--- a/src/main/scala/io/iohk/ethereum/db/components/DataSourcesComponent.scala
+++ b/src/main/scala/io/iohk/ethereum/db/components/DataSourcesComponent.scala
@@ -8,19 +8,21 @@ trait DataSourcesComponent {
 
   trait DataSources {
 
-    val evmCodeStorage: DataSource
+    def evmCodeDataSource: DataSource
 
-    val mptDataSource: DataSource
+    def mptDataSource: DataSource
 
-    val receiptsDataSource: DataSource
+    def receiptsDataSource: DataSource
 
-    val blockHeadersDataSource: DataSource
+    def blockHeadersDataSource: DataSource
 
-    val blockBodiesDataSource: DataSource
+    def blockBodiesDataSource: DataSource
 
-    val blockHeightsHashesDataSource: DataSource
+    def blockHeightsHashesDataSource: DataSource
 
-    val totalDifficultyDataSource: DataSource
+    def totalDifficultyDataSource: DataSource
+
+    def appStateDataSource: DataSource
 
     def closeAll: Unit
 

--- a/src/main/scala/io/iohk/ethereum/db/components/DataSourcesComponent.scala
+++ b/src/main/scala/io/iohk/ethereum/db/components/DataSourcesComponent.scala
@@ -8,21 +8,21 @@ trait DataSourcesComponent {
 
   trait DataSources {
 
-    def evmCodeDataSource: DataSource
+    val evmCodeDataSource: DataSource
 
-    def mptDataSource: DataSource
+    val mptDataSource: DataSource
 
-    def receiptsDataSource: DataSource
+    val receiptsDataSource: DataSource
 
-    def blockHeadersDataSource: DataSource
+    val blockHeadersDataSource: DataSource
 
-    def blockBodiesDataSource: DataSource
+    val blockBodiesDataSource: DataSource
 
-    def blockHeightsHashesDataSource: DataSource
+    val blockHeightsHashesDataSource: DataSource
 
-    def totalDifficultyDataSource: DataSource
+    val totalDifficultyDataSource: DataSource
 
-    def appStateDataSource: DataSource
+    val appStateDataSource: DataSource
 
     def closeAll: Unit
 

--- a/src/main/scala/io/iohk/ethereum/db/components/SharedEphemDataSources.scala
+++ b/src/main/scala/io/iohk/ethereum/db/components/SharedEphemDataSources.scala
@@ -7,7 +7,7 @@ trait SharedEphemDataSources extends DataSourcesComponent {
 
   val dataSources = new DataSources {
 
-    override val evmCodeStorage: DataSource = ephemDataSource
+    override val evmCodeDataSource: DataSource = ephemDataSource
 
     override val mptDataSource: DataSource = ephemDataSource
 
@@ -20,6 +20,8 @@ trait SharedEphemDataSources extends DataSourcesComponent {
     override val blockHeadersDataSource: DataSource = ephemDataSource
 
     override val totalDifficultyDataSource: DataSource = ephemDataSource
+
+    override val appStateDataSource: DataSource = ephemDataSource
 
     override def closeAll: Unit = ()
   }

--- a/src/main/scala/io/iohk/ethereum/db/components/SharedIodbDataSources.scala
+++ b/src/main/scala/io/iohk/ethereum/db/components/SharedIodbDataSources.scala
@@ -15,13 +15,15 @@ trait SharedIodbDataSources extends DataSourcesComponent {
 
     override val blockHeadersDataSource: DataSource = dataSource
 
-    override val evmCodeStorage: DataSource = dataSource
+    override val evmCodeDataSource: DataSource = dataSource
 
     override val mptDataSource: DataSource = dataSource
 
     override val receiptsDataSource: DataSource = dataSource
 
     override val totalDifficultyDataSource: DataSource = dataSource
+
+    override val appStateDataSource: DataSource = dataSource
 
     override def closeAll: Unit = dataSource.close()
   }

--- a/src/main/scala/io/iohk/ethereum/db/components/SharedLevelDBDataSources.scala
+++ b/src/main/scala/io/iohk/ethereum/db/components/SharedLevelDBDataSources.scala
@@ -15,13 +15,15 @@ trait SharedLevelDBDataSources extends DataSourcesComponent {
 
     override val blockHeadersDataSource: DataSource = dataSource
 
-    override val evmCodeStorage: DataSource = dataSource
+    override val evmCodeDataSource: DataSource = dataSource
 
     override val mptDataSource: DataSource = dataSource
 
     override val receiptsDataSource: DataSource = dataSource
 
     override val totalDifficultyDataSource: DataSource = dataSource
+
+    override val appStateDataSource: DataSource = dataSource
 
     override def closeAll: Unit = dataSource.close()
   }

--- a/src/main/scala/io/iohk/ethereum/db/components/Storages.scala
+++ b/src/main/scala/io/iohk/ethereum/db/components/Storages.scala
@@ -23,11 +23,13 @@ object Storages {
 
       override val mptNodeStorage: MptNodeStorage = new MptNodeStorage(dataSources.mptDataSource)
 
-      override val evmCodeStorage: EvmCodeStorage = new EvmCodeStorage(dataSources.evmCodeStorage)
+      override val evmCodeStorage: EvmCodeStorage = new EvmCodeStorage(dataSources.evmCodeDataSource)
 
       override val totalDifficultyStorage: TotalDifficultyStorage =
         new TotalDifficultyStorage(dataSources.totalDifficultyDataSource)
           .put(Config.Blockchain.genesisHash, Config.Blockchain.genesisDifficulty)
+
+      override val appStateStorage: AppStateStorage = new AppStateStorage(dataSources.appStateDataSource)
     }
 
   }
@@ -53,11 +55,13 @@ object Storages {
 
       override val mptNodeStorage: MptNodeStorage = new MptNodeStorage(dataSources.mptDataSource)
 
-      override val evmCodeStorage: EvmCodeStorage = new EvmCodeStorage(dataSources.evmCodeStorage)
+      override val evmCodeStorage: EvmCodeStorage = new EvmCodeStorage(dataSources.evmCodeDataSource)
 
       override val totalDifficultyStorage: TotalDifficultyStorage =
         new TotalDifficultyStorage(dataSources.totalDifficultyDataSource)
           .put(Config.Blockchain.genesisHash, Config.Blockchain.genesisDifficulty)
+
+      override val appStateStorage: AppStateStorage = new AppStateStorage(dataSources.appStateDataSource)
     }
   }
 }

--- a/src/main/scala/io/iohk/ethereum/db/components/StoragesComponent.scala
+++ b/src/main/scala/io/iohk/ethereum/db/components/StoragesComponent.scala
@@ -5,24 +5,24 @@ import io.iohk.ethereum.domain.BlockchainStorages
 
 trait StoragesComponent {
 
-  def storages: Storages
+  val storages: Storages
 
   trait Storages extends BlockchainStorages {
 
-    def blockHeadersStorage: BlockHeadersStorage
+    val blockHeadersStorage: BlockHeadersStorage
 
-    def blockBodiesStorage: BlockBodiesStorage
+    val blockBodiesStorage: BlockBodiesStorage
 
-    def blockNumberMappingStorage: BlockNumberMappingStorage
+    val blockNumberMappingStorage: BlockNumberMappingStorage
 
-    def receiptStorage: ReceiptStorage
+    val receiptStorage: ReceiptStorage
 
-    def mptNodeStorage: MptNodeStorage
+    val mptNodeStorage: MptNodeStorage
 
-    def evmCodeStorage: EvmCodeStorage
+    val evmCodeStorage: EvmCodeStorage
 
-    def totalDifficultyStorage: TotalDifficultyStorage
+    val totalDifficultyStorage: TotalDifficultyStorage
 
-    def appStateStorage: AppStateStorage
+    val appStateStorage: AppStateStorage
   }
 }

--- a/src/main/scala/io/iohk/ethereum/db/components/StoragesComponent.scala
+++ b/src/main/scala/io/iohk/ethereum/db/components/StoragesComponent.scala
@@ -5,23 +5,24 @@ import io.iohk.ethereum.domain.BlockchainStorages
 
 trait StoragesComponent {
 
-  val storages: Storages
+  def storages: Storages
 
   trait Storages extends BlockchainStorages {
 
-    val blockHeadersStorage: BlockHeadersStorage
+    def blockHeadersStorage: BlockHeadersStorage
 
-    val blockBodiesStorage: BlockBodiesStorage
+    def blockBodiesStorage: BlockBodiesStorage
 
-    val blockNumberMappingStorage: BlockNumberMappingStorage
+    def blockNumberMappingStorage: BlockNumberMappingStorage
 
-    val receiptStorage: ReceiptStorage
+    def receiptStorage: ReceiptStorage
 
-    val mptNodeStorage: MptNodeStorage
+    def mptNodeStorage: MptNodeStorage
 
-    val evmCodeStorage: EvmCodeStorage
+    def evmCodeStorage: EvmCodeStorage
 
-    val totalDifficultyStorage: TotalDifficultyStorage
+    def totalDifficultyStorage: TotalDifficultyStorage
 
+    def appStateStorage: AppStateStorage
   }
 }

--- a/src/main/scala/io/iohk/ethereum/db/storage/AppStateStorage.scala
+++ b/src/main/scala/io/iohk/ethereum/db/storage/AppStateStorage.scala
@@ -1,0 +1,43 @@
+package io.iohk.ethereum.db.storage
+
+import io.iohk.ethereum.db.dataSource.DataSource
+import io.iohk.ethereum.db.storage.AppStateStorage._
+
+/**
+  * This class is used to store app state variables
+  *   Key: see AppStateStorage.Keys
+  *   Value: stored string value
+  */
+class AppStateStorage(val dataSource: DataSource) extends KeyValueStorage[Key, Value]{
+  type T = AppStateStorage
+
+  val namespace: IndexedSeq[Byte] = Namespaces.AppStateNamespace
+  def keySerializer: Key => IndexedSeq[Byte] = _.name.getBytes
+  def valueSerializer: String => IndexedSeq[Byte] = _.getBytes
+  def valueDeserializer: IndexedSeq[Byte] => String = (valueBytes: IndexedSeq[Byte]) => new String(valueBytes.toArray)
+
+  protected def apply(dataSource: DataSource): AppStateStorage = new AppStateStorage(dataSource)
+
+  def getBestBlockNumber(): BigInt =
+    BigInt(get(Keys.BestBlockNumber).getOrElse("0"))
+
+  def putBestBlockNumber(bestBlockNumber: BigInt): AppStateStorage =
+    put(Keys.BestBlockNumber, bestBlockNumber.toString)
+
+  def getFastSyncTargetBlockNumber(): Option[BigInt] =
+    get(Keys.FastSyncTargetBlock).map(BigInt.apply)
+
+  def putFastSyncTargetBlockNumber(fastSyncTargetBlockNumber: BigInt): AppStateStorage =
+    put(Keys.FastSyncTargetBlock, fastSyncTargetBlockNumber.toString)
+}
+
+object AppStateStorage {
+  type Value = String
+
+  case class Key private (name: String)
+
+  object Keys {
+    val BestBlockNumber = Key("BestBlockNumber")
+    val FastSyncTargetBlock = Key("FastSyncTargetBlock")
+  }
+}

--- a/src/main/scala/io/iohk/ethereum/db/storage/KeyValueStorage.scala
+++ b/src/main/scala/io/iohk/ethereum/db/storage/KeyValueStorage.scala
@@ -66,5 +66,6 @@ object Namespaces {
   val NodeNamespace: IndexedSeq[Byte] = IndexedSeq[Byte]('n'.toByte)
   val CodeNamespace: IndexedSeq[Byte] = IndexedSeq[Byte]('c'.toByte)
   val TotalDifficultyNamespace: IndexedSeq[Byte] = IndexedSeq[Byte]('t'.toByte)
+  val AppStateNamespace: IndexedSeq[Byte] = IndexedSeq[Byte]('s'.toByte)
   val HeightsNamespace: IndexedSeq[Byte] = IndexedSeq[Byte]('i'.toByte)
 }

--- a/src/main/scala/io/iohk/ethereum/domain/Blockchain.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/Blockchain.scala
@@ -181,13 +181,13 @@ class BlockchainImpl(
 }
 
 trait BlockchainStorages {
-  val blockHeadersStorage: BlockHeadersStorage
-  val blockBodiesStorage: BlockBodiesStorage
-  val blockNumberMappingStorage: BlockNumberMappingStorage
-  val receiptStorage: ReceiptStorage
-  val evmCodeStorage: EvmCodeStorage
-  val mptNodeStorage: MptNodeStorage
-  val totalDifficultyStorage: TotalDifficultyStorage
+  def blockHeadersStorage: BlockHeadersStorage
+  def blockBodiesStorage: BlockBodiesStorage
+  def blockNumberMappingStorage: BlockNumberMappingStorage
+  def receiptStorage: ReceiptStorage
+  def evmCodeStorage: EvmCodeStorage
+  def mptNodeStorage: MptNodeStorage
+  def totalDifficultyStorage: TotalDifficultyStorage
 }
 
 object BlockchainImpl {

--- a/src/main/scala/io/iohk/ethereum/domain/Blockchain.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/Blockchain.scala
@@ -181,13 +181,13 @@ class BlockchainImpl(
 }
 
 trait BlockchainStorages {
-  def blockHeadersStorage: BlockHeadersStorage
-  def blockBodiesStorage: BlockBodiesStorage
-  def blockNumberMappingStorage: BlockNumberMappingStorage
-  def receiptStorage: ReceiptStorage
-  def evmCodeStorage: EvmCodeStorage
-  def mptNodeStorage: MptNodeStorage
-  def totalDifficultyStorage: TotalDifficultyStorage
+  val blockHeadersStorage: BlockHeadersStorage
+  val blockBodiesStorage: BlockBodiesStorage
+  val blockNumberMappingStorage: BlockNumberMappingStorage
+  val receiptStorage: ReceiptStorage
+  val evmCodeStorage: EvmCodeStorage
+  val mptNodeStorage: MptNodeStorage
+  val totalDifficultyStorage: TotalDifficultyStorage
 }
 
 object BlockchainImpl {

--- a/src/main/scala/io/iohk/ethereum/network/FastSyncHost.scala
+++ b/src/main/scala/io/iohk/ethereum/network/FastSyncHost.scala
@@ -10,8 +10,8 @@ import io.iohk.ethereum.network.p2p.messages.PV63._
 import io.iohk.ethereum.network.rlpx.RLPxConnectionHandler
 
 trait FastSyncHost {
-  def peerConfiguration: PeerConfiguration
-  def blockchain: Blockchain
+  val peerConfiguration: PeerConfiguration
+  val blockchain: Blockchain
 
   def handleEvmMptFastDownload(rlpxConnection: RLPxConnection): Actor.Receive = {
     case RLPxConnectionHandler.MessageReceived(request: GetNodeData) =>

--- a/src/main/scala/io/iohk/ethereum/network/FastSyncHost.scala
+++ b/src/main/scala/io/iohk/ethereum/network/FastSyncHost.scala
@@ -10,16 +10,16 @@ import io.iohk.ethereum.network.p2p.messages.PV63._
 import io.iohk.ethereum.network.rlpx.RLPxConnectionHandler
 
 trait FastSyncHost {
-  val peerConfiguration: PeerConfiguration
-  val storage: Blockchain
+  def peerConfiguration: PeerConfiguration
+  def blockchain: Blockchain
 
   def handleEvmMptFastDownload(rlpxConnection: RLPxConnection): Actor.Receive = {
     case RLPxConnectionHandler.MessageReceived(request: GetNodeData) =>
       import io.iohk.ethereum.rlp.encode
 
       val result: Seq[ByteString] = request.mptElementsHashes.take(peerConfiguration.fastSyncHostConfiguration.maxMptComponentsPerMessage).flatMap { hash =>
-        storage.getMptNodeByHash(hash).map((node: MptNode) => ByteString(encode[MptNode](node)))
-          .orElse(storage.getEvmCodeByHash(hash).map((evm: ByteString) => evm))
+        blockchain.getMptNodeByHash(hash).map((node: MptNode) => ByteString(encode[MptNode](node)))
+          .orElse(blockchain.getEvmCodeByHash(hash).map((evm: ByteString) => evm))
       }
 
       rlpxConnection.sendMessage(NodeData(result))
@@ -28,18 +28,18 @@ trait FastSyncHost {
   def handleBlockFastDownload(rlpxConnection: RLPxConnection, log: LoggingAdapter): Actor.Receive = {
     case RLPxConnectionHandler.MessageReceived(request: GetReceipts) =>
       val receipts = request.blockHashes.take(peerConfiguration.fastSyncHostConfiguration.maxReceiptsPerMessage)
-        .flatMap(hash => storage.getReceiptsByHash(hash))
+        .flatMap(hash => blockchain.getReceiptsByHash(hash))
 
       rlpxConnection.sendMessage(Receipts(receipts))
 
     case RLPxConnectionHandler.MessageReceived(request: GetBlockBodies) =>
       val blockBodies = request.hashes.take(peerConfiguration.fastSyncHostConfiguration.maxBlocksBodiesPerMessage)
-        .flatMap(hash => storage.getBlockBodyByHash(hash))
+        .flatMap(hash => blockchain.getBlockBodyByHash(hash))
 
       rlpxConnection.sendMessage(BlockBodies(blockBodies))
 
     case RLPxConnectionHandler.MessageReceived(request: GetBlockHeaders) =>
-      val blockNumber = request.block.fold(a => Some(a), b => storage.getBlockHeaderByHash(b).map(_.number))
+      val blockNumber = request.block.fold(a => Some(a), b => blockchain.getBlockHeaderByHash(b).map(_.number))
 
       blockNumber match {
         case Some(startBlockNumber) if startBlockNumber >= 0 && request.maxHeaders >= 0 && request.skip >= 0 =>
@@ -56,7 +56,7 @@ trait FastSyncHost {
             startBlockNumber to (startBlockNumber + (request.skip + 1) * headersCount - 1) by (request.skip + 1)
           }
 
-          val blockHeaders: Seq[BlockHeader] = range.flatMap { a: BigInt => storage.getBlockHeaderByNumber(a) }
+          val blockHeaders: Seq[BlockHeader] = range.flatMap { a: BigInt => blockchain.getBlockHeaderByNumber(a) }
 
           rlpxConnection.sendMessage(BlockHeaders(blockHeaders))
 

--- a/src/main/scala/io/iohk/ethereum/utils/NodeStatus.scala
+++ b/src/main/scala/io/iohk/ethereum/utils/NodeStatus.scala
@@ -2,7 +2,6 @@ package io.iohk.ethereum.utils
 
 import java.net.InetSocketAddress
 
-import akka.util.ByteString
 import io.iohk.ethereum.network._
 import org.spongycastle.crypto.AsymmetricCipherKeyPair
 import org.spongycastle.crypto.params.ECPublicKeyParameters
@@ -13,12 +12,9 @@ object ServerStatus {
   case class Listening(address: InetSocketAddress) extends ServerStatus
 }
 
-case class BlockchainStatus(totalDifficulty: BigInt, bestHash: ByteString, bestNumber: BigInt)
-
 case class NodeStatus(
     key: AsymmetricCipherKeyPair,
-    serverStatus: ServerStatus,
-    blockchainStatus: BlockchainStatus) {
+    serverStatus: ServerStatus) {
 
   val nodeId = key.getPublic.asInstanceOf[ECPublicKeyParameters].toNodeId
 }

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/FastSyncBlockBodiesRequestHandlerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/FastSyncBlockBodiesRequestHandlerSpec.scala
@@ -5,8 +5,6 @@ import akka.actor.ActorSystem
 import akka.testkit.TestProbe
 import akka.util.ByteString
 import com.miguno.akka.testing.VirtualTime
-import io.iohk.ethereum.db.components.{SharedEphemDataSources, Storages}
-import io.iohk.ethereum.domain.{Blockchain, BlockchainImpl}
 import io.iohk.ethereum.network.PeerActor
 import io.iohk.ethereum.network.p2p.messages.PV62.{BlockBodies, BlockBody, GetBlockBodies}
 import org.scalatest.{FlatSpec, Matchers}
@@ -71,6 +69,7 @@ class FastSyncBlockBodiesRequestHandlerSpec extends FlatSpec with Matchers {
       parent.childActorOf(FastSyncBlockBodiesRequestHandler.props(
         peer.ref,
         requestedHashes,
+        storagesInstance.storages.appStateStorage,
         blockchain)(time.scheduler))
   }
 

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/FastSyncBlockHeadersRequestHandlerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/FastSyncBlockHeadersRequestHandlerSpec.scala
@@ -10,7 +10,7 @@ import com.miguno.akka.testing.VirtualTime
 import io.iohk.ethereum.network.PeerActor
 import io.iohk.ethereum.crypto
 import io.iohk.ethereum.utils.Config
-import io.iohk.ethereum.utils.{BlockchainStatus, NodeStatus, ServerStatus}
+import io.iohk.ethereum.utils.{NodeStatus, ServerStatus}
 import io.iohk.ethereum.domain.BlockHeader
 import io.iohk.ethereum.network.p2p.messages.PV62.{BlockHeaders, GetBlockHeaders}
 import org.scalatest.{FlatSpec, Matchers}
@@ -23,18 +23,18 @@ class FastSyncBlockHeadersRequestHandlerSpec extends FlatSpec with Matchers {
 
     val responseHeaders = Seq(BlockHeader(Config.Blockchain.genesisHash, ByteString(""), ByteString(""),
       ByteString(""), ByteString(""), ByteString(""),
-      ByteString(""), 0, 0, 0, 0, 0, ByteString(""), ByteString(""), ByteString("")))
+      ByteString(""), 0, block, 0, 0, 0, ByteString(""), ByteString(""), ByteString("")))
 
     peer.reply(PeerActor.MessageReceived(BlockHeaders(responseHeaders)))
 
     parent.expectMsgAllOf(
       FastSyncController.EnqueueBlockBodies(Seq(responseHeaders.head.hash)),
-      FastSyncController.EnqueueReceipts(Seq(responseHeaders.head.hash)))
+      FastSyncController.EnqueueReceipts(Seq(responseHeaders.head.hash)),
+      FastSyncController.UpdateBestBlockHeaderNumber(responseHeaders.last.number))
+
     parent.expectMsg(FastSyncRequestHandler.Done)
 
     blockchain.getBlockHeaderByHash(responseHeaders.head.hash) shouldBe Some(responseHeaders.head)
-
-    nodeStatusHolder().blockchainStatus.bestNumber shouldBe responseHeaders.last.number
 
     peer.expectMsg(PeerActor.Unsubscribe)
   }
@@ -69,8 +69,7 @@ class FastSyncBlockHeadersRequestHandlerSpec extends FlatSpec with Matchers {
 
     val nodeStatus = NodeStatus(
       key = nodeKey,
-      serverStatus = ServerStatus.NotListening,
-      blockchainStatus = BlockchainStatus(0, ByteString("123"), 0))
+      serverStatus = ServerStatus.NotListening)
 
     val nodeStatusHolder = Agent(nodeStatus)
 

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/FastSyncControllerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/FastSyncControllerSpec.scala
@@ -4,6 +4,7 @@ import java.net.InetSocketAddress
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
+
 import akka.actor.{ActorSystem, PoisonPill, Props, Terminated}
 import akka.agent.Agent
 import akka.testkit.{TestActorRef, TestProbe}
@@ -12,16 +13,17 @@ import com.miguno.akka.testing.VirtualTime
 import io.iohk.ethereum.crypto
 import io.iohk.ethereum.db.dataSource.EphemDataSource
 import io.iohk.ethereum.db.storage._
-import io.iohk.ethereum.domain.{BlockHeader, Blockchain}
+import io.iohk.ethereum.domain.BlockHeader
 import io.iohk.ethereum.network.PeerActor
 import io.iohk.ethereum.network.PeerManagerActor.{GetPeers, Peer, PeersResponse}
 import io.iohk.ethereum.network.p2p.messages.PV62._
 import io.iohk.ethereum.network.p2p.messages.PV63.{GetNodeData, GetReceipts, NodeData, Receipts}
 import io.iohk.ethereum.network.p2p.messages.CommonMessages.Status
-import io.iohk.ethereum.utils.{BlockchainStatus, NodeStatus, ServerStatus}
+import io.iohk.ethereum.utils.{NodeStatus, ServerStatus}
 import org.scalatest.{FlatSpec, Matchers}
 import org.spongycastle.util.encoders.Hex
 
+// scalastyle:off magic.number
 class FastSyncControllerSpec extends FlatSpec with Matchers {
 
   "FastSyncController" should "download target block and request state nodes" in new TestSetup {
@@ -65,10 +67,7 @@ class FastSyncControllerSpec extends FlatSpec with Matchers {
     peer2.expectMsg(PeerActor.SendMessage(GetBlockHeaders(Left(expectedTargetBlock), 1, 0, reverse = false)))
     peer2.reply(PeerActor.MessageReceived(BlockHeaders(Seq(targetBlockHeader))))
 
-    nodeStatusHolder.send(_.copy(blockchainStatus = BlockchainStatus(
-      targetBlockHeader.difficulty,
-      targetBlockHeader.hash,
-      targetBlockHeader.number)))
+    storagesInstance.storages.appStateStorage.putBestBlockNumber(targetBlockHeader.number)
 
     peer1.ref ! PoisonPill
 
@@ -87,10 +86,7 @@ class FastSyncControllerSpec extends FlatSpec with Matchers {
       number = expectedTargetBlock,
       stateRoot = ByteString(Hex.decode("deae1dfad5ec8dcef15915811e1f044d2543674fd648f94345231da9fc2646cc")))
 
-    nodeStatusHolder.send(_.copy(blockchainStatus = BlockchainStatus(
-      targetBlockHeader.difficulty,
-      ByteString("not the target"),
-      targetBlockHeader.number - 1)))
+    storagesInstance.storages.appStateStorage.putBestBlockNumber(targetBlockHeader.number - 1)
 
     time.advance(1.seconds)
 
@@ -176,6 +172,10 @@ class FastSyncControllerSpec extends FlatSpec with Matchers {
     peer2.expectMsg(PeerActor.GetStatus)
     peer2.reply(PeerActor.StatusResponse(PeerActor.Status.Handshaked(peer2Status)))
 
+    val expectedTargetBlock = 399500
+    val targetBlockHeader = baseBlockHeader.copy(number = expectedTargetBlock)
+    storagesInstance.storages.appStateStorage.putBestBlockNumber(targetBlockHeader.number)
+
     fastSyncController ! FastSyncController.StartFastSync
 
     peer1.expectMsg(PeerActor.Subscribe(Set(BlockHeaders.code)))
@@ -188,19 +188,11 @@ class FastSyncControllerSpec extends FlatSpec with Matchers {
     peer2.reply(PeerActor.MessageReceived(BlockHeaders(Seq(baseBlockHeader.copy(number = 400000)))))
     peer2.expectMsg(PeerActor.Unsubscribe)
 
-    val expectedTargetBlock = 399500
-
     peer1.expectNoMsg()
 
-    val targetBlockHeader = baseBlockHeader.copy(number = expectedTargetBlock)
     peer2.expectMsg(PeerActor.Subscribe(Set(BlockHeaders.code)))
     peer2.expectMsg(PeerActor.SendMessage(GetBlockHeaders(Left(expectedTargetBlock), 1, 0, reverse = false)))
     peer2.reply(PeerActor.MessageReceived(BlockHeaders(Seq(targetBlockHeader))))
-
-    nodeStatusHolder.send(_.copy(blockchainStatus = BlockchainStatus(
-      targetBlockHeader.difficulty,
-      targetBlockHeader.hash,
-      targetBlockHeader.number)))
 
     peer2.expectMsg(PeerActor.Unsubscribe)
 
@@ -233,8 +225,7 @@ class FastSyncControllerSpec extends FlatSpec with Matchers {
 
     val nodeStatus = NodeStatus(
       key = nodeKey,
-      serverStatus = ServerStatus.NotListening,
-      blockchainStatus = BlockchainStatus(0, ByteString("changeme"), 0))
+      serverStatus = ServerStatus.NotListening)
 
     val nodeStatusHolder = Agent(nodeStatus)
 
@@ -244,6 +235,7 @@ class FastSyncControllerSpec extends FlatSpec with Matchers {
     val dataSource = EphemDataSource()
 
     val fastSyncController = TestActorRef(Props(new FastSyncController(peerManager.ref, nodeStatusHolder,
+      storagesInstance.storages.appStateStorage,
       blockchain,
       new MptNodeStorage(dataSource),
       externalSchedulerOpt = Some(time.scheduler))))

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/FastSyncReceiptsRequestHandlerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/FastSyncReceiptsRequestHandlerSpec.scala
@@ -2,11 +2,10 @@ package io.iohk.ethereum.blockchain.sync
 
 import scala.concurrent.duration._
 
-import akka.actor.{Terminated, PoisonPill, ActorSystem}
+import akka.actor.{PoisonPill, ActorSystem}
 import akka.testkit.TestProbe
 import akka.util.ByteString
 import com.miguno.akka.testing.VirtualTime
-import io.iohk.ethereum.db.dataSource.EphemDataSource
 import io.iohk.ethereum.network.PeerActor
 import io.iohk.ethereum.network.p2p.messages.PV63.{Receipt, Receipts, GetReceipts}
 import org.scalatest.{FlatSpec, Matchers}
@@ -67,6 +66,7 @@ class FastSyncReceiptsRequestHandlerSpec extends FlatSpec with Matchers {
       parent.childActorOf(FastSyncReceiptsRequestHandler.props(
         peer.ref,
         requestedHashes,
+        storagesInstance.storages.appStateStorage,
         blockchain)(time.scheduler))
   }
 

--- a/src/test/scala/io/iohk/ethereum/network/PeerManagerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/network/PeerManagerSpec.scala
@@ -7,10 +7,9 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import akka.actor._
 import akka.agent.Agent
 import akka.testkit.{TestActorRef, TestProbe}
-import akka.util.ByteString
 import com.miguno.akka.testing.VirtualTime
 import io.iohk.ethereum.crypto
-import io.iohk.ethereum.utils.{Config, BlockchainStatus, ServerStatus, NodeStatus}
+import io.iohk.ethereum.utils.{Config, ServerStatus, NodeStatus}
 import org.scalatest.{FlatSpec, Matchers}
 
 class PeerManagerSpec extends FlatSpec with Matchers {
@@ -51,8 +50,7 @@ class PeerManagerSpec extends FlatSpec with Matchers {
 
     val nodeStatus = NodeStatus(
       key = nodeKey,
-      serverStatus = ServerStatus.NotListening,
-      blockchainStatus = BlockchainStatus(0, ByteString("123"), 0))
+      serverStatus = ServerStatus.NotListening)
 
     val nodeStatusHolder = Agent(nodeStatus)
 

--- a/src/test/scala/io/iohk/ethereum/network/p2p/BlockBroadcastActorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/network/p2p/BlockBroadcastActorSpec.scala
@@ -4,6 +4,7 @@ import java.net.InetSocketAddress
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
+
 import akka.actor.ActorSystem
 import akka.agent.Agent
 import akka.testkit.{TestActorRef, TestProbe}
@@ -17,10 +18,10 @@ import io.iohk.ethereum.network.PeerManagerActor.{GetPeers, Peer}
 import io.iohk.ethereum.network.p2p.messages.CommonMessages.NewBlock
 import io.iohk.ethereum.network.p2p.messages.PV62
 import io.iohk.ethereum.network.{BlockBroadcastActor, PeerActor, PeerManagerActor}
+import io.iohk.ethereum.network.p2p.messages.PV62._
+import io.iohk.ethereum.utils.{NodeStatus, ServerStatus}
 import org.scalatest.{FlatSpec, Matchers}
 import org.spongycastle.util.encoders.Hex
-import io.iohk.ethereum.network.p2p.messages.PV62._
-import io.iohk.ethereum.utils.{BlockchainStatus, NodeStatus, ServerStatus}
 
 class BlockBroadcastActorSpec extends FlatSpec with Matchers {
 
@@ -176,8 +177,7 @@ class BlockBroadcastActorSpec extends FlatSpec with Matchers {
 
     val nodeStatus = NodeStatus(
       key = nodeKey,
-      serverStatus = ServerStatus.NotListening,
-      blockchainStatus = BlockchainStatus(0, ByteString("changeme"), 0))
+      serverStatus = ServerStatus.NotListening)
 
     val nodeStatusHolder = Agent(nodeStatus)
 
@@ -196,6 +196,7 @@ class BlockBroadcastActorSpec extends FlatSpec with Matchers {
       nodeStatusHolder,
       peer.ref,
       peerManager.ref,
+      storagesInstance.storages.appStateStorage,
       blockchain
     ))
 


### PR DESCRIPTION
Add storage for most recent fully downloaded (with body and receipts) block. Use that to resume fast sync where we left off.