### PR TITLE
[EC-143] Code throws 'data too short' exception regularly

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -72,7 +72,7 @@ etc-client {
     max-concurrent-requests = 50
     block-headers-per-request = 2048
     block-bodies-per-request = 128
-    receipts-per-request = 128
+    receipts-per-request = 60
     nodes-per-request = 1000
     min-peers-to-choose-target-block = 2
     target-block-offset = 500


### PR DESCRIPTION
Issue is related to too big message containing receipts, fix for now is to limit number of receipts that can be send with one message
Final fix is adding support for multi frame messages