### PR TITLE
Static analysis fixes

### DIFF
--- a/src/it/scala/io/iohk/ethereum/db/DataSourceIntegrationTestBehavior.scala
+++ b/src/it/scala/io/iohk/ethereum/db/DataSourceIntegrationTestBehavior.scala
@@ -192,7 +192,7 @@ trait DataSourceIntegrationTestBehavior
           db.update(OtherNamespace2, Seq(), keyList.zip(valList2))
 
           //Removal of keys from the OtherNamespace namespace
-          db.update(OtherNamespace, keyList, Seq.empty)
+          db.update(OtherNamespace, keyList, Nil)
 
           keyList.foreach { key => assert(db.get(OtherNamespace, key).isEmpty) }
           keyList.zip(valList2).foreach { case (key, value) =>
@@ -200,7 +200,7 @@ trait DataSourceIntegrationTestBehavior
           }
 
           //Removal of keys from the OtherNamespace2 namespace
-          db.update(OtherNamespace2, keyList, Seq.empty)
+          db.update(OtherNamespace2, keyList, Nil)
 
           keyList.foreach { key => assert(db.get(OtherNamespace, key).isEmpty) }
           keyList.foreach { key => assert(db.get(OtherNamespace2, key).isEmpty) }

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/FastSyncNodesRequestHandler.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/FastSyncNodesRequestHandler.scala
@@ -33,10 +33,10 @@ class FastSyncNodesRequestHandler(
 
     val hashesToRequest = (nodeData.values.indices zip receivedHashes) flatMap { case (idx, valueHash) =>
       requestedHashes.find(_.v == valueHash) map {
-        case StateMptNodeHash(_) =>
+        case _: StateMptNodeHash =>
           handleMptNode(nodeData.getMptNode(idx))
 
-        case ContractStorageMptNodeHash(_) =>
+        case _: ContractStorageMptNodeHash =>
           handleContractMptNode(nodeData.getMptNode(idx))
 
         case EvmCodeHash(hash) =>

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/RegularSync.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/RegularSync.scala
@@ -17,7 +17,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 trait RegularSync {
   selfSyncController: SyncController =>
 
-  private var headersQueue: Seq[BlockHeader] = Seq.empty
+  private var headersQueue: Seq[BlockHeader] = Nil
   private var broadcasting = false
   private var waitingForActor: Option[ActorRef] = None
 
@@ -157,13 +157,13 @@ trait RegularSync {
   }
 
   private def scheduleResume() = {
-    headersQueue = Seq.empty
+    headersQueue = Nil
     scheduler.scheduleOnce(checkForNewBlockInterval, context.self, ResumeRegularSync)
   }
 
   private def resumeWithDifferentPeer(currentPeer: ActorRef) = {
     self ! BlacklistPeer(currentPeer, "because of error in response")
-    headersQueue = Seq.empty
+    headersQueue = Nil
     context.self ! ResumeRegularSync
   }
 

--- a/src/main/scala/io/iohk/ethereum/common/SimpleMap.scala
+++ b/src/main/scala/io/iohk/ethereum/common/SimpleMap.scala
@@ -20,7 +20,7 @@ trait SimpleMap[K, V, T <: SimpleMap[K, V, T]] {
     * @param value
     * @return New trie with the (key-value) pair inserted.
     */
-  def put(key: K, value: V): T = update(Seq.empty, Seq(key -> value))
+  def put(key: K, value: V): T = update(Nil, Seq(key -> value))
 
   /**
     * This function inserts a (key-value) pair into the trie. If the key is already asociated with another value it is updated.
@@ -37,7 +37,7 @@ trait SimpleMap[K, V, T <: SimpleMap[K, V, T]] {
     * @param key
     * @return New trie with the (key-value) pair associated with the key passed deleted from the trie.
     */
-  def remove(key: K): T = update(Seq(key), Seq.empty)
+  def remove(key: K): T = update(Seq(key), Nil)
 
   /**
     * This function deletes a (key-value) pair from the trie. If no (key-value) pair exists with the passed trie then there's no effect on it.

--- a/src/main/scala/io/iohk/ethereum/common/SimpleMap.scala
+++ b/src/main/scala/io/iohk/ethereum/common/SimpleMap.scala
@@ -20,7 +20,7 @@ trait SimpleMap[K, V, T <: SimpleMap[K, V, T]] {
     * @param value
     * @return New trie with the (key-value) pair inserted.
     */
-  def put(key: K, value: V): T = update(Seq(), Seq(key -> value))
+  def put(key: K, value: V): T = update(Seq.empty, Seq(key -> value))
 
   /**
     * This function inserts a (key-value) pair into the trie. If the key is already asociated with another value it is updated.
@@ -37,7 +37,7 @@ trait SimpleMap[K, V, T <: SimpleMap[K, V, T]] {
     * @param key
     * @return New trie with the (key-value) pair associated with the key passed deleted from the trie.
     */
-  def remove(key: K): T = update(Seq(key), Seq())
+  def remove(key: K): T = update(Seq(key), Seq.empty)
 
   /**
     * This function deletes a (key-value) pair from the trie. If no (key-value) pair exists with the passed trie then there's no effect on it.

--- a/src/main/scala/io/iohk/ethereum/mpt/MerklePatriciaTrie.scala
+++ b/src/main/scala/io/iohk/ethereum/mpt/MerklePatriciaTrie.scala
@@ -16,12 +16,12 @@ object MerklePatriciaTrie {
   case class MPTException(message: String) extends RuntimeException(message)
 
   private case class NodeInsertResult(newNode: Node,
-    toDeleteFromStorage: Seq[Node] = Seq(),
-    toUpdateInStorage: Seq[Node] = Seq())
+    toDeleteFromStorage: Seq[Node] = Seq.empty,
+    toUpdateInStorage: Seq[Node] = Seq.empty)
 
   private case class NodeRemoveResult(hasChanged: Boolean, newNode: Option[Node],
-    toDeleteFromStorage: Seq[Node] = Seq(),
-    toUpdateInStorage: Seq[Node] = Seq())
+    toDeleteFromStorage: Seq[Node] = Seq.empty,
+    toUpdateInStorage: Seq[Node] = Seq.empty)
 
   type HashFn = Array[Byte] => Array[Byte]
 
@@ -184,7 +184,7 @@ class MerklePatriciaTrie[K, V](private val rootHash: Option[Array[Byte]],
       val newRoot = LeafNode(keyNibbles, vSerializer.toBytes(value), hashFn)
       val newRootHash = newRoot.hash
       new MerklePatriciaTrie(Some(newRootHash),
-        updateNodesInStorage(getRootHash, Some(newRoot), Seq(), Seq(newRoot), nodeStorage),
+        updateNodesInStorage(getRootHash, Some(newRoot), Seq.empty, Seq(newRoot), nodeStorage),
         hashFn)
     }
   }
@@ -403,7 +403,7 @@ class MerklePatriciaTrie[K, V](private val rootHash: Option[Array[Byte]],
     // We want to delete Branch node value
     case (BranchNode(children, _, _), true) =>
       // We need to remove old node and fix it because we removed the value
-      val fixedNode = fix(BranchNode(children, None, hashFn), nodeStorage, Seq())
+      val fixedNode = fix(BranchNode(children, None, hashFn), nodeStorage, Seq.empty)
       NodeRemoveResult(hasChanged = true, newNode = Some(fixedNode), toDeleteFromStorage = Seq(node), toUpdateInStorage = Seq(fixedNode))
     case (branchNode@BranchNode(children, optStoredValue, _), false) =>
       // We might be trying to remove a node that's inside one of the 16 mapped nibbles

--- a/src/main/scala/io/iohk/ethereum/mpt/MerklePatriciaTrie.scala
+++ b/src/main/scala/io/iohk/ethereum/mpt/MerklePatriciaTrie.scala
@@ -16,12 +16,12 @@ object MerklePatriciaTrie {
   case class MPTException(message: String) extends RuntimeException(message)
 
   private case class NodeInsertResult(newNode: Node,
-    toDeleteFromStorage: Seq[Node] = Seq.empty,
-    toUpdateInStorage: Seq[Node] = Seq.empty)
+    toDeleteFromStorage: Seq[Node] = Nil,
+    toUpdateInStorage: Seq[Node] = Nil)
 
   private case class NodeRemoveResult(hasChanged: Boolean, newNode: Option[Node],
-    toDeleteFromStorage: Seq[Node] = Seq.empty,
-    toUpdateInStorage: Seq[Node] = Seq.empty)
+    toDeleteFromStorage: Seq[Node] = Nil,
+    toUpdateInStorage: Seq[Node] = Nil)
 
   type HashFn = Array[Byte] => Array[Byte]
 
@@ -184,7 +184,7 @@ class MerklePatriciaTrie[K, V](private val rootHash: Option[Array[Byte]],
       val newRoot = LeafNode(keyNibbles, vSerializer.toBytes(value), hashFn)
       val newRootHash = newRoot.hash
       new MerklePatriciaTrie(Some(newRootHash),
-        updateNodesInStorage(getRootHash, Some(newRoot), Seq.empty, Seq(newRoot), nodeStorage),
+        updateNodesInStorage(getRootHash, Some(newRoot), Nil, Seq(newRoot), nodeStorage),
         hashFn)
     }
   }
@@ -403,7 +403,7 @@ class MerklePatriciaTrie[K, V](private val rootHash: Option[Array[Byte]],
     // We want to delete Branch node value
     case (BranchNode(children, _, _), true) =>
       // We need to remove old node and fix it because we removed the value
-      val fixedNode = fix(BranchNode(children, None, hashFn), nodeStorage, Seq.empty)
+      val fixedNode = fix(BranchNode(children, None, hashFn), nodeStorage, Nil)
       NodeRemoveResult(hasChanged = true, newNode = Some(fixedNode), toDeleteFromStorage = Seq(node), toUpdateInStorage = Seq(fixedNode))
     case (branchNode@BranchNode(children, optStoredValue, _), false) =>
       // We might be trying to remove a node that's inside one of the 16 mapped nibbles
@@ -492,7 +492,7 @@ class MerklePatriciaTrie[K, V](private val rootHash: Option[Array[Byte]],
   @tailrec
   private def fix(node: Node, nodeStorage: NodeStorage, notStoredYet: Seq[Node]): Node = node match {
     case BranchNode(children, optStoredValue, _) =>
-      val usedIndexes = children.indices.foldLeft[Seq[Int]](Seq.empty) {
+      val usedIndexes = children.indices.foldLeft[Seq[Int]](Nil) {
         (acc, i) =>
           if (children(i).isDefined) i +: acc else acc
       }

--- a/src/main/scala/io/iohk/ethereum/network/PeerActor.scala
+++ b/src/main/scala/io/iohk/ethereum/network/PeerActor.scala
@@ -268,7 +268,7 @@ class PeerActor(
       log.debug("Received message: {}", message)
       blockchain.getBlockHeaderByNumber(number) match {
         case Some(header) => rlpxConnection.sendMessage(BlockHeaders(Seq(header)))
-        case None => rlpxConnection.sendMessage(BlockHeaders(Seq.empty))
+        case None => rlpxConnection.sendMessage(BlockHeaders(Nil))
       }
   }
 

--- a/src/main/scala/io/iohk/ethereum/vm/Program.scala
+++ b/src/main/scala/io/iohk/ethereum/vm/Program.scala
@@ -30,7 +30,7 @@ case class Program(code: ByteString) {
     * @param accum with the previously obtained valid jump destinations.
     */
   @tailrec
-  private def validJumpDestinationsAfterPosition(pos: Int, accum: Set[Int] = Set()): Set[Int] = {
+  private def validJumpDestinationsAfterPosition(pos: Int, accum: Set[Int] = Set.empty): Set[Int] = {
     if(pos < 0 || pos >= length) accum
     else {
       val byte = code(pos)

--- a/src/main/scala/io/iohk/ethereum/vm/ProgramState.scala
+++ b/src/main/scala/io/iohk/ethereum/vm/ProgramState.scala
@@ -35,7 +35,7 @@ case class ProgramState[W <: WorldStateProxy[W, S], S <: Storage[S]](
   returnData: ByteString = ByteString.empty,
   //TODO: investigate whether we need this or should refunds be simply added to current gas
   gasRefund: UInt256 = 0,
-  addressesToDelete: Seq[Address] = Seq.empty,
+  addressesToDelete: Seq[Address] = Nil,
   logs: Vector[TxLogEntry] = Vector.empty,
   halted: Boolean = false,
   error: Option[ProgramError] = None

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/SyncControllerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/SyncControllerSpec.scala
@@ -217,13 +217,13 @@ class SyncControllerSpec extends FlatSpec with Matchers {
 
     peer.expectMsg(PeerActor.SendMessage(GetBlockBodies(Seq(newBlockHeader.hash))))
     peer.expectMsg(PeerActor.Subscribe(Set(BlockBodies.code)))
-    peer.reply(PeerActor.MessageReceived(BlockBodies(Seq(BlockBody(Seq.empty, Seq.empty)))))
+    peer.reply(PeerActor.MessageReceived(BlockBodies(Seq(BlockBody(Nil, Nil)))))
 
     peer.expectMsgAllOf(10.seconds,
       PeerActor.SendMessage(GetBlockHeaders(Left(expectedMaxBlock + 2), Config.FastSync.blockHeadersPerRequest, 0, reverse = false)),
       PeerActor.Subscribe(Set(BlockHeaders.code)))
 
-    blockchain.getBlockByNumber(expectedMaxBlock + 1) shouldBe Some(Block(newBlockHeader, BlockBody(Seq.empty, Seq.empty)))
+    blockchain.getBlockByNumber(expectedMaxBlock + 1) shouldBe Some(Block(newBlockHeader, BlockBody(Nil, Nil)))
     blockchain.getTotalDifficultyByHash(newBlockHeader.hash) shouldBe Some(maxBlocTotalDifficulty + newBlockHeader.difficulty)
   }
 
@@ -254,7 +254,7 @@ class SyncControllerSpec extends FlatSpec with Matchers {
     storagesInstance.storages.appStateStorage.putBestBlockNumber(maxBlockHeader.number)
 
     storagesInstance.storages.blockHeadersStorage.put(maxBlockHeader.hash, maxBlockHeader)
-    storagesInstance.storages.blockBodiesStorage.put(maxBlockHeader.hash, BlockBody(Seq.empty, Seq.empty))
+    storagesInstance.storages.blockBodiesStorage.put(maxBlockHeader.hash, BlockBody(Nil, Nil))
     storagesInstance.storages.blockNumberMappingStorage.put(maxBlockHeader.number, maxBlockHeader.hash)
 
     storagesInstance.storages.blockHeadersStorage.put(commonRoot.hash, commonRoot)
@@ -279,7 +279,7 @@ class SyncControllerSpec extends FlatSpec with Matchers {
 
     peer.expectMsg(PeerActor.SendMessage(GetBlockBodies(Seq(newBlockHeaderParent.hash, newBlockHeader.hash))))
     peer.expectMsg(PeerActor.Subscribe(Set(BlockBodies.code)))
-    peer.reply(PeerActor.MessageReceived(BlockBodies(Seq(BlockBody(Seq.empty, Seq.empty), BlockBody(Seq.empty, Seq.empty)))))
+    peer.reply(PeerActor.MessageReceived(BlockBodies(Seq(BlockBody(Nil, Nil), BlockBody(Nil, Nil)))))
 
     //start next download cycle
 
@@ -288,18 +288,18 @@ class SyncControllerSpec extends FlatSpec with Matchers {
     peer.reply(PeerActor.MessageReceived(BlockHeaders(Seq(nextNewBlockHeader))))
     peer.expectMsg(PeerActor.SendMessage(GetBlockBodies(Seq(nextNewBlockHeader.hash))))
     peer.expectMsg(PeerActor.Subscribe(Set(BlockBodies.code)))
-    peer.reply(PeerActor.MessageReceived(BlockBodies(Seq(BlockBody(Seq.empty, Seq.empty)))))
+    peer.reply(PeerActor.MessageReceived(BlockBodies(Seq(BlockBody(Nil, Nil)))))
 
     //wait for actor to insert data
     Thread.sleep(3.seconds.toMillis)
 
-    blockchain.getBlockByNumber(expectedMaxBlock) shouldBe Some(Block(newBlockHeaderParent, BlockBody(Seq.empty, Seq.empty)))
+    blockchain.getBlockByNumber(expectedMaxBlock) shouldBe Some(Block(newBlockHeaderParent, BlockBody(Nil, Nil)))
     blockchain.getTotalDifficultyByHash(newBlockHeaderParent.hash) shouldBe Some(commonRootTotalDifficulty + newBlockHeaderParent.difficulty)
 
-    blockchain.getBlockByNumber(expectedMaxBlock + 1) shouldBe Some(Block(newBlockHeader, BlockBody(Seq.empty, Seq.empty)))
+    blockchain.getBlockByNumber(expectedMaxBlock + 1) shouldBe Some(Block(newBlockHeader, BlockBody(Nil, Nil)))
     blockchain.getTotalDifficultyByHash(newBlockHeader.hash) shouldBe Some(commonRootTotalDifficulty + newBlockHeaderParent.difficulty + newBlockHeader.difficulty)
 
-    blockchain.getBlockByNumber(expectedMaxBlock + 2) shouldBe Some(Block(nextNewBlockHeader, BlockBody(Seq.empty, Seq.empty)))
+    blockchain.getBlockByNumber(expectedMaxBlock + 2) shouldBe Some(Block(nextNewBlockHeader, BlockBody(Nil, Nil)))
     blockchain.getTotalDifficultyByHash(nextNewBlockHeader.hash) shouldBe Some(commonRootTotalDifficulty + newBlockHeaderParent.difficulty + newBlockHeader.difficulty + nextNewBlockHeader.difficulty)
 
     storagesInstance.storages.appStateStorage.getBestBlockNumber() shouldBe nextNewBlockHeader.number

--- a/src/test/scala/io/iohk/ethereum/db/dataSource/DataSourceTestBehavior.scala
+++ b/src/test/scala/io/iohk/ethereum/db/dataSource/DataSourceTestBehavior.scala
@@ -97,7 +97,7 @@ trait DataSourceTestBehavior
         assert(dataSource.get(OtherNamespace2, someByteString).contains(someValue2))
 
         //Removal
-        dataSource.update(OtherNamespace2, Seq(someByteString), Seq.empty)
+        dataSource.update(OtherNamespace2, Seq(someByteString), Nil)
 
         assert(dataSource.get(OtherNamespace, someByteString).contains(someValue1))
         assert(dataSource.get(OtherNamespace2, someByteString).isEmpty)

--- a/src/test/scala/io/iohk/ethereum/ledger/BlockRewardSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/BlockRewardSpec.scala
@@ -59,7 +59,7 @@ class BlockRewardSpec extends FlatSpec with Matchers {
       .saveAccount(validAccountAddress3, Account(balance = 30))
 
     // We don't care for this tests if block is not valid
-    def sampleBlock(minerAddress: Address, ommerMiners: Seq[Address] = Seq.empty): Block = {
+    def sampleBlock(minerAddress: Address, ommerMiners: Seq[Address] = Nil): Block = {
       Block(
         header = Fixtures.Blocks.Genesis.header.copy(beneficiary = minerAddress.bytes, number = 10),
         body = Fixtures.Blocks.Genesis.body.copy(

--- a/src/test/scala/io/iohk/ethereum/network/p2p/PeerActorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/network/p2p/PeerActorSpec.scala
@@ -399,10 +399,10 @@ class PeerActorSpec extends FlatSpec with Matchers {
   it should "update max peer when receiving new block" in new TestSetup {
     //given
     val firstHeader: BlockHeader = etcForkBlockHeader.copy(number = daoForkBlockNumber + 4)
-    val firstBlock = NewBlock(Block(firstHeader, BlockBody(Seq.empty, Seq.empty)), 300)
+    val firstBlock = NewBlock(Block(firstHeader, BlockBody(Nil, Nil)), 300)
 
     val secondHeader: BlockHeader = etcForkBlockHeader.copy(number = daoForkBlockNumber + 2)
-    val secondBlock = NewBlock(Block(secondHeader, BlockBody(Seq.empty, Seq.empty)), 300)
+    val secondBlock = NewBlock(Block(secondHeader, BlockBody(Nil, Nil)), 300)
 
     val probe = TestProbe()
 
@@ -461,10 +461,10 @@ class PeerActorSpec extends FlatSpec with Matchers {
   it should "update max peer when sending new block" in new TestSetup {
     //given
     val firstHeader: BlockHeader = etcForkBlockHeader.copy(number = daoForkBlockNumber + 4)
-    val firstBlock = NewBlock(Block(firstHeader, BlockBody(Seq.empty, Seq.empty)), 300)
+    val firstBlock = NewBlock(Block(firstHeader, BlockBody(Nil, Nil)), 300)
 
     val secondHeader: BlockHeader = etcForkBlockHeader.copy(number = daoForkBlockNumber + 2)
-    val secondBlock = NewBlock(Block(secondHeader, BlockBody(Seq.empty, Seq.empty)), 300)
+    val secondBlock = NewBlock(Block(secondHeader, BlockBody(Nil, Nil)), 300)
 
     val probe = TestProbe()
 


### PR DESCRIPTION
## Description

Includes several fixes to issues detected while running different static analysis tools.
The main problems fixed were:

* Changed `Seq()` and `Seq.empty` to `Nil`.
* Changed `Set()` to `Set.empty`.
* Refactoring mentioned in #102 comments.