### PR TITLE
Fixed bugs in tx execution

### DIFF
--- a/src/main/scala/io/iohk/ethereum/domain/SignedTransaction.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/SignedTransaction.scala
@@ -75,6 +75,9 @@ object SignedTransaction {
 
     for {
       key <- recoveredPublicKey
+
+      //TODO: Parity doesn't do this (https://github.com/paritytech/parity/blob/master/ethkey/src/keypair.rs#L23-L28)
+      //      more research is needed on why `key.tail` is needed
       addrBytes = crypto.kec256(key.tail).slice(FirstByteOfAddress, LastByteOfAddress)
       if addrBytes.length == Address.Length
     } yield Address(addrBytes)

--- a/src/main/scala/io/iohk/ethereum/domain/SignedTransaction.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/SignedTransaction.scala
@@ -75,7 +75,7 @@ object SignedTransaction {
 
     for {
       key <- recoveredPublicKey
-      addrBytes = crypto.kec256(key).slice(FirstByteOfAddress, LastByteOfAddress)
+      addrBytes = crypto.kec256(key.tail).slice(FirstByteOfAddress, LastByteOfAddress)
       if addrBytes.length == Address.Length
     } yield Address(addrBytes)
   }

--- a/src/main/scala/io/iohk/ethereum/ledger/BloomFilter.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/BloomFilter.scala
@@ -9,7 +9,7 @@ object BloomFilter {
 
   val BloomFilterByteSize: Int = 256
   private val BloomFilterBitSize: Int = BloomFilterByteSize * 8
-  private val EmptyBloomFilter: Array[Byte] = Array.fill(BloomFilterByteSize)(0.toByte)
+  val EmptyBloomFilter: ByteString = ByteString(Array.fill(BloomFilterByteSize)(0.toByte))
   private val IntIndexesToAccess: Set[Int] = Set(0, 2, 4)
 
   /**
@@ -22,7 +22,7 @@ object BloomFilter {
   def create(logs: Set[TxLogEntry]): ByteString = {
     val bloomFilters = logs.map(createBloomFilterForLogEntry)
     if(bloomFilters.isEmpty)
-      ByteString(EmptyBloomFilter)
+      EmptyBloomFilter
     else
       ByteString(or(bloomFilters.toSeq: _*))
   }
@@ -42,7 +42,7 @@ object BloomFilter {
       val index16bit = (hashedBytes(i + 1) & 0xFF) + ((hashedBytes(i) & 0xFF) << 8)
       index16bit % BloomFilterBitSize //Obtain only 11 bits from the index
     }
-    bitsToSet.foldLeft(EmptyBloomFilter){ case (prevBloom, index) => setBit(prevBloom, index) }.reverse
+    bitsToSet.foldLeft(EmptyBloomFilter.toArray){ case (prevBloom, index) => setBit(prevBloom, index) }.reverse
   }
 
   private def setBit(bytes: Array[Byte], bitIndex: Int): Array[Byte] = {

--- a/src/main/scala/io/iohk/ethereum/ledger/InMemoryWorldStateProxy.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/InMemoryWorldStateProxy.scala
@@ -33,12 +33,6 @@ object InMemoryWorldStateProxy {
     new InMemoryWorldStateProxy(stateStorage, accountsStateTrieProxy, Map.empty, storages.evmCodeStorage, Map.empty, getBlockHashByNumber)
   }
 
-  def persistIfHashMatches(stateRootHash: ByteString, worldState: InMemoryWorldStateProxy): InMemoryWorldStateProxy = {
-    val commited = persistState(worldState)
-    if (commited.stateRootHash == stateRootHash) commited
-    else worldState
-  }
-
   /**
     * Updates state trie with current changes but does not persist them into the storages. To do so it:
     *   - Commits code (to get account's code hashes)
@@ -82,7 +76,7 @@ object InMemoryWorldStateProxy {
 
   /**
     * Returns an [[InMemorySimpleMapProxy]] of the accounts state trie "The world state (state), is a mapping
-    * between addresses (160-bit identifiers) and account states (a data structure serialised as RLP [...]).
+    * between Keccak 256-bit hashes of the addresses (160-bit identifiers) and account states (a data structure serialised as RLP [...]).
     * Though not stored on the blockchain, it is assumed that the implementation will maintain this mapping in a
     * modified Merkle Patricia tree [...])."
     *
@@ -99,9 +93,8 @@ object InMemoryWorldStateProxy {
         stateRootHash.toArray[Byte],
         accountsStorage,
         kec256(_: Array[Byte])
-      )(byteStringSerializer, accountSerializer)
+      )(HashByteArraySerializable(byteStringSerializer), accountSerializer)
     )
-    //
   }
 
   /**

--- a/src/main/scala/io/iohk/ethereum/ledger/Ledger.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/Ledger.scala
@@ -50,7 +50,7 @@ object Ledger extends Logger {
     stateStorage: NodeStorage):
   ExecResult = {
     val initialWorldStateProxy = InMemoryWorldStateProxy(storages, stateStorage,
-      blockchain.getBlockHeaderByHash(block.header.parentHash).map(_.stateRoot)
+      blockchain.getBlockHeaderByHash(block.header.hash).map(_.stateRoot)
     )
     block.body.transactionList.foldLeft[ExecResult](ExecResult(worldState = initialWorldStateProxy)) {
       case (ExecResult(worldStateProxy, acumGas, receipts), stx) =>

--- a/src/test/scala/io/iohk/ethereum/ledger/InMemoryWorldStateProxySpec.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/InMemoryWorldStateProxySpec.scala
@@ -9,6 +9,12 @@ import org.spongycastle.util.encoders.Hex
 
 class InMemoryWorldStateProxySpec extends FlatSpec with Matchers {
 
+  def persistIfHashMatches(stateRootHash: ByteString, worldState: InMemoryWorldStateProxy): InMemoryWorldStateProxy = {
+    val commited = InMemoryWorldStateProxy.persistState(worldState)
+    if (commited.stateRootHash == stateRootHash) commited
+    else worldState
+  }
+
   "InMemoryWorldStateProxy" should "allow to create and retrieve an account" in new TestSetup {
     worldState.newEmptyAccount(address1).accountExists(address1) shouldBe true
   }
@@ -70,8 +76,8 @@ class InMemoryWorldStateProxySpec extends FlatSpec with Matchers {
     validateInitialWorld(afterUpdatesWorldState)
 
     // Persist and check
-    val persistedWorldState = InMemoryWorldStateProxy.persistIfHashMatches(
-      ByteString(Hex.decode("1246b67299251e9d4645fc7d5e08df0edfdd3c5bdcd4cfbe929fc9244b6cac40")),
+    val persistedWorldState = persistIfHashMatches(
+      ByteString(Hex.decode("bf117ca2e8a9ec7978cac9f46a6714b7e4fa9c065d5ba03fc3c0502710d92d19")),
       afterUpdatesWorldState
     )
     validateInitialWorld(persistedWorldState)
@@ -91,7 +97,7 @@ class InMemoryWorldStateProxySpec extends FlatSpec with Matchers {
     updatedNewWorldState.getStorage(address1).load(addr) shouldEqual value
 
     // Persist and check again
-    val persistedNewWorldState = InMemoryWorldStateProxy.persistIfHashMatches(
+    val persistedNewWorldState = persistIfHashMatches(
       ByteString(Hex.decode("71e5a0e173527cd8dde2e587a09c4a8f6a138226e2979a7fcbd273a89d117511")),
       updatedNewWorldState
     )

--- a/src/test/scala/io/iohk/ethereum/ledger/InMemoryWorldStateProxySpec.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/InMemoryWorldStateProxySpec.scala
@@ -9,12 +9,6 @@ import org.spongycastle.util.encoders.Hex
 
 class InMemoryWorldStateProxySpec extends FlatSpec with Matchers {
 
-  def persistIfHashMatches(stateRootHash: ByteString, worldState: InMemoryWorldStateProxy): InMemoryWorldStateProxy = {
-    val commited = InMemoryWorldStateProxy.persistState(worldState)
-    if (commited.stateRootHash == stateRootHash) commited
-    else worldState
-  }
-
   "InMemoryWorldStateProxy" should "allow to create and retrieve an account" in new TestSetup {
     worldState.newEmptyAccount(address1).accountExists(address1) shouldBe true
   }
@@ -76,10 +70,7 @@ class InMemoryWorldStateProxySpec extends FlatSpec with Matchers {
     validateInitialWorld(afterUpdatesWorldState)
 
     // Persist and check
-    val persistedWorldState = persistIfHashMatches(
-      ByteString(Hex.decode("bf117ca2e8a9ec7978cac9f46a6714b7e4fa9c065d5ba03fc3c0502710d92d19")),
-      afterUpdatesWorldState
-    )
+    val persistedWorldState = InMemoryWorldStateProxy.persistState(afterUpdatesWorldState)
     validateInitialWorld(persistedWorldState)
 
     // Create a new WS instance based on storages and new root state and check
@@ -97,10 +88,7 @@ class InMemoryWorldStateProxySpec extends FlatSpec with Matchers {
     updatedNewWorldState.getStorage(address1).load(addr) shouldEqual value
 
     // Persist and check again
-    val persistedNewWorldState = persistIfHashMatches(
-      ByteString(Hex.decode("71e5a0e173527cd8dde2e587a09c4a8f6a138226e2979a7fcbd273a89d117511")),
-      updatedNewWorldState
-    )
+    val persistedNewWorldState = InMemoryWorldStateProxy.persistState(updatedNewWorldState)
 
     persistedNewWorldState.getGuaranteedAccount(address1).balance shouldEqual account.balance
     persistedNewWorldState.getGuaranteedAccount(address2).balance shouldEqual 0


### PR DESCRIPTION
## Description

Includes fixes to several issues that where detected during tx execution, this includes:
* Before running `validateBlockAfterExecution` we persist the trie (so as to obtain the correct state root hash).
* The state trie is now a secure trie (the keys are hashed before inserting them).
* Fixing how the sender is recovered from a transaction (in https://github.com/ethereum/ethereumj/blob/develop/ethereumj-core/src/main/java/org/ethereum/crypto/ECKey.java#L439 the head of the public key is dropped).
* Fixed in `BlockValidator.validateLogBloom` how we handle the case where there are no receipts.