### PR TITLE
Fixed more bugs in tx execution

### DIFF
--- a/src/evmTest/scala/io/iohk/ethereum/vm/utils/EvmTestEnv.scala
+++ b/src/evmTest/scala/io/iohk/ethereum/vm/utils/EvmTestEnv.scala
@@ -130,7 +130,7 @@ trait EvmTestEnv {
              gasLimit: BigInt = BigInt(2).pow(256) - 1,
              gasPrice: BigInt = 1,
              sender: Address = defaultSender): ProgramResult[MockWorldState, MockStorage] = {
-      val transaction = MockVmInput.transaction(sender, callData, value, gasLimit, gasPrice, contract.address)
+      val transaction = MockVmInput.transaction(sender, callData, value, gasLimit, gasPrice, Some(contract.address))
       val blockHeader = MockVmInput.blockHeader
       val pc = ProgramContext[MockWorldState, MockStorage](transaction, blockHeader, world)
 

--- a/src/main/scala/io/iohk/ethereum/domain/Address.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/Address.scala
@@ -21,12 +21,9 @@ object Address {
 
   def apply(addr: Long): Address = Address(UInt256(addr))
 
-  val empty: Address = Address(ByteString())
 }
 
 class Address private(val bytes: ByteString) {
-
-  def isEmpty: Boolean = bytes == Address.empty.bytes
 
   def toArray: Array[Byte] = bytes.toArray
 

--- a/src/main/scala/io/iohk/ethereum/domain/SignedTransaction.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/SignedTransaction.scala
@@ -42,6 +42,7 @@ object SignedTransaction {
 
   private def getSender(tx: Transaction, signature: ECDSASignature, recoveredPointSign: Int): Option[Address] = {
     val ECDSASignature(r, s, v) = signature
+    val receivingAddressAsArray: Array[Byte] = tx.receivingAddress.map(_.toArray).getOrElse(Array.emptyByteArray)
     val bytesToSign: Array[Byte] = if (v == negativePointSign || v == positivePointSign) {
       //global transaction
       crypto.kec256(
@@ -49,7 +50,7 @@ object SignedTransaction {
           tx.nonce,
           tx.gasPrice,
           tx.gasLimit,
-          tx.receivingAddress.toArray,
+          receivingAddressAsArray,
           tx.value,
           tx.payload)))
     } else {
@@ -59,7 +60,7 @@ object SignedTransaction {
           tx.nonce,
           tx.gasPrice,
           tx.gasLimit,
-          tx.receivingAddress.toArray,
+          receivingAddressAsArray,
           tx.value,
           tx.payload,
           Config.Blockchain.chainId,
@@ -103,7 +104,7 @@ object SignedTransaction {
         tx.nonce,
         tx.gasPrice,
         tx.gasLimit,
-        tx.receivingAddress.toArray,
+        tx.receivingAddress.map(_.toArray).getOrElse(Array.emptyByteArray): Array[Byte],
         tx.value,
         tx.payload,
         Config.Blockchain.chainId,

--- a/src/main/scala/io/iohk/ethereum/domain/Transaction.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/Transaction.scala
@@ -10,13 +10,16 @@ object Transaction {
   val GasLength = 32
   val ValueLength = 32
 
+  def apply(nonce: BigInt, gasPrice: BigInt, gasLimit: BigInt, receivingAddress: Address, value: BigInt, payload: ByteString): Transaction =
+    Transaction(nonce, gasPrice, gasLimit, Some(receivingAddress), value, payload)
+
 }
 
 case class Transaction(
   nonce: BigInt,
   gasPrice: BigInt,
   gasLimit: BigInt,
-  receivingAddress: Address,
+  receivingAddress: Option[Address],
   value: BigInt,
   payload: ByteString) {
 
@@ -27,7 +30,7 @@ case class Transaction(
          |nonce: $nonce
          |gasPrice: $gasPrice
          |gasLimit: $gasLimit
-         |receivingAddress: ${Hex.toHexString(receivingAddress.toArray)}
+         |receivingAddress: ${if(receivingAddress.isDefined) Hex.toHexString(receivingAddress.get.toArray) else "[Contract creation]"}
          |value: $value wei
          |payload: ${if (isContractInit) "ContractInit: " else "TransactionData: "}${Hex.toHexString(payload.toArray[Byte])}
          |}""".stripMargin

--- a/src/main/scala/io/iohk/ethereum/ledger/Ledger.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/Ledger.scala
@@ -166,7 +166,7 @@ class Ledger(vm: VM) extends Logger {
     * @param tx Target transaction
     * @return Upfront cost
     */
-  private def calculateUpfrontGas(tx: Transaction): BigInt = tx.gasLimit * tx.gasPrice
+  private def calculateUpfrontGas(tx: Transaction): UInt256 = UInt256(tx.gasLimit * tx.gasPrice)
 
   /**
     * v0 ≡ Tg (Tx gas limit) * Tp (Tx gas price) + Tv (Tx value). See YP equation number (65)
@@ -240,7 +240,7 @@ class Ledger(vm: VM) extends Logger {
 
   /**
     * Increments account nonce by 1 stated in YP equation (69) and
-    * Pays the upfront Tx gas calculated as TxGasPrice * TxGasLimit + TxValue from balance. YP equation (68)
+    * Pays the upfront Tx gas calculated as TxGasPrice * TxGasLimit from balance. YP equation (68)
     *
     * @param stx
     * @param worldStateProxy
@@ -249,7 +249,7 @@ class Ledger(vm: VM) extends Logger {
   private[ledger] def updateSenderAccountBeforeExecution(stx: SignedTransaction, worldStateProxy: InMemoryWorldStateProxy): InMemoryWorldStateProxy = {
     val senderAddress = stx.senderAddress
     val account = worldStateProxy.getGuaranteedAccount(senderAddress)
-    worldStateProxy.saveAccount(senderAddress, account.increaseBalance(-calculateUpfrontCost(stx.tx)).increaseNonce)
+    worldStateProxy.saveAccount(senderAddress, account.increaseBalance(-calculateUpfrontGas(stx.tx)).increaseNonce)
   }
 
   /**
@@ -268,7 +268,7 @@ class Ledger(vm: VM) extends Logger {
 
   private def runVM(stx: SignedTransaction, blockHeader: BlockHeader, worldStateProxy: InMemoryWorldStateProxy): PR = {
     val context: PC = ProgramContext(stx, blockHeader, worldStateProxy)
-    val result = vm.run(context)
+    val result: PR = vm.run(context)
     if (stx.tx.isContractInit && result.error.isEmpty)
       saveNewContract(context.env.ownerAddr, result)
     else

--- a/src/main/scala/io/iohk/ethereum/network/p2p/messages/CommonMessages.scala
+++ b/src/main/scala/io/iohk/ethereum/network/p2p/messages/CommonMessages.scala
@@ -50,15 +50,16 @@ object CommonMessages {
       override def encode(signedTx: SignedTransaction): RLPEncodeable = {
         import signedTx._
         import signedTx.tx._
-        RLPList(nonce, gasPrice, gasLimit, receivingAddress.toArray, value,
+        RLPList(nonce, gasPrice, gasLimit, receivingAddress.map(_.toArray).getOrElse(Array.emptyByteArray): Array[Byte], value,
           payload, signature.v, BigInt(signature.r), BigInt(signature.s))
       }
 
       override def decode(rlp: RLPEncodeable): SignedTransaction = rlp match {
         case RLPList(nonce, gasPrice, gasLimit, (receivingAddress: RLPValue), value,
         payload, pointSign, signatureRandom, signature) =>
+          val receivingAddressOpt = if(receivingAddress.bytes.isEmpty) None else Some(Address(receivingAddress.bytes))
           SignedTransaction(
-            Transaction(nonce, gasPrice, gasLimit, Address(receivingAddress.bytes), value, payload),
+            Transaction(nonce, gasPrice, gasLimit, receivingAddressOpt, value, payload),
             pointSign,
             signatureRandom.bytes,
             signature.bytes

--- a/src/main/scala/io/iohk/ethereum/vm/ProgramContext.scala
+++ b/src/main/scala/io/iohk/ethereum/vm/ProgramContext.scala
@@ -19,21 +19,22 @@ object ProgramContext {
   }
 
   private def callOrCreate[W <: WorldStateProxy[W, S], S <: Storage[S]](world: W, tx: Transaction, senderAddress: Address): (W, Address, Program) = {
-    if (tx.receivingAddress.isEmpty) {
-      // contract create
-      val (address, world1) = world.newAddress(senderAddress)
-      val world2 = world1.newEmptyAccount(address)
-      val world3 = world2.transfer(senderAddress, address, UInt256(tx.value))
-      val code = tx.payload
+    tx.receivingAddress match {
+      case None =>
+        // contract create
+        val (address, world1) = world.newAddress(senderAddress)
+        val world2 = world1.newEmptyAccount(address)
+        val world3 = world2.transfer(senderAddress, address, UInt256(tx.value))
+        val code = tx.payload
 
-      (world3, address, Program(code))
+        (world3, address, Program(code))
 
-    } else {
-      // message call
-      val world1 = world.transfer(senderAddress, tx.receivingAddress.get, UInt256(tx.value))
-      val code = world1.getCode(tx.receivingAddress.get)
+      case Some(txReceivingAddress) =>
+        // message call
+        val world1 = world.transfer(senderAddress, txReceivingAddress, UInt256(tx.value))
+        val code = world1.getCode(txReceivingAddress)
 
-      (world1, tx.receivingAddress.get, Program(code))
+        (world1, tx.receivingAddress.get, Program(code))
     }
   }
 }

--- a/src/main/scala/io/iohk/ethereum/vm/ProgramContext.scala
+++ b/src/main/scala/io/iohk/ethereum/vm/ProgramContext.scala
@@ -30,10 +30,10 @@ object ProgramContext {
 
     } else {
       // message call
-      val world1 = world.transfer(senderAddress, tx.receivingAddress, UInt256(tx.value))
-      val code = world1.getCode(tx.receivingAddress)
+      val world1 = world.transfer(senderAddress, tx.receivingAddress.get, UInt256(tx.value))
+      val code = world1.getCode(tx.receivingAddress.get)
 
-      (world1, tx.receivingAddress, Program(code))
+      (world1, tx.receivingAddress.get, Program(code))
     }
   }
 }

--- a/src/main/scala/io/iohk/ethereum/vmrunner/MockVmInput.scala
+++ b/src/main/scala/io/iohk/ethereum/vmrunner/MockVmInput.scala
@@ -23,10 +23,10 @@ object MockVmInput {
     value: BigInt,
     gasLimit: BigInt,
     gasPrice: BigInt = defaultGasPrice,
-    receivingAddress: Address = Address.empty,
+    receivingAddress: Address = Address(ByteString()),
     nonce: BigInt = 0
   ): SignedTransaction =
-    new MockTransaction(Transaction(nonce, gasPrice, gasLimit, receivingAddress, value, payload), senderAddress)
+    new MockTransaction(Transaction(nonce, gasPrice, gasLimit, Some(receivingAddress), value, payload), senderAddress)
 
 
   def blockHeader: BlockHeader =

--- a/src/main/scala/io/iohk/ethereum/vmrunner/MockVmInput.scala
+++ b/src/main/scala/io/iohk/ethereum/vmrunner/MockVmInput.scala
@@ -23,10 +23,10 @@ object MockVmInput {
     value: BigInt,
     gasLimit: BigInt,
     gasPrice: BigInt = defaultGasPrice,
-    receivingAddress: Address = Address(ByteString()),
+    receivingAddress: Option[Address] = None,
     nonce: BigInt = 0
   ): SignedTransaction =
-    new MockTransaction(Transaction(nonce, gasPrice, gasLimit, Some(receivingAddress), value, payload), senderAddress)
+    new MockTransaction(Transaction(nonce, gasPrice, gasLimit, receivingAddress, value, payload), senderAddress)
 
 
   def blockHeader: BlockHeader =

--- a/src/main/scala/io/iohk/ethereum/vmrunner/State.scala
+++ b/src/main/scala/io/iohk/ethereum/vmrunner/State.scala
@@ -51,7 +51,7 @@ object State {
   }
 
   def runTransaction(xAccount: XAccount, callData: ByteString, gas: BigInt, value: BigInt): PR = {
-    val tx = MockVmInput.transaction(creatorAddress, callData, value, gas, receivingAddress = xAccount.address)
+    val tx = MockVmInput.transaction(creatorAddress, callData, value, gas, receivingAddress = Some(xAccount.address))
     val bh = MockVmInput.blockHeader
 
     val context: PC = ProgramContext(tx, bh, world)


### PR DESCRIPTION
Includes fixes to the bugs:
* Both `Ledger.updateSenderAccountBeforeExecution` and `ProgramContext.callOrCreate` decreased tx.value from sender of a tx in the state world so the sender's balance was decreased by `tx.value` twice
* In case a tx was for contract creation (so `receivingAddress` was empty) the `recevingAdress` was padded with zeros (resulting in the address `0x00000000000000000000` instead of an empty one). This changed the result of encoding the `SignedTransaction`for `BlockValidator.validateTransactionRoot`. The `tx.recevingAddress` was changed to an `Option[Address]` with `None` signifying that the tx is for contract creation.