### PR TITLE
[EC-159] Fixed nonce being increased twice in contract creation

### DIFF
--- a/src/evmTest/scala/io/iohk/ethereum/vm/utils/EvmTestEnv.scala
+++ b/src/evmTest/scala/io/iohk/ethereum/vm/utils/EvmTestEnv.scala
@@ -55,10 +55,7 @@ trait EvmTestEnv {
                      constructorArgs: Seq[Any] = Nil): (ProgramResult[MockWorldState, MockStorage], Contract) = {
     val creator = world.getAccount(creatorAddress).get
 
-    val contractAddress = {
-      val hash = crypto.kec256(rlp.encode(RLPList(creatorAddress.bytes, creator.nonce)))
-      Address(hash.takeRight(Address.Length))
-    }
+    val (contractAddress, worldAfterNonceIncrease) = world.increaseCreatorNonceAndCreateAddress(creatorAddress)
 
     val contractInitCode = Utils.loadContractCodeFromFile(new File(s"$ContractsDir/$name.bin"))
     val contractAbi = Utils.loadContractAbiFromFile(new File(s"$ContractsDir/$name.abi"))
@@ -68,14 +65,13 @@ trait EvmTestEnv {
     val tx = MockVmInput.transaction(creatorAddress, payload, value, gasLimit, gasPrice)
     val bh = MockVmInput.blockHeader
 
-    val context = ProgramContext[MockWorldState, MockStorage](tx, bh, world, config)
+    val context = ProgramContext[MockWorldState, MockStorage](tx, bh, worldAfterNonceIncrease, config)
     val result = VM.run(context)
 
     contractsAbis += (name -> contractAbi.right.get)
     contractsAddresses += (name -> contractAddress)
 
     internalWorld = result.world
-      .saveAccount(creatorAddress, creator.increaseNonce)
       .saveAccount(contractAddress, Account(UInt256(0), UInt256(value), Account.EmptyStorageRootHash, kec256(result.returnData)))
       .saveCode(contractAddress, result.returnData)
 

--- a/src/evmTest/scala/io/iohk/ethereum/vm/utils/EvmTestEnv.scala
+++ b/src/evmTest/scala/io/iohk/ethereum/vm/utils/EvmTestEnv.scala
@@ -55,7 +55,7 @@ trait EvmTestEnv {
                      constructorArgs: Seq[Any] = Nil): (ProgramResult[MockWorldState, MockStorage], Contract) = {
     val creator = world.getAccount(creatorAddress).get
 
-    val (contractAddress, worldAfterNonceIncrease) = world.increaseCreatorNonceAndCreateAddress(creatorAddress)
+    val (contractAddress, worldAfterNonceIncrease) = world.createAddressWithOpCode(creatorAddress)
 
     val contractInitCode = Utils.loadContractCodeFromFile(new File(s"$ContractsDir/$name.bin"))
     val contractAbi = Utils.loadContractAbiFromFile(new File(s"$ContractsDir/$name.abi"))

--- a/src/main/scala/io/iohk/ethereum/vm/OpCode.scala
+++ b/src/main/scala/io/iohk/ethereum/vm/OpCode.scala
@@ -675,7 +675,7 @@ case object CREATE extends OpCode(0xf0, 3, 1, _.G_create) {
     } else {
 
       val (initCode, memory1) = state.memory.load(inOffset, inSize)
-      val (newAddress, world1) = state.world.increaseCreatorNonceAndCreateAddress(state.env.ownerAddr)
+      val (newAddress, world1) = state.world.createAddressWithOpCode(state.env.ownerAddr)
       val world2 = world1.transfer(state.env.ownerAddr, newAddress, endowment)
 
       val newEnv = state.env.copy(

--- a/src/main/scala/io/iohk/ethereum/vm/OpCode.scala
+++ b/src/main/scala/io/iohk/ethereum/vm/OpCode.scala
@@ -675,7 +675,7 @@ case object CREATE extends OpCode(0xf0, 3, 1, _.G_create) {
     } else {
 
       val (initCode, memory1) = state.memory.load(inOffset, inSize)
-      val (newAddress, world1) = state.world.newAddress(state.env.ownerAddr)
+      val (newAddress, world1) = state.world.increaseCreatorNonceAndCreateAddress(state.env.ownerAddr)
       val world2 = world1.transfer(state.env.ownerAddr, newAddress, endowment)
 
       val newEnv = state.env.copy(

--- a/src/main/scala/io/iohk/ethereum/vm/ProgramContext.scala
+++ b/src/main/scala/io/iohk/ethereum/vm/ProgramContext.scala
@@ -27,8 +27,8 @@ object ProgramContext {
     tx.receivingAddress match {
       case None =>
         // contract create
-        val (address, world1) = world.newAddress(senderAddress)
-        val world2 = world1.newEmptyAccount(address)
+        val address = world.createAddress(senderAddress)
+        val world2 = world.newEmptyAccount(address)
         val world3 = world2.transfer(senderAddress, address, UInt256(tx.value))
         val code = tx.payload
 
@@ -36,10 +36,10 @@ object ProgramContext {
 
       case Some(txReceivingAddress) =>
         // message call
-        val world1 = world.transfer(senderAddress, txReceivingAddress, UInt256(tx.value))
-        val code = world1.getCode(txReceivingAddress)
+        val worldAfterTransfer = world.transfer(senderAddress, txReceivingAddress, UInt256(tx.value))
+        val code = worldAfterTransfer.getCode(txReceivingAddress)
 
-        (world1, tx.receivingAddress.get, Program(code))
+        (worldAfterTransfer, tx.receivingAddress.get, Program(code))
     }
   }
 }

--- a/src/main/scala/io/iohk/ethereum/vm/WorldStateProxy.scala
+++ b/src/main/scala/io/iohk/ethereum/vm/WorldStateProxy.scala
@@ -54,11 +54,27 @@ trait WorldStateProxy[WS <: WorldStateProxy[WS, S], S <: Storage[S]] { self: WS 
     }
   }
 
-  def newAddress(creatorAddr: Address): (Address, WS) = {
-    val creator = getGuaranteedAccount(creatorAddr)
-    val hash = kec256(rlp.encode(RLPList(creatorAddr.bytes, creator.nonce)))
-    val addr = Address(hash)
-    val updated = saveAccount(creatorAddr, creator.increaseNonce)
-    (addr, updated)
+  /**
+    * Creates a new address based on the address and nonce of the creator. YP equation 82
+    *
+    * @param creatorAddr, the address of the creator of the new address
+    * @return the new address
+    */
+  def createAddress(creatorAddr: Address): Address = {
+    val creatorAccount = getGuaranteedAccount(creatorAddr)
+    val hash = kec256(rlp.encode(RLPList(creatorAddr.bytes, creatorAccount.nonce - 1)))
+    Address(hash)
+  }
+
+  /**
+    * Increases the creator's nonce and creates a new address based on the address and the new nonce of the creator
+    *
+    * @param creatorAddr, the address of the creator of the new address
+    * @return the new address and the state world after the creator's nonce was increased
+    */
+  def increaseCreatorNonceAndCreateAddress(creatorAddr: Address): (Address, WS) = {
+    val creatorAccount = getGuaranteedAccount(creatorAddr)
+    val updatedWorld = saveAccount(creatorAddr, creatorAccount.increaseNonce)
+    updatedWorld.createAddress(creatorAddr) -> updatedWorld
   }
 }

--- a/src/main/scala/io/iohk/ethereum/vm/WorldStateProxy.scala
+++ b/src/main/scala/io/iohk/ethereum/vm/WorldStateProxy.scala
@@ -72,7 +72,7 @@ trait WorldStateProxy[WS <: WorldStateProxy[WS, S], S <: Storage[S]] { self: WS 
     * @param creatorAddr, the address of the creator of the new address
     * @return the new address and the state world after the creator's nonce was increased
     */
-  def increaseCreatorNonceAndCreateAddress(creatorAddr: Address): (Address, WS) = {
+  def createAddressWithOpCode(creatorAddr: Address): (Address, WS) = {
     val creatorAccount = getGuaranteedAccount(creatorAddr)
     val updatedWorld = saveAccount(creatorAddr, creatorAccount.increaseNonce)
     updatedWorld.createAddress(creatorAddr) -> updatedWorld

--- a/src/main/scala/io/iohk/ethereum/vmrunner/State.scala
+++ b/src/main/scala/io/iohk/ethereum/vmrunner/State.scala
@@ -21,7 +21,7 @@ object State {
 
 
   def createAccount(name: String, balance: BigInt, gas: BigInt, code: ByteString, abis: Seq[ABI]): (Address, PR) = {
-    val (newAddress, _) = world.increaseCreatorNonceAndCreateAddress(creatorAddress)
+    val (newAddress, _) = world.createAddressWithOpCode(creatorAddress)
     val tx = MockVmInput.transaction(creatorAddress, code, balance, gas)
     val bh = MockVmInput.blockHeader
 

--- a/src/main/scala/io/iohk/ethereum/vmrunner/State.scala
+++ b/src/main/scala/io/iohk/ethereum/vmrunner/State.scala
@@ -21,7 +21,7 @@ object State {
 
 
   def createAccount(name: String, balance: BigInt, gas: BigInt, code: ByteString, abis: Seq[ABI]): (Address, PR) = {
-    val (newAddress, _) = world.newAddress(creatorAddress)
+    val (newAddress, _) = world.increaseCreatorNonceAndCreateAddress(creatorAddress)
     val tx = MockVmInput.transaction(creatorAddress, code, balance, gas)
     val bh = MockVmInput.blockHeader
 

--- a/src/test/scala/io/iohk/ethereum/ledger/LedgerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/LedgerSpec.scala
@@ -22,7 +22,96 @@ class LedgerSpec extends FlatSpec with PropertyChecks with Matchers {
   }
 
 
-  "Ledger" should "correctly adjust gas used when refunding gas to the sender and paying for gas to the miner" in {
+  "Ledger" should "correctly adjust gas used when refunding gas to the sender and paying for gas to the miner" in new TestSetup {
+
+    val initialOriginBalance: UInt256 = 1000000
+    val initialMinerBalance: UInt256 = 2000000
+
+    val table = Table[UInt256, UInt256, Option[ProgramError], UInt256](
+      ("gasUsed", "refundsFromVM", "maybeError", "balanceDelta"),
+      (25000, 20000, None, (25000 / 2) * defaultGasPrice),
+      (25000, 10000, None, (25000 - 10000) * 10),
+      (125000, 10000, Some(OutOfGas), defaultGasLimit * defaultGasPrice),
+      (125000, 100000, Some(OutOfGas), defaultGasLimit * defaultGasPrice)
+    )
+
+    forAll(table) { (gasUsed, gasRefund, error, balanceDelta) =>
+
+      val initialWorld = emptyWorld
+        .saveAccount(originAddress, Account(nonce = UInt256(defaultTx.nonce), balance = initialOriginBalance))
+        .saveAccount(minerAddress, Account(balance = initialMinerBalance))
+
+      val tx = defaultTx.copy(gasPrice = defaultGasPrice, gasLimit = defaultGasLimit)
+      val stx = SignedTransaction.sign(tx, keyPair)
+
+      val header = defaultBlockHeader.copy(beneficiary = minerAddress.bytes)
+
+      val result: PR = ProgramResult(
+        returnData = bEmpty,
+        gasRemaining = defaultGasLimit - gasUsed,
+        world = Ledger.updateSenderAccountBeforeExecution(stx, initialWorld),
+        Nil,
+        Nil,
+        gasRefund,
+        error
+      )
+
+      val mockVM = new MockVM(_ => result)
+      val ledger = new Ledger(mockVM)
+
+      val postTxWorld = ledger.executeTransaction(stx, header, initialWorld).worldState
+
+      postTxWorld.getBalance(originAddress) shouldEqual (initialOriginBalance - balanceDelta)
+      postTxWorld.getBalance(minerAddress) shouldEqual (initialMinerBalance + balanceDelta)
+    }
+  }
+
+  it should "correctly change the nonce when executing a tx that results in contract creation" in new TestSetup {
+
+    val initialOriginBalance: UInt256 = 1000000
+    val initialMinerBalance: UInt256 = 2000000
+
+    val initialOriginNonce = defaultTx.nonce
+
+    val initialWorld = emptyWorld
+      .saveAccount(originAddress, Account(nonce = UInt256(initialOriginNonce), balance = initialOriginBalance))
+      .saveAccount(minerAddress, Account(balance = initialMinerBalance))
+
+    val tx = defaultTx.copy(gasPrice = defaultGasPrice, gasLimit = defaultGasLimit, receivingAddress = None, payload = ByteString.empty)
+    val stx = SignedTransaction.sign(tx, keyPair)
+
+    val header = defaultBlockHeader.copy(beneficiary = minerAddress.bytes)
+
+    val postTxWorld = Ledger.executeTransaction(stx, header, initialWorld).worldState
+
+    postTxWorld.getGuaranteedAccount(originAddress).nonce shouldBe (initialOriginNonce + 1)
+  }
+
+  it should "correctly change the nonce when executing a tx that results in a message call" in new TestSetup {
+
+    val initialOriginBalance: UInt256 = 1000000
+    val initialMinerBalance: UInt256 = 2000000
+
+    val initialOriginNonce = defaultTx.nonce
+
+    val initialWorld = emptyWorld
+      .saveAccount(originAddress, Account(nonce = UInt256(initialOriginNonce), balance = initialOriginBalance))
+      .saveAccount(minerAddress, Account(balance = initialMinerBalance))
+
+    val tx = defaultTx.copy(
+      gasPrice = defaultGasPrice, gasLimit = defaultGasLimit,
+      receivingAddress = Some(originAddress), payload = ByteString.empty
+    )
+    val stx = SignedTransaction.sign(tx, keyPair)
+
+    val header = defaultBlockHeader.copy(beneficiary = minerAddress.bytes)
+
+    val postTxWorld = Ledger.executeTransaction(stx, header, initialWorld).worldState
+
+    postTxWorld.getGuaranteedAccount(originAddress).nonce shouldBe (initialOriginNonce + 1)
+  }
+
+  trait TestSetup {
     val keyPair = generateKeyPair()
     val originAddress = Address(kec256(keyPair.getPublic.asInstanceOf[ECPublicKeyParameters].getQ.getEncoded(false)))
     val minerAddress = Address(666)
@@ -53,19 +142,6 @@ class LedgerSpec extends FlatSpec with PropertyChecks with Matchers {
       value = 0,
       payload = ByteString.empty)
 
-    val gasPrice: UInt256 = 10
-    val gasLimit: UInt256 = 1000000
-    val initialOriginBalance: UInt256 = 1000000
-    val initialMinerBalance: UInt256 = 2000000
-
-    val table = Table[UInt256, UInt256, Option[ProgramError], UInt256](
-      ("gasUsed", "refundsFromVM", "maybeError", "balanceDelta"),
-      (25000, 20000, None, (25000 / 2) * gasPrice),
-      (25000, 10000, None, (25000 - 10000) * 10),
-      (125000, 10000, Some(OutOfGas), gasLimit * gasPrice),
-      (125000, 100000, Some(OutOfGas), gasLimit * gasPrice)
-    )
-
     val storagesInstance = new SharedEphemDataSources with Storages.DefaultStorages
 
     val emptyWorld = InMemoryWorldStateProxy(
@@ -73,35 +149,8 @@ class LedgerSpec extends FlatSpec with PropertyChecks with Matchers {
       storagesInstance.storages.nodeStorage
     )
 
-    forAll(table) { (gasUsed, gasRefund, error, balanceDelta) =>
-
-      val initialWorld = emptyWorld
-        .saveAccount(originAddress, Account(nonce = UInt256(defaultTx.nonce), balance = initialOriginBalance))
-        .saveAccount(minerAddress, Account(balance = initialMinerBalance))
-
-      val tx = defaultTx.copy(gasPrice = gasPrice, gasLimit = gasLimit)
-      val stx = SignedTransaction.sign(tx, keyPair)
-
-      val header = defaultBlockHeader.copy(beneficiary = minerAddress.bytes)
-
-      val result: PR = ProgramResult(
-        returnData = bEmpty,
-        gasRemaining = gasLimit - gasUsed,
-        world = Ledger.updateSenderAccountBeforeExecution(stx, initialWorld),
-        Nil,
-        Nil,
-        gasRefund,
-        error
-      )
-
-      val mockVM = new MockVM(_ => result)
-      val ledger = new Ledger(mockVM)
-
-      val postTxWorld = ledger.executeTransaction(stx, header, initialWorld).worldState
-
-      postTxWorld.getBalance(originAddress) shouldEqual (initialOriginBalance - balanceDelta)
-      postTxWorld.getBalance(minerAddress) shouldEqual (initialMinerBalance + balanceDelta)
-    }
+    val defaultGasPrice: UInt256 = 10
+    val defaultGasLimit: UInt256 = 1000000
   }
 
 }

--- a/src/test/scala/io/iohk/ethereum/vm/CreateOpcodeSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/vm/CreateOpcodeSpec.scala
@@ -14,7 +14,7 @@ class CreateOpcodeSpec extends WordSpec with Matchers {
     val creatorAddr = Address(0xcafe)
     val endowment: UInt256 = 123
     val initWorld = MockWorldState().saveAccount(creatorAddr, Account.Empty.increaseBalance(endowment))
-    val newAddr = initWorld.increaseCreatorNonceAndCreateAddress(creatorAddr)._1
+    val newAddr = initWorld.createAddressWithOpCode(creatorAddr)._1
 
     // doubles the value passed in the input data
     val contractCode = Assembly(

--- a/src/test/scala/io/iohk/ethereum/vm/CreateOpcodeSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/vm/CreateOpcodeSpec.scala
@@ -14,7 +14,7 @@ class CreateOpcodeSpec extends WordSpec with Matchers {
     val creatorAddr = Address(0xcafe)
     val endowment: UInt256 = 123
     val initWorld = MockWorldState().saveAccount(creatorAddr, Account.Empty.increaseBalance(endowment))
-    val newAddr = initWorld.newAddress(creatorAddr)._1
+    val newAddr = initWorld.increaseCreatorNonceAndCreateAddress(creatorAddr)._1
 
     // doubles the value passed in the input data
     val contractCode = Assembly(


### PR DESCRIPTION
## Description

Includes a fix to nonce being increased twice in contract creation (before it was increased both in `WorldState.newAddress` and `Ledger.updateSenderAccountBeforeExecution`).