### PR TITLE
[EC-156] Remove erasing of nodes in MPT

### DIFF
--- a/src/it/scala/io/iohk/ethereum/mpt/MerklePatriciaTreeIntegrationSuite.scala
+++ b/src/it/scala/io/iohk/ethereum/mpt/MerklePatriciaTreeIntegrationSuite.scala
@@ -1,11 +1,13 @@
 package io.iohk.ethereum.mpt
 
+import java.io.File
 import java.nio.ByteBuffer
+import java.nio.file.Files
 import java.security.MessageDigest
 
 import io.iohk.ethereum.ObjectGenerators
 import io.iohk.ethereum.crypto.kec256
-import io.iohk.ethereum.db.dataSource.EphemDataSource
+import io.iohk.ethereum.db.dataSource.{EphemDataSource, LevelDBDataSource, LevelDbConfig}
 import io.iohk.ethereum.db.storage.NodeStorage
 import io.iohk.ethereum.mpt.MerklePatriciaTrie.defaultByteArraySerializable
 import io.iohk.ethereum.utils.Logger
@@ -18,11 +20,10 @@ import scala.util.Random
 class MerklePatriciaTreeIntegrationSuite extends FunSuite
   with PropertyChecks
   with ObjectGenerators
-  with Logger {
+  with Logger
+  with PersistentStorage {
 
   val hashFn = kec256(_: Array[Byte])
-
-  val EmptyTrie = MerklePatriciaTrie[Array[Byte], Array[Byte]](new NodeStorage(EphemDataSource()), hashFn)
 
   val KeySize: Int = 32 + 1 /* Hash size + prefix */
 
@@ -40,91 +41,130 @@ class MerklePatriciaTreeIntegrationSuite extends FunSuite
     MessageDigest.getInstance("MD5").digest(bytes)
   }
 
-  test("EthereumJ compatibility - Insert of the first 40000 numbers"){
-    val shuffledKeys = Random.shuffle(0 to 40000).map(intByteArraySerializable.toBytes)
-    val trie = shuffledKeys.foldLeft(EmptyTrie) { case (recTrie, key) => recTrie.put(key, key) }
-    assert(Hex.toHexString(trie.getRootHash) == "3f8b75707975e5c16588fa1ba3e69f8da39f4e7bf3ca28b029c7dcb589923463")
-  }
-
-  test("EthereumJ compatibility - Insert of the first 20000 numbers hashed"){
-    val shuffledKeys = Random.shuffle(0 to 20000).map(intByteArraySerializable.toBytes)
-    val trie = shuffledKeys.foldLeft(EmptyTrie) { case (recTrie, key) => recTrie.put(md5(key), key) }
-
-    // We insert keys that should have no effect so as to test that is the case (and for more code coverage)
-    val trieAfterInsertNoEffect = shuffledKeys.take(20000/2).foldLeft(trie) { case (recTrie, key) => recTrie.put(md5(key), key) }
-    assert(Hex.toHexString(trieAfterInsertNoEffect.getRootHash) == "a522b23a640c5fdb726e3f9644863e8913fe86339909fe881957efa0c23cebaa")
-  }
-
-  test("EthereumJ compatibility - Insert of the first 20000 numbers hashed and then remove half of them"){
-    val keys = (0 to 20000).map(intByteArraySerializable.toBytes)
-    val trie = Random.shuffle(keys).foldLeft(EmptyTrie) { case (recTrie, key) => recTrie.put(md5(key), key) }
-
-    // We delete have of the (key-value) pairs we had inserted
-    val trieAfterDelete = Random.shuffle(keys.take(20000/2)).foldLeft(trie) { case (recTrie, key) => recTrie.remove(md5(key)) }
-
-    // We delete keys with no effect so as to test that is the case (and for more code coverage)
-    val trieAfterDeleteNoEffect = keys.take(20000/2).foldLeft(trieAfterDelete) { case (recTrie, key) => recTrie.remove(md5(key)) }
-    assert(Hex.toHexString(trieAfterDeleteNoEffect.getRootHash) == "a693b82dcc5a9e581e9bf9aa7af3aed31fe3eb61f97fd733ce44c9f9df2d7f45")
-  }
-
-  test("EthereumJ compatibility - Insert of the first 20000 numbers hashed (with some sliced)"){
-    val keys = (0 to 20000).map(intByteArraySerializable.toBytes)
-
-    // We slice some of the keys so that me test more code coverage (if not we only test keys with the same length)
-    val slicedKeys = keys.zipWithIndex.map{case (key, index) =>
-      val hashedKey = md5(key)
-      if(index%2==0) hashedKey.take(hashedKey.length/2) else hashedKey
+  test("EthereumJ compatibility - Insert of the first 40000 numbers") {
+    withNodeStorage { ns =>
+      val EmptyTrie = MerklePatriciaTrie[Array[Byte], Array[Byte]](ns, hashFn)
+      val shuffledKeys = Random.shuffle(0 to 40000).map(intByteArraySerializable.toBytes)
+      val trie = shuffledKeys.foldLeft(EmptyTrie) { case (recTrie, key) => recTrie.put(key, key) }
+      assert(Hex.toHexString(trie.getRootHash) == "3f8b75707975e5c16588fa1ba3e69f8da39f4e7bf3ca28b029c7dcb589923463")
     }
-    val keyValuePairs = slicedKeys.zip(keys)
+  }
 
-    val trie = Random.shuffle(keyValuePairs).foldLeft(EmptyTrie) { case (recTrie, (key, value)) => recTrie.put(key, value) }
-    assert(Hex.toHexString(trie.getRootHash) == "46cde8656f3be6ce93ba9dcb1017548f44c65d1ea659ac827fac8c9ac77cf6b3")
+  test("EthereumJ compatibility - Insert of the first 20000 numbers hashed") {
+    withNodeStorage { ns =>
+      val EmptyTrie = MerklePatriciaTrie[Array[Byte], Array[Byte]](ns, hashFn)
+      val shuffledKeys = Random.shuffle(0 to 20000).map(intByteArraySerializable.toBytes)
+      val trie = shuffledKeys.foldLeft(EmptyTrie) { case (recTrie, key) => recTrie.put(md5(key), key) }
+
+      // We insert keys that should have no effect so as to test that is the case (and for more code coverage)
+      val trieAfterInsertNoEffect = shuffledKeys.take(20000 / 2).foldLeft(trie) { case (recTrie, key) => recTrie.put(md5(key), key) }
+      assert(Hex.toHexString(trieAfterInsertNoEffect.getRootHash) == "a522b23a640c5fdb726e3f9644863e8913fe86339909fe881957efa0c23cebaa")
+    }
+  }
+
+  test("EthereumJ compatibility - Insert of the first 20000 numbers hashed and then remove half of them") {
+    withNodeStorage { ns =>
+      val EmptyTrie = MerklePatriciaTrie[Array[Byte], Array[Byte]](ns, hashFn)
+      val keys = (0 to 20000).map(intByteArraySerializable.toBytes)
+      val trie = Random.shuffle(keys).foldLeft(EmptyTrie) { case (recTrie, key) => recTrie.put(md5(key), key) }
+
+      // We delete have of the (key-value) pairs we had inserted
+      val trieAfterDelete = Random.shuffle(keys.take(20000 / 2)).foldLeft(trie) { case (recTrie, key) => recTrie.remove(md5(key)) }
+
+      // We delete keys with no effect so as to test that is the case (and for more code coverage)
+      val trieAfterDeleteNoEffect = keys.take(20000 / 2).foldLeft(trieAfterDelete) { case (recTrie, key) => recTrie.remove(md5(key)) }
+      assert(Hex.toHexString(trieAfterDeleteNoEffect.getRootHash) == "a693b82dcc5a9e581e9bf9aa7af3aed31fe3eb61f97fd733ce44c9f9df2d7f45")
+    }
+  }
+
+  test("EthereumJ compatibility - Insert of the first 20000 numbers hashed (with some sliced)") {
+    withNodeStorage { ns =>
+      val EmptyTrie = MerklePatriciaTrie[Array[Byte], Array[Byte]](ns, hashFn)
+      val keys = (0 to 20000).map(intByteArraySerializable.toBytes)
+
+      // We slice some of the keys so that me test more code coverage (if not we only test keys with the same length)
+      val slicedKeys = keys.zipWithIndex.map { case (key, index) =>
+        val hashedKey = md5(key)
+        if (index % 2 == 0) hashedKey.take(hashedKey.length / 2) else hashedKey
+      }
+      val keyValuePairs = slicedKeys.zip(keys)
+
+      val trie = Random.shuffle(keyValuePairs).foldLeft(EmptyTrie) { case (recTrie, (key, value)) => recTrie.put(key, value) }
+      assert(Hex.toHexString(trie.getRootHash) == "46cde8656f3be6ce93ba9dcb1017548f44c65d1ea659ac827fac8c9ac77cf6b3")
+    }
   }
 
   test("EthereumJ compatibility - Insert of the first 20000 numbers hashed (with some sliced) and then remove half of them") {
-    val keys = (0 to 20000).map(intByteArraySerializable.toBytes)
+    withNodeStorage { ns =>
+      val EmptyTrie = MerklePatriciaTrie[Array[Byte], Array[Byte]](ns, hashFn)
+      val keys = (0 to 20000).map(intByteArraySerializable.toBytes)
 
-    // We slice some of the keys so that me test more code coverage (if not we only test keys with the same length)
-    val slicedKeys = keys.zipWithIndex.map { case (key, index) =>
-      val hashedKey = md5(key)
-      if (index % 2 == 0) hashedKey.take(hashedKey.length / 2) else hashedKey }
-    val keyValuePairs = slicedKeys.zip(keys)
+      // We slice some of the keys so that me test more code coverage (if not we only test keys with the same length)
+      val slicedKeys = keys.zipWithIndex.map { case (key, index) =>
+        val hashedKey = md5(key)
+        if (index % 2 == 0) hashedKey.take(hashedKey.length / 2) else hashedKey
+      }
+      val keyValuePairs = slicedKeys.zip(keys)
 
-    val trie = Random.shuffle(keyValuePairs).foldLeft(EmptyTrie) { case (recTrie, (key, value)) => recTrie.put(key, value) }
+      val trie = Random.shuffle(keyValuePairs).foldLeft(EmptyTrie) { case (recTrie, (key, value)) => recTrie.put(key, value) }
 
-    assert(Hex.toHexString(trie.getRootHash) == "46cde8656f3be6ce93ba9dcb1017548f44c65d1ea659ac827fac8c9ac77cf6b3")
+      assert(Hex.toHexString(trie.getRootHash) == "46cde8656f3be6ce93ba9dcb1017548f44c65d1ea659ac827fac8c9ac77cf6b3")
 
-    // We delete have of the (key-value) pairs we had inserted
-    val trieAfterDelete = Random.shuffle(keyValuePairs.take(20000 / 2)).foldLeft(trie) { case (recTrie, (key, _)) => recTrie.remove(key) }
+      // We delete have of the (key-value) pairs we had inserted
+      val trieAfterDelete = Random.shuffle(keyValuePairs.take(20000 / 2)).foldLeft(trie) { case (recTrie, (key, _)) => recTrie.remove(key) }
 
-    assert(Hex.toHexString(trieAfterDelete.getRootHash) == "ae7b65dddd3ac0428082160cf3ceff0276cf6e6deaa23b42c4c156b50a459822")
+      assert(Hex.toHexString(trieAfterDelete.getRootHash) == "ae7b65dddd3ac0428082160cf3ceff0276cf6e6deaa23b42c4c156b50a459822")
+    }
   }
 
   /* Performance test */
-  test("Performance test (From: https://github.com/ethereum/wiki/wiki/Benchmarks)"){
-    val Rounds = 1000
-    val Symmetric = true
+  test("Performance test (From: https://github.com/ethereum/wiki/wiki/Benchmarks)") {
+    withNodeStorage { ns =>
+      val EmptyTrie = MerklePatriciaTrie[Array[Byte], Array[Byte]](ns, hashFn)
+      val Rounds = 1000
+      val Symmetric = true
 
-    val start: Long = System.currentTimeMillis
-    val emptyTrie = MerklePatriciaTrie[Array[Byte], Array[Byte]](new NodeStorage(EphemDataSource()), hashFn)
-    var seed: Array[Byte] = Array.fill(32)(0.toByte)
+      val start: Long = System.currentTimeMillis
+      val emptyTrie = MerklePatriciaTrie[Array[Byte], Array[Byte]](new NodeStorage(EphemDataSource()), hashFn)
+      var seed: Array[Byte] = Array.fill(32)(0.toByte)
 
-    val trieResult = (0 until Rounds).foldLeft(emptyTrie){ case (recTrie, i) =>
-      seed = hashFn(seed)
-      if(!Symmetric) recTrie.put(seed, seed)
-      else{
-        val mykey = seed
+      val trieResult = (0 until Rounds).foldLeft(emptyTrie) { case (recTrie, i) =>
         seed = hashFn(seed)
-        val myval = if((seed(0) & 0xFF) % 2 == 1) Array[Byte](seed.last) else seed
-        recTrie.put(mykey, myval)
+        if (!Symmetric) recTrie.put(seed, seed)
+        else {
+          val mykey = seed
+          seed = hashFn(seed)
+          val myval = if ((seed(0) & 0xFF) % 2 == 1) Array[Byte](seed.last) else seed
+          recTrie.put(mykey, myval)
+        }
       }
+      val rootHash = Hex.toHexString(trieResult.getRootHash)
+
+      log.debug("Time taken(ms): " + (System.currentTimeMillis - start))
+      log.debug("Root hash obtained: " + rootHash)
+
+      if (Symmetric) assert(rootHash.take(4) == "36f6" && rootHash.drop(rootHash.length - 4) == "93a3")
+      else assert(rootHash.take(4) == "da8a" && rootHash.drop(rootHash.length - 4) == "0ca4")
     }
-    val rootHash = Hex.toHexString(trieResult.getRootHash)
+  }
+}
 
-    log.debug("Time taken(ms): " + (System.currentTimeMillis - start))
-    log.debug("Root hash obtained: " + rootHash)
+trait PersistentStorage {
+  def withNodeStorage(testCode: NodeStorage => Unit): Unit = {
+    val dbPath = Files.createTempDirectory("testdb").toAbsolutePath.toString
+    val dataSource = LevelDBDataSource(new LevelDbConfig {
+      override val cacheSize: Int = 0
+      override val verifyChecksums: Boolean = true
+      override val paranoidChecks: Boolean = true
+      override val createIfMissing: Boolean = true
+      override val path: String = dbPath
+    })
 
-    if(Symmetric) assert(rootHash.take(4) == "36f6" && rootHash.drop(rootHash.length-4) == "93a3")
-    else assert(rootHash.take(4) == "da8a" && rootHash.drop(rootHash.length-4) == "0ca4")
+    try {
+      testCode(new NodeStorage(dataSource))
+    } finally {
+      val dir = new File(dbPath)
+      !dir.exists() || dir.delete()
+    }
   }
 }

--- a/src/main/scala/io/iohk/ethereum/mpt/MerklePatriciaTrie.scala
+++ b/src/main/scala/io/iohk/ethereum/mpt/MerklePatriciaTrie.scala
@@ -16,11 +16,9 @@ object MerklePatriciaTrie {
   case class MPTException(message: String) extends RuntimeException(message)
 
   private case class NodeInsertResult(newNode: Node,
-    toDeleteFromStorage: Seq[Node] = Nil,
     toUpdateInStorage: Seq[Node] = Nil)
 
   private case class NodeRemoveResult(hasChanged: Boolean, newNode: Option[Node],
-    toDeleteFromStorage: Seq[Node] = Nil,
     toUpdateInStorage: Seq[Node] = Nil)
 
   type HashFn = Array[Byte] => Array[Byte]
@@ -53,19 +51,14 @@ object MerklePatriciaTrie {
   private def updateNodesInStorage(
     previousRootHash: Array[Byte],
     newRoot: Option[Node],
-    toRemove: Seq[Node],
     toUpdate: Seq[Node],
     nodeStorage: NodeStorage): NodeStorage = {
     val rootCapped = newRoot.map(_.capped).getOrElse(Array.emptyByteArray)
-    val toBeRemoved = toRemove.filter { node =>
-      val nCapped = node.capped
-      nCapped.length == 32 || (node.hash sameElements previousRootHash)
-    }.map(n => ByteString(n.hash))
     val toBeUpdated = toUpdate.filter { n =>
       val nCapped = n.capped
       nCapped.length == 32 || (nCapped sameElements rootCapped)
     }.map(node => ByteString(node.hash) -> node.encode)
-    nodeStorage.update(toBeRemoved, toBeUpdated)
+    nodeStorage.update(Nil, toBeUpdated)
   }
 
   private def getNextNode(extensionNode: ExtensionNode, nodeStorage: NodeStorage)(implicit nodeDec: RLPDecoder[Node]): Node =
@@ -171,12 +164,11 @@ class MerklePatriciaTrie[K, V](private val rootHash: Option[Array[Byte]],
     val keyNibbles = HexPrefix.bytesToNibbles(kSerializer.toBytes(key))
     rootHash map { rootId =>
       val root = getNode(rootId, nodeStorage)
-      val NodeInsertResult(newRoot, nodesToRemoveFromStorage, nodesToUpdateInStorage) = put(root, keyNibbles, vSerializer.toBytes(value))
+      val NodeInsertResult(newRoot, nodesToUpdateInStorage) = put(root, keyNibbles, vSerializer.toBytes(value))
       val newRootHash = newRoot.hash
       val newSource = updateNodesInStorage(
         previousRootHash = getRootHash,
         newRoot = Some(newRoot),
-        toRemove = nodesToRemoveFromStorage,
         toUpdate = nodesToUpdateInStorage,
         nodeStorage = nodeStorage)
       new MerklePatriciaTrie(Some(newRootHash), newSource, hashFn)(kSerializer, vSerializer)
@@ -184,7 +176,7 @@ class MerklePatriciaTrie[K, V](private val rootHash: Option[Array[Byte]],
       val newRoot = LeafNode(keyNibbles, vSerializer.toBytes(value), hashFn)
       val newRootHash = newRoot.hash
       new MerklePatriciaTrie(Some(newRootHash),
-        updateNodesInStorage(getRootHash, Some(newRoot), Nil, Seq(newRoot), nodeStorage),
+        updateNodesInStorage(getRootHash, Some(newRoot), Seq(newRoot), nodeStorage),
         hashFn)
     }
   }
@@ -201,24 +193,22 @@ class MerklePatriciaTrie[K, V](private val rootHash: Option[Array[Byte]],
       val keyNibbles = HexPrefix.bytesToNibbles(bytes = kSerializer.toBytes(key))
       val root = getNode(rootId, nodeStorage)
       remove(root, keyNibbles) match {
-        case NodeRemoveResult(true, Some(newRoot), nodesToRemoveFromStorage, nodesToUpdateInStorage) =>
+        case NodeRemoveResult(true, Some(newRoot), nodesToUpdateInStorage) =>
           val newRootHash = newRoot.hash
           val afterDeletenodeStorage = updateNodesInStorage(
             previousRootHash = getRootHash,
             newRoot = Some(newRoot),
-            toRemove = nodesToRemoveFromStorage,
             toUpdate = nodesToUpdateInStorage,
             nodeStorage = nodeStorage)
           new MerklePatriciaTrie(Some(newRootHash), afterDeletenodeStorage, hashFn)(kSerializer, vSerializer)
-        case NodeRemoveResult(true, None, nodesToRemoveFromStorage, nodesToUpdateInStorage) =>
+        case NodeRemoveResult(true, None, nodesToUpdateInStorage) =>
           val afterDeletenodeStorage = updateNodesInStorage(
             previousRootHash = getRootHash,
             newRoot = None,
-            toRemove = nodesToRemoveFromStorage,
             toUpdate = nodesToUpdateInStorage,
             nodeStorage = nodeStorage)
           new MerklePatriciaTrie(None, afterDeletenodeStorage, hashFn)(kSerializer, vSerializer)
-        case NodeRemoveResult(false, _, _, _) => this
+        case NodeRemoveResult(false, _, _) => this
       }
     } getOrElse {
       this
@@ -272,7 +262,6 @@ class MerklePatriciaTrie[K, V](private val rootHash: Option[Array[Byte]],
         val newLeafNode = LeafNode(existingKey, value, hashFn)
         NodeInsertResult(
           newNode = newLeafNode,
-          toDeleteFromStorage = Seq(node),
           toUpdateInStorage = Seq(newLeafNode)
         )
       case 0 =>
@@ -285,10 +274,9 @@ class MerklePatriciaTrie[K, V](private val rootHash: Option[Array[Byte]],
             val newLeafNode = LeafNode(existingKey.tail, storedValue, hashFn)
             BranchNode.withSingleChild(existingKey(0), newLeafNode, None, hashFn) -> Some(newLeafNode)
           }
-        val NodeInsertResult(newBranchNode: BranchNode, toDeleteFromStorage, toUpdateInStorage) = put(temporalBranchNode, searchKey, value)
+        val NodeInsertResult(newBranchNode: BranchNode, toUpdateInStorage) = put(temporalBranchNode, searchKey, value)
         NodeInsertResult(
           newNode = newBranchNode,
-          toDeleteFromStorage = node +: toDeleteFromStorage,
           toUpdateInStorage = maybeNewLeaf.toList ++ toUpdateInStorage
         )
       case ml =>
@@ -297,11 +285,10 @@ class MerklePatriciaTrie[K, V](private val rootHash: Option[Array[Byte]],
         val temporalNode =
           if (ml == existingKey.length) BranchNode.withValueOnly(storedValue, hashFn)
           else LeafNode(existingKey.drop(ml), storedValue, hashFn)
-        val NodeInsertResult(newBranchNode: BranchNode, toDeleteFromStorage, toUpdateInStorage) = put(temporalNode, searchKeySuffix, value)
+        val NodeInsertResult(newBranchNode: BranchNode, toUpdateInStorage) = put(temporalNode, searchKeySuffix, value)
         val newExtNode = ExtensionNode(searchKeyPrefix, newBranchNode, hashFn)
         NodeInsertResult(
           newNode = newExtNode,
-          toDeleteFromStorage = node +: toDeleteFromStorage,
           toUpdateInStorage = newExtNode +: toUpdateInStorage
         )
     }
@@ -322,31 +309,28 @@ class MerklePatriciaTrie[K, V](private val rootHash: Option[Array[Byte]],
             BranchNode.withSingleChild(sharedKeyHead, newExtNode, None, hashFn) -> Some(newExtNode)
           }
         }
-        val NodeInsertResult(newBranchNode: BranchNode, toDeleteFromStorage, toUpdateInStorage) = put(temporalBranchNode, searchKey, value)
+        val NodeInsertResult(newBranchNode: BranchNode, toUpdateInStorage) = put(temporalBranchNode, searchKey, value)
         NodeInsertResult(
           newNode = newBranchNode,
-          toDeleteFromStorage = extensionNode +: toDeleteFromStorage,
           toUpdateInStorage = maybeNewLeaf.toList ++ toUpdateInStorage
         )
       case ml if ml == sharedKey.length =>
         // Current extension node's key is a prefix of the one being inserted, so we insert recursively on the extension's child
-        val NodeInsertResult(newChild: BranchNode, toDeleteFromStorage, toUpdateInStorage) =
+        val NodeInsertResult(newChild: BranchNode, toUpdateInStorage) =
           put(getNextNode(extensionNode, nodeStorage), searchKey.drop(ml), value)
         val newExtNode = ExtensionNode(sharedKey, newChild, hashFn)
         NodeInsertResult(
           newNode = newExtNode,
-          toDeleteFromStorage = extensionNode +: toDeleteFromStorage,
           toUpdateInStorage = newExtNode +: toUpdateInStorage
         )
       case ml =>
         // Partially shared prefix, we have to replace the node with an extension with the shared prefix
         val (sharedKeyPrefix, sharedKeySuffix) = sharedKey.splitAt(ml)
         val temporalExtensionNode = ExtensionNode(sharedKeySuffix, next, hashFn)
-        val NodeInsertResult(newBranchNode: BranchNode, toDeleteFromStorage, toUpdateInStorage) = put(temporalExtensionNode, searchKey.drop(ml), value)
+        val NodeInsertResult(newBranchNode: BranchNode, toUpdateInStorage) = put(temporalExtensionNode, searchKey.drop(ml), value)
         val newExtNode = ExtensionNode(sharedKeyPrefix, newBranchNode, hashFn)
         NodeInsertResult(
           newNode = newExtNode,
-          toDeleteFromStorage = extensionNode +: toDeleteFromStorage,
           toUpdateInStorage = newExtNode +: toUpdateInStorage
         )
     }
@@ -359,7 +343,6 @@ class MerklePatriciaTrie[K, V](private val rootHash: Option[Array[Byte]],
       val newBranchNode = BranchNode(children, Some(value), hashFn)
       NodeInsertResult(
         newNode = newBranchNode,
-        toDeleteFromStorage = Seq(branchNode),
         toUpdateInStorage = Seq(newBranchNode)
       )
     }
@@ -369,12 +352,11 @@ class MerklePatriciaTrie[K, V](private val rootHash: Option[Array[Byte]],
       val searchKeyRemaining = searchKey.tail
       if (children(searchKeyHead).isDefined) {
         // The associated child is not empty, we recursively insert in that child
-        val NodeInsertResult(changedChild, toDeleteFromStorage, toUpdateInStorage) =
+        val NodeInsertResult(changedChild, toUpdateInStorage) =
           put(getChild(branchNode, searchKeyHead, nodeStorage).get, searchKeyRemaining, value)
         val newBranchNode = branchNode.updateChild(searchKeyHead, changedChild, hashFn)
         NodeInsertResult(
           newNode = newBranchNode,
-          toDeleteFromStorage = branchNode +: toDeleteFromStorage,
           toUpdateInStorage = newBranchNode +: toUpdateInStorage
         )
       }
@@ -384,7 +366,6 @@ class MerklePatriciaTrie[K, V](private val rootHash: Option[Array[Byte]],
         val newBranchNode = branchNode.updateChild(searchKeyHead, newLeafNode, hashFn)
         NodeInsertResult(
           newNode = newBranchNode,
-          toDeleteFromStorage = Seq(branchNode),
           toUpdateInStorage = Seq(newLeafNode, newBranchNode)
         )
       }
@@ -404,14 +385,14 @@ class MerklePatriciaTrie[K, V](private val rootHash: Option[Array[Byte]],
     case (BranchNode(children, _, _), true) =>
       // We need to remove old node and fix it because we removed the value
       val fixedNode = fix(BranchNode(children, None, hashFn), nodeStorage, Nil)
-      NodeRemoveResult(hasChanged = true, newNode = Some(fixedNode), toDeleteFromStorage = Seq(node), toUpdateInStorage = Seq(fixedNode))
+      NodeRemoveResult(hasChanged = true, newNode = Some(fixedNode), toUpdateInStorage = Seq(fixedNode))
     case (branchNode@BranchNode(children, optStoredValue, _), false) =>
       // We might be trying to remove a node that's inside one of the 16 mapped nibbles
       val searchKeyHead = searchKey(0)
       getChild(branchNode, searchKeyHead, nodeStorage) map { child =>
         // Child has been found so we try to remove it
         remove(child, searchKey.tail) match {
-          case NodeRemoveResult(true, maybeNewChild, nodesToRemoveFromStorage, nodesToUpdateInStorage) =>
+          case NodeRemoveResult(true, maybeNewChild, nodesToUpdateInStorage) =>
             // Something changed in a child so we need to fix
             val nodeToFix = maybeNewChild map { newChild =>
               branchNode.updateChild(searchKeyHead, newChild, hashFn)
@@ -422,14 +403,12 @@ class MerklePatriciaTrie[K, V](private val rootHash: Option[Array[Byte]],
             NodeRemoveResult(
               hasChanged = true,
               newNode = Some(fixedNode),
-              toDeleteFromStorage = node +: nodesToRemoveFromStorage,
               toUpdateInStorage = fixedNode +: nodesToUpdateInStorage)
           // No removal made on children, so we return without any change
-          case NodeRemoveResult(false, _, nodesToRemoveFromStorage, nodesToUpdateInStorage) =>
+          case NodeRemoveResult(false, _, nodesToUpdateInStorage) =>
             NodeRemoveResult(
               hasChanged = false,
               newNode = None,
-              toDeleteFromStorage = nodesToRemoveFromStorage,
               toUpdateInStorage = nodesToUpdateInStorage)
         }
       } getOrElse {
@@ -442,7 +421,7 @@ class MerklePatriciaTrie[K, V](private val rootHash: Option[Array[Byte]],
     val LeafNode(existingKey, _, _) = leafNode
     if (existingKey sameElements searchKey) {
       // We found the node to delete
-      NodeRemoveResult(hasChanged = true, newNode = None, toDeleteFromStorage = Seq(leafNode))
+      NodeRemoveResult(hasChanged = true, newNode = None)
     }
     else NodeRemoveResult(hasChanged = false, newNode = None)
   }
@@ -453,7 +432,7 @@ class MerklePatriciaTrie[K, V](private val rootHash: Option[Array[Byte]],
     if (cp == sharedKey.length) {
       // A child node of this extension is removed, so move forward
       remove(getNextNode(extensionNode, nodeStorage), searchKey.drop(cp)) match {
-        case NodeRemoveResult(true, maybeNewChild, nodesToRemoveFromStorage, nodesToUpdateInStorage) =>
+        case NodeRemoveResult(true, maybeNewChild, nodesToUpdateInStorage) =>
           // If we changed the child, we need to fix this extension node
           maybeNewChild map { newChild =>
             val toFix = ExtensionNode(sharedKey, newChild, hashFn)
@@ -461,16 +440,14 @@ class MerklePatriciaTrie[K, V](private val rootHash: Option[Array[Byte]],
             NodeRemoveResult(
               hasChanged = true,
               newNode = Some(fixedNode),
-              toDeleteFromStorage = extensionNode +: nodesToRemoveFromStorage,
               toUpdateInStorage = fixedNode +: nodesToUpdateInStorage)
           } getOrElse {
             throw MPTException("A trie with newRoot extension should have at least 2 values stored")
           }
-        case NodeRemoveResult(false, _, nodesToRemoveFromStorage, nodesToUpdateInStorage) =>
+        case NodeRemoveResult(false, _, nodesToUpdateInStorage) =>
           NodeRemoveResult(
             hasChanged = false,
             newNode = None,
-            toDeleteFromStorage = nodesToRemoveFromStorage,
             toUpdateInStorage = nodesToUpdateInStorage)
       }
     }

--- a/src/test/scala/io/iohk/ethereum/mpt/MerklePatriciaTrieSuite.scala
+++ b/src/test/scala/io/iohk/ethereum/mpt/MerklePatriciaTrieSuite.scala
@@ -427,4 +427,28 @@ class MerklePatriciaTrieSuite extends FunSuite
     assert(Hex.toHexString(storage.getRootHash) == "e6fbee0b67e3a6f0b9ea775ce585509aa4a0c3fe3f83d1e49a7d484489b755bc")
 
   }
+
+  /**
+    * The MPT tested in this example has duplicated nodes as the branch node has two children with the same node: LeafNode("a", value)
+    * When one of the key-value that uses one of this nodes is removed, this shouldn't affect the use of the other key-value
+    * which shares the same LeafNode
+    */
+  test("PatriciaTrie insert causes node duplicated and removal of one of them should not fail") {
+    val key1 = Hex.decode("ba")
+    val key2 = Hex.decode("aa")
+    val key3 = Hex.decode("")
+    val value = Hex.decode("012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789")
+    val trie = EmptyTrie.put(key1, value).put(key2, value).put(key3, value)
+    val trieAfterRemoval = trie.remove(key1)
+
+    //Old trie still works
+    assert(trie.get(key1).getOrElse(Array.emptyByteArray) sameElements value)
+    assert(trie.get(key2).getOrElse(Array.emptyByteArray) sameElements value)
+    assert(trie.get(key3).getOrElse(Array.emptyByteArray) sameElements value)
+
+    //New trie is consistent
+    assert(trieAfterRemoval.get(key1).isEmpty)
+    assert(trieAfterRemoval.get(key2).getOrElse(Array.emptyByteArray) sameElements value)
+    assert(trieAfterRemoval.get(key3).getOrElse(Array.emptyByteArray) sameElements value)
+  }
 }


### PR DESCRIPTION
## Description

This commit removes old mpt nodes deletion from underlying db. From now on, a pruning system needs to be performed in order to free space.

## Implementation note

Mpt now doesn't _know_ that some nodes are useless now. If we think our pruning implementation requires to record "deletes" - for example if it's made using reference counting method - this commit can be rolled back. 