### PR TITLE
Handle pre-Homestead contract creation when not enough gas

### DIFF
--- a/src/main/scala/io/iohk/ethereum/ledger/Ledger.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/Ledger.scala
@@ -317,13 +317,16 @@ class Ledger(vm: VM) extends Logger {
 
   private def saveNewContract(address: Address, result: PR, config: EvmConfig): PR = {
     val codeDepositCost = config.calcCodeDepositCost(result.returnData)
-    if (result.gasRemaining < codeDepositCost)
-      result.copy(error = Some(OutOfGas))
-    else
+    if (result.gasRemaining < codeDepositCost) {
+      if (config.exceptionalFailedCodeDeposit)
+        result.copy(error = Some(OutOfGas))
+      else
+        result
+    } else {
       result.copy(
         gasRemaining = result.gasRemaining - codeDepositCost,
-        world = result.world.saveCode(address, result.returnData)
-      )
+        world = result.world.saveCode(address, result.returnData))
+    }
   }
 
   /**

--- a/src/main/scala/io/iohk/ethereum/ledger/Ledger.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/Ledger.scala
@@ -110,7 +110,6 @@ class Ledger(vm: VM) extends Logger {
     val worldBeforeTransfer = updateSenderAccountBeforeExecution(stx, world)
     val result = runVM(stx, blockHeader, worldBeforeTransfer)
 
-    //FIXME: This only implements error handling as done in Homestead
     val resultWithErrorHandling: PR =
       if(result.error.isDefined) {
         //Rollback to the world before transfer was done if an error happened

--- a/src/main/scala/io/iohk/ethereum/vm/EvmConfig.scala
+++ b/src/main/scala/io/iohk/ethereum/vm/EvmConfig.scala
@@ -30,14 +30,6 @@ object EvmConfig {
     subGasCapDivisor = None,
     chargeSelfDestructForNewAccount = false)
 
-  /*
-    TODO (CREATE):
-    If contract creation does not have enough gas to pay for the final gas fee
-    for adding the contract code to the state, the contract creation fails (ie. goes out-of-gas)
-    rather than leaving an empty contract.
-
-    See: exceptional_failed_code_deposit in Parity
-   */
   val HomesteadConfig = EvmConfig(
     feeSchedule = new FeeSchedule.HomesteadFeeSchedule,
     opCodes = OpCodes.HomesteadOpCodes,
@@ -45,11 +37,6 @@ object EvmConfig {
     subGasCapDivisor = None,
     chargeSelfDestructForNewAccount = false)
 
-  /*
-  TODO(CREATE): sub_gas_cap_divisor
-    If Some(x): let limit = GAS * (x - 1) / x; let CALL's gas = min(requested, limit). let CREATE's gas = limit.
-    If None: let CALL's gas = (requested > GAS ? [OOG] : GAS). let CREATE's gas = GAS
-   */
   val PostEIP150Config = HomesteadConfig.copy(
     feeSchedule = new FeeSchedule.PostEIP150FeeSchedule,
     subGasCapDivisor = Some(64),

--- a/src/test/scala/io/iohk/ethereum/ledger/LedgerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/LedgerSpec.scala
@@ -6,13 +6,16 @@ import akka.util.ByteString.{empty => bEmpty}
 import io.iohk.ethereum.crypto._
 import io.iohk.ethereum.db.components.{SharedEphemDataSources, Storages}
 import io.iohk.ethereum.domain._
+import io.iohk.ethereum.rlp
+import io.iohk.ethereum.rlp.RLPList
 import io.iohk.ethereum.utils.Config
 import io.iohk.ethereum.ledger.Ledger.{PC, PR}
 import io.iohk.ethereum.vm.{Storage, WorldStateProxy, _}
 import org.scalatest.{FlatSpec, Matchers}
 import org.scalatest.prop.PropertyChecks
 import org.spongycastle.crypto.params.ECPublicKeyParameters
-
+import io.iohk.ethereum.rlp.RLPImplicitConversions._
+import io.iohk.ethereum.rlp.RLPImplicits._
 
 class LedgerSpec extends FlatSpec with PropertyChecks with Matchers {
 
@@ -21,8 +24,8 @@ class LedgerSpec extends FlatSpec with PropertyChecks with Matchers {
       runFn(context.asInstanceOf[PC]).asInstanceOf[ProgramResult[W, S]]
   }
 
-  def createResult(context: PC, gasUsed: UInt256, gasLimit: UInt256, gasRefund: UInt256, error: Option[ProgramError]): PR = ProgramResult(
-    returnData = bEmpty,
+  def createResult(context: PC, gasUsed: UInt256, gasLimit: UInt256, gasRefund: UInt256, error: Option[ProgramError], returnData: ByteString = bEmpty): PR = ProgramResult(
+    returnData = returnData,
     gasRemaining = gasLimit - gasUsed,
     world = context.world,
     Nil,
@@ -113,6 +116,60 @@ class LedgerSpec extends FlatSpec with PropertyChecks with Matchers {
     val postTxWorld = ledger.executeTransaction(stx, header, initialWorld).worldState
 
     postTxWorld.getGuaranteedAccount(originAddress).nonce shouldBe (initialOriginNonce + 1)
+  }
+
+  it should "allow to create an account and not run out of gas before Homestead" in new TestSetup {
+    val initialOriginBalance: UInt256 = 1000000
+
+    val initialOriginNonce = defaultTx.nonce
+
+    val initialWorld = emptyWorld
+      .saveAccount(originAddress, Account(nonce = UInt256(initialOriginNonce), balance = initialOriginBalance))
+
+    val tx = defaultTx.copy(gasPrice = defaultGasPrice, gasLimit = defaultGasLimit, receivingAddress = None, payload = ByteString.empty)
+    val stx = SignedTransaction.sign(tx, keyPair)
+
+    val header = defaultBlockHeader.copy(beneficiary = minerAddress.bytes, number = Config.Blockchain.homesteadBlockNumber - 1)
+
+    val ledger = new Ledger(new MockVM(createResult(_, defaultGasLimit, defaultGasLimit, 0, None, returnData = ByteString("contract code"))))
+
+    val txResult = ledger.executeTransaction(stx, header, initialWorld)
+    val postTxWorld = txResult.worldState
+
+    val newContractAddress = {
+      val hash = kec256(rlp.encode(RLPList(originAddress.bytes, initialOriginNonce)))
+      Address(hash)
+    }
+
+    postTxWorld.accountExists(newContractAddress) shouldBe true
+    postTxWorld.getCode(newContractAddress) shouldBe ByteString()
+  }
+
+  it should "run out of gas in contract creation after Homestead" in new TestSetup {
+    val initialOriginBalance: UInt256 = 1000000
+
+    val initialOriginNonce = defaultTx.nonce
+
+    val initialWorld = emptyWorld
+      .saveAccount(originAddress, Account(nonce = UInt256(initialOriginNonce), balance = initialOriginBalance))
+
+    val tx = defaultTx.copy(gasPrice = defaultGasPrice, gasLimit = defaultGasLimit, receivingAddress = None, payload = ByteString.empty)
+    val stx = SignedTransaction.sign(tx, keyPair)
+
+    val header = defaultBlockHeader.copy(beneficiary = minerAddress.bytes, number = Config.Blockchain.homesteadBlockNumber + 1)
+
+    val ledger = new Ledger(new MockVM(createResult(_, defaultGasLimit, defaultGasLimit, 0, None, returnData = ByteString("contract code"))))
+
+    val txResult = ledger.executeTransaction(stx, header, initialWorld)
+    val postTxWorld = txResult.worldState
+
+    val newContractAddress = {
+      val hash = kec256(rlp.encode(RLPList(originAddress.bytes, initialOriginNonce)))
+      Address(hash)
+    }
+
+    postTxWorld.accountExists(newContractAddress) shouldBe false
+    postTxWorld.getCode(newContractAddress) shouldBe ByteString()
   }
 
   trait TestSetup {


### PR DESCRIPTION
We need this logic in two places: CREATE op code (already there) and Ledger (this PR).