### PR TITLE
Store zero contract storage error

### DIFF
--- a/src/main/scala/io/iohk/ethereum/ledger/InMemoryWorldStateProxy.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/InMemoryWorldStateProxy.scala
@@ -121,7 +121,12 @@ object InMemoryWorldStateProxy {
 class InMemoryWorldStateProxyStorage(val wrapped: InMemorySimpleMapProxy[UInt256, UInt256, MerklePatriciaTrie[UInt256, UInt256]])
   extends Storage[InMemoryWorldStateProxyStorage] {
 
-  override def store(addr: UInt256, value: UInt256): InMemoryWorldStateProxyStorage = new InMemoryWorldStateProxyStorage(wrapped.put(addr, value))
+  override def store(addr: UInt256, value: UInt256): InMemoryWorldStateProxyStorage = {
+    val newWrapped =
+      if(value.isZero) wrapped - addr
+      else wrapped + (addr -> value)
+    new InMemoryWorldStateProxyStorage(newWrapped)
+  }
 
   override def load(addr: UInt256): UInt256 = wrapped.get(addr).getOrElse(UInt256.Zero)
 }


### PR DESCRIPTION
## Description

At block #49157 a SSTORE operation to `address 1` with a `UInt256.Zero` value was being called. When doing so, instead of removing data from `address 1` we were storing the `UInt256.Zero`

- [Tx Link](https://live.ether.camp/transaction/e9b2d3e8a2bc996a1c7742de825fdae2466ae783ce53484304efffe304ff232d)
- [Code being executed](https://live.ether.camp/transaction/e9b2d3e8a2bc996a1c7742de825fdae2466ae783ce53484304efffe304ff232d/vmtrace#41)

## Fix

Always, when storing `UInt256.Zero` in contract storage, we should remove that _row_ from the underlying trie.

This leads to execution up to block #49439