### PR TITLE
increase test timeout

### DIFF
--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/SyncControllerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/SyncControllerSpec.scala
@@ -391,7 +391,8 @@ class SyncControllerSpec extends FlatSpec with Matchers {
     peer1.expectMsg(PeerActor.Subscribe(Set(BlockBodies.code)))
     peer1.reply(PeerActor.MessageReceived(BlockBodies(Seq(BlockBody(Nil, Nil), BlockBody(Nil, Nil)))))
 
-    peer1.expectMsgAllOf(10.seconds,
+    //TODO: investigate why such a long timeout is required
+    peer1.expectMsgAllOf(15.seconds,
       PeerActor.SendMessage(GetBlockHeaders(Left(expectedMaxBlock + 3), Config.FastSync.blockHeadersPerRequest, 0, reverse = false)),
       PeerActor.Subscribe(Set(BlockHeaders.code)),
       PeerActor.BroadcastBlocks(Seq(
@@ -455,7 +456,8 @@ class SyncControllerSpec extends FlatSpec with Matchers {
     peer1.expectMsg(PeerActor.Subscribe(Set(BlockBodies.code)))
     peer1.reply(PeerActor.MessageReceived(BlockBodies(Seq(BlockBody(Nil, Nil), BlockBody(Nil, Nil)))))
 
-    peer2.expectMsgAllOf(10.seconds,
+    //TODO: investigate why such a long timeout is required
+    peer2.expectMsgAllOf(15.seconds,
       PeerActor.SendMessage(GetBlockHeaders(Left(expectedMaxBlock + 2), Config.FastSync.blockHeadersPerRequest, 0, reverse = false)),
       PeerActor.Subscribe(Set(BlockHeaders.code)),
       PeerActor.BroadcastBlocks(Seq(NewBlock(Block(newBlockHeader, BlockBody(Nil, Nil)), maxBlocTotalDifficulty + newBlockDifficulty)))


### PR DESCRIPTION
The failing test was:

```
[info] - should only broadcast blocks that it was able to successfully execute *** FAILED *** (104 milliseconds)
[info]   java.lang.AssertionError: assertion failed: not found [Subscribe(Set(20))]
[info]   at scala.Predef$.assert(Predef.scala:219)
[info]   at akka.testkit.TestKitBase.checkMissingAndUnexpected(TestKit.scala:543)
[info]   at akka.testkit.TestKitBase.expectMsgAllOf_internal(TestKit.scala:551)
[info]   at akka.testkit.TestKitBase.expectMsgAllOf(TestKit.scala:537)
[info]   at akka.testkit.TestKitBase.expectMsgAllOf$(TestKit.scala:537)
[info]   at akka.testkit.TestKit.expectMsgAllOf(TestKit.scala:814)
[info]   at io.iohk.ethereum.blockchain.sync.SyncControllerSpec$$anon$8.<init>(SyncControllerSpec.scala:461)
[info]   at io.iohk.ethereum.blockchain.sync.SyncControllerSpec.$anonfun$new$8(SyncControllerSpec.scala:406)
[info]   at org.scalatest.OutcomeOf.outcomeOf(OutcomeOf.scala:85)
[info]   at org.scalatest.OutcomeOf.outcomeOf$(OutcomeOf.scala:83)
```

Apparently, increasing these timeouts helps. At some point, we should investigate why that is.
