### PR TITLE
Logs should be cleared after an error is returned when executing a TX

### DIFF
--- a/src/main/scala/io/iohk/ethereum/ledger/Ledger.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/Ledger.scala
@@ -124,7 +124,7 @@ class LedgerImpl(vm: VM, blockchainConfig: BlockchainConfig) extends Ledger with
     val resultWithErrorHandling: PR =
       if(result.error.isDefined) {
         //Rollback to the world before transfer was done if an error happened
-        result.copy(world = checkpointWorldState, addressesToDelete = Nil)
+        result.copy(world = checkpointWorldState, addressesToDelete = Nil, logs = Nil)
       } else
         result
 


### PR DESCRIPTION
## Description

At block #53145 an `InvalidJump` error is returned and the Receipts validation is failing.

## Fix

When an error is returned logs should be cleared as it's done [here](https://github.com/paritytech/parity/blob/master/ethcore/src/executive.rs#L497), making the receipts match the ones in the blockHeader

This leads to execution up to block #62102

_Note: This PR needs this one https://github.com/input-output-hk/etc-client/pull/147 to be merged first_

