### PR TITLE
Logs improved in order to help when debugging errored tx executions

### DIFF
--- a/src/main/scala/io/iohk/ethereum/domain/Receipt.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/Receipt.scala
@@ -16,10 +16,10 @@ case class Receipt(
   override def toString: String = {
     s"""
        |Receipt{
-       |postTransactionStateHash: ${Hex.toHexString(postTransactionStateHash.toArray[Byte])}
-       |cumulativeGasUsed: $cumulativeGasUsed
-       |logsBloomFilter: ${Hex.toHexString(logsBloomFilter.toArray[Byte])}
-       |logs: $logs
+       | postTransactionStateHash: ${Hex.toHexString(postTransactionStateHash.toArray[Byte])}
+       | cumulativeGasUsed: $cumulativeGasUsed
+       | logsBloomFilter: ${Hex.toHexString(logsBloomFilter.toArray[Byte])}
+       | logs: $logs
        |}
        """.stripMargin
   }

--- a/src/main/scala/io/iohk/ethereum/domain/SignedTransaction.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/SignedTransaction.scala
@@ -4,14 +4,14 @@ import java.math.BigInteger
 
 import akka.util.ByteString
 import io.iohk.ethereum.crypto
-import io.iohk.ethereum.crypto.ECDSASignature
+import io.iohk.ethereum.crypto.{ECDSASignature, kec256}
 import io.iohk.ethereum.rlp.RLPImplicitConversions._
 import io.iohk.ethereum.rlp.RLPImplicits._
 import io.iohk.ethereum.rlp.{encode => rlpEncode, _}
 import org.spongycastle.crypto.AsymmetricCipherKeyPair
 import org.spongycastle.crypto.params.ECPublicKeyParameters
 import org.spongycastle.util.encoders.Hex
-
+import io.iohk.ethereum.network.p2p.messages.CommonMessages.SignedTransactions._
 
 object SignedTransaction {
 
@@ -134,4 +134,7 @@ case class SignedTransaction (
          |sender: ${Hex.toHexString(senderAddress.bytes.toArray)}
          |}""".stripMargin
   }
+
+  lazy val hash: ByteString = ByteString(kec256(rlpEncode[SignedTransaction](this)))
+  lazy val hashAsHexString: String = Hex.toHexString(hash.toArray[Byte])
 }

--- a/src/main/scala/io/iohk/ethereum/ledger/Ledger.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/Ledger.scala
@@ -107,12 +107,15 @@ class LedgerImpl(vm: VM, blockchainConfig: BlockchainConfig) extends Ledger with
               logs = logs
             )
 
+            log.debug(s"Receipt generated for tx ${stx.hashAsHexString}, $receipt")
+
             executeTransactions(otherStxs, newWorld, blockHeader, config, signedTransactionValidator, receipt.cumulativeGasUsed, acumReceipts :+ receipt)
           case Left(error) => Left(TxsExecutionError(error))
         }
     }
 
   private[ledger] def executeTransaction(stx: SignedTransaction, blockHeader: BlockHeader, world: InMemoryWorldStateProxy): TxResult = {
+    log.debug(s"Transaction ${stx.hashAsHexString} execution start")
     val gasPrice = UInt256(stx.tx.gasPrice)
     val gasLimit = UInt256(stx.tx.gasLimit)
     val config = EvmConfig.forBlock(blockHeader.number, blockchainConfig)
@@ -129,13 +132,20 @@ class LedgerImpl(vm: VM, blockchainConfig: BlockchainConfig) extends Ledger with
         result
 
     val totalGasToRefund = calcTotalGasToRefund(stx, resultWithErrorHandling)
+    val executionGasToPayToMiner = gasLimit - totalGasToRefund
 
     val refundGasFn = pay(stx.senderAddress, totalGasToRefund * gasPrice) _
-    val payMinerForGasFn = pay(Address(blockHeader.beneficiary), (gasLimit - totalGasToRefund) * gasPrice) _
+    val payMinerForGasFn = pay(Address(blockHeader.beneficiary), executionGasToPayToMiner * gasPrice) _
     val deleteAccountsFn = deleteAccounts(resultWithErrorHandling.addressesToDelete) _
     val persistStateFn = InMemoryWorldStateProxy.persistState _
 
     val world2 = (refundGasFn andThen payMinerForGasFn andThen deleteAccountsFn andThen persistStateFn)(resultWithErrorHandling.world)
+
+    log.debug(
+      s"""Transaction ${stx.hashAsHexString} execution end. Summary:
+         | - Error: ${result.error}.
+         | - Total Gas to Refund: $totalGasToRefund
+         | - Execution gas paid to miner: $executionGasToPayToMiner""".stripMargin)
 
     TxResult(world2, gasLimit - totalGasToRefund, resultWithErrorHandling.logs)
   }

--- a/src/main/scala/io/iohk/ethereum/rpc/BlockController.scala
+++ b/src/main/scala/io/iohk/ethereum/rpc/BlockController.scala
@@ -74,7 +74,7 @@ object BlockController {
       ommersHash = ommersHash,
       stateRoot = stateRoot,
       unixTimestamp = unixTimestamp,
-      transactions = transactionList.map(tx => ByteString(kec256(encode[SignedTransaction](tx)))),
+      transactions = transactionList.map(_.hash),
       transactionsRoot = transactionsRoot,
       uncles = uncleNodesList.map(h => h.hash),
       size = Block.size(block)

--- a/src/main/scala/io/iohk/ethereum/vm/VM.scala
+++ b/src/main/scala/io/iohk/ethereum/vm/VM.scala
@@ -1,11 +1,13 @@
 package io.iohk.ethereum.vm
 
+import io.iohk.ethereum.utils.Logger
+
 import scala.annotation.tailrec
 
 /**
   * Entry point to executing a program.
   */
-class VM {
+class VM extends Logger {
 
   /**
     * Executes a program
@@ -32,6 +34,8 @@ class VM {
     state.config.byteToOpCode.get(byte) match {
       case Some(opCode) =>
         val newState = opCode.execute(state)
+        import newState._
+        log.trace(s"$opCode | pc: $pc | depth: ${env.callDepth} | stack: ${stack}")
         if (newState.halted)
           newState
         else


### PR DESCRIPTION
## Description

This PR has some logging statements that will help while debugging the app. 

### Sample output

```
12:57:46.880 io.iohk.ethereum.ledger.LedgerImpl - Transaction e310dde4735aa6ab90d69910aacdce77ad399db3f94a5b4bba93fa01df353a08 execution start
12:57:46.881 io.iohk.ethereum.vm.VM$ - CALLDATASIZE | pc: 1 | depth: 0 | stack: Stack(0)
12:57:46.881 io.iohk.ethereum.vm.VM$ - PUSH1 | pc: 3 | depth: 0 | stack: Stack(0,0)
12:57:46.881 io.iohk.ethereum.vm.VM$ - DUP1 | pc: 4 | depth: 0 | stack: Stack(0,0,0)
12:57:46.881 io.iohk.ethereum.vm.VM$ - CALLDATACOPY | pc: 5 | depth: 0 | stack: Stack()
12:57:46.881 io.iohk.ethereum.vm.VM$ - PUSH1 | pc: 7 | depth: 0 | stack: Stack(32)
12:57:46.881 io.iohk.ethereum.vm.VM$ - PUSH1 | pc: 9 | depth: 0 | stack: Stack(0,32)
12:57:46.881 io.iohk.ethereum.vm.VM$ - CALLDATASIZE | pc: 10 | depth: 0 | stack: Stack(0,0,32)
12:57:46.881 io.iohk.ethereum.vm.VM$ - PUSH1 | pc: 12 | depth: 0 | stack: Stack(0,0,0,32)
12:57:46.882 io.iohk.ethereum.vm.VM$ - CALLVALUE | pc: 13 | depth: 0 | stack: Stack(4000000000000000000,0,0,0,32)
12:57:46.882 io.iohk.ethereum.vm.VM$ - PUSH20 | pc: 34 | depth: 0 | stack: Stack(1223700839609117144123285671976769777565056674185,4000000000000000000,0,0,0,32)
12:57:46.882 io.iohk.ethereum.vm.VM$ - PUSH2 | pc: 37 | depth: 0 | stack: Stack(9050,1223700839609117144123285671976769777565056674185,4000000000000000000,0,0,0,32)
12:57:46.882 io.iohk.ethereum.vm.VM$ - GAS | pc: 38 | depth: 0 | stack: Stack(106752,9050,1223700839609117144123285671976769777565056674185,4000000000000000000,0,0,0,32)
12:57:46.882 io.iohk.ethereum.vm.VM$ - SUB | pc: 39 | depth: 0 | stack: Stack(97702,1223700839609117144123285671976769777565056674185,4000000000000000000,0,0,0,32)
12:57:46.883 io.iohk.ethereum.vm.VM$ - STOP | pc: 0 | depth: 1 | stack: Stack()
12:57:46.883 io.iohk.ethereum.vm.VM$ - CALLCODE | pc: 40 | depth: 0 | stack: Stack(1)
12:57:46.883 io.iohk.ethereum.vm.VM$ - PUSH1 | pc: 42 | depth: 0 | stack: Stack(32,1)
12:57:46.883 io.iohk.ethereum.vm.VM$ - PUSH1 | pc: 44 | depth: 0 | stack: Stack(0,32,1)
12:57:46.883 io.iohk.ethereum.vm.VM$ - RETURN | pc: 44 | depth: 0 | stack: Stack(1)
12:57:46.887 io.iohk.ethereum.ledger.LedgerImpl - Transaction e310dde4735aa6ab90d69910aacdce77ad399db3f94a5b4bba93fa01df353a08 execution end. Summary:
 - Error: None.
 - Total Gas to Refund: 99997
 - Execution gas paid to miner: 27787
12:57:46.887 io.iohk.ethereum.ledger.LedgerImpl - Receipt generated for tx e310dde4735aa6ab90d69910aacdce77ad399db3f94a5b4bba93fa01df353a08, 
Receipt{
 postTransactionStateHash: b3890eb01d11af24b96534b1da50a4e7e5490d519b4d79f76d653be0a3ea6aa9
 cumulativeGasUsed: 579105
 logsBloomFilter: 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
 logs: Vector()
}
```