### PR TITLE
Fix evm inputData when executing contract init transaction

### DIFF
--- a/src/main/scala/io/iohk/ethereum/vm/ProgramContext.scala
+++ b/src/main/scala/io/iohk/ethereum/vm/ProgramContext.scala
@@ -16,13 +16,13 @@ object ProgramContext {
     import stx.tx
 
     // YP eq (91)
-    val programInput =
+    val inputData =
       if(tx.isContractInit) ByteString.empty
       else tx.payload
 
     val senderAddress = stx.senderAddress
 
-    val env = ExecEnv(recipientAddress, senderAddress, senderAddress, UInt256(tx.gasPrice), programInput,
+    val env = ExecEnv(recipientAddress, senderAddress, senderAddress, UInt256(tx.gasPrice), inputData,
       UInt256(tx.value), program, blockHeader, callDepth = 0)
 
     val gasLimit = tx.gasLimit - config.calcTransactionIntrinsicGas(tx.payload, tx.isContractInit)

--- a/src/main/scala/io/iohk/ethereum/vm/ProgramContext.scala
+++ b/src/main/scala/io/iohk/ethereum/vm/ProgramContext.scala
@@ -1,5 +1,6 @@
 package io.iohk.ethereum.vm
 
+import akka.util.ByteString
 import io.iohk.ethereum.domain._
 
 
@@ -14,9 +15,14 @@ object ProgramContext {
 
     import stx.tx
 
+    // YP eq (91)
+    val programInput =
+      if(tx.isContractInit) ByteString.empty
+      else tx.payload
+
     val senderAddress = stx.senderAddress
 
-    val env = ExecEnv(recipientAddress, senderAddress, senderAddress, UInt256(tx.gasPrice), tx.payload,
+    val env = ExecEnv(recipientAddress, senderAddress, senderAddress, UInt256(tx.gasPrice), programInput,
       UInt256(tx.value), program, blockHeader, callDepth = 0)
 
     val gasLimit = tx.gasLimit - config.calcTransactionIntrinsicGas(tx.payload, tx.isContractInit)

--- a/src/test/scala/io/iohk/ethereum/ledger/LedgerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/LedgerSpec.scala
@@ -11,7 +11,7 @@ import io.iohk.ethereum.rlp
 import io.iohk.ethereum.rlp.RLPList
 import io.iohk.ethereum.utils.{BlockchainConfig, Config}
 import io.iohk.ethereum.ledger.Ledger.{PC, PR}
-import io.iohk.ethereum.vm._
+import io.iohk.ethereum.vm.{UInt256, _}
 import org.scalatest.{FlatSpec, Matchers}
 import org.scalatest.prop.PropertyChecks
 import org.spongycastle.crypto.params.ECPublicKeyParameters
@@ -211,6 +211,34 @@ class LedgerSpec extends FlatSpec with PropertyChecks with Matchers {
       val txResult = ledger.executeTransaction(stx, defaultBlockHeader, initialWorld)
 
       txResult.logs.size shouldBe logsSize
+    }
+  }
+
+  it should "correctly send the transaction input data whether it's a contract creation or not" in new TestSetup {
+
+    val txPayload = ByteString("the payload")
+
+    val table = Table[Option[Address], ByteString](
+      ("Receiving Address", "Input Data"),
+      (defaultTx.receivingAddress, txPayload),
+      (None, ByteString.empty)
+    )
+
+    forAll(table) { (maybeReceivingAddress, inputData) =>
+
+      val initialWorld = emptyWorld
+        .saveAccount(originAddress, Account(nonce = UInt256(defaultTx.nonce), balance = UInt256.MaxValue))
+
+      val mockVM = new MockVM((pc: Ledger.PC) => {
+        pc.env.inputData shouldEqual inputData
+        createResult(pc, defaultGasLimit, defaultGasLimit, 0, None, returnData = ByteString("contract code"))
+      })
+      val ledger = new LedgerImpl(mockVM, blockchainConfig)
+
+      val tx = defaultTx.copy(receivingAddress = maybeReceivingAddress, payload = txPayload)
+      val stx = SignedTransaction.sign(tx, keyPair, blockchainConfig.chainId)
+
+      ledger.executeTransaction(stx, defaultBlockHeader, initialWorld)
     }
   }
 


### PR DESCRIPTION
## Description

At block #153259 a contract init is being called and the resulting gas does not match.

## Fix

When it's a contract init transaction, payload shouldn't be used as ExecEnv inputData. YP eq 91

This leads to block #179332