### PR TITLE
Fix for contract init that might be using an account that already exists

### DIFF
--- a/src/main/scala/io/iohk/ethereum/ledger/Ledger.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/Ledger.scala
@@ -320,12 +320,8 @@ class LedgerImpl(vm: VM, blockchainConfig: BlockchainConfig) extends Ledger with
     stx.tx.receivingAddress match {
       case None =>
         val address = worldStateProxy.createAddress(stx.senderAddress)
-        val world1 =
-          // YP eq (86) implies that the address might have already received funds before contract init. We need to check that.
-          if(worldStateProxy.getAccount(address).isDefined) worldStateProxy
-          else worldStateProxy.newEmptyAccount(address)
-        val world2 = world1.transfer(stx.senderAddress, address, UInt256(stx.tx.value))
-        ProgramContext(stx, address,  Program(stx.tx.payload), blockHeader, world2, config)
+        val world1 = worldStateProxy.transfer(stx.senderAddress, address, UInt256(stx.tx.value))
+        ProgramContext(stx, address,  Program(stx.tx.payload), blockHeader, world1, config)
 
       case Some(txReceivingAddress) =>
         val world1 = worldStateProxy.transfer(stx.senderAddress, txReceivingAddress, UInt256(stx.tx.value))

--- a/src/main/scala/io/iohk/ethereum/ledger/Ledger.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/Ledger.scala
@@ -320,7 +320,10 @@ class LedgerImpl(vm: VM, blockchainConfig: BlockchainConfig) extends Ledger with
     stx.tx.receivingAddress match {
       case None =>
         val address = worldStateProxy.createAddress(stx.senderAddress)
-        val world1 = worldStateProxy.newEmptyAccount(address)
+        val world1 =
+          // YP eq (86) implies that the address might have already received funds before contract init. We need to check that.
+          if(worldStateProxy.getAccount(address).isDefined) worldStateProxy
+          else worldStateProxy.newEmptyAccount(address)
         val world2 = world1.transfer(stx.senderAddress, address, UInt256(stx.tx.value))
         ProgramContext(stx, address,  Program(stx.tx.payload), blockHeader, world2, config)
 

--- a/src/test/scala/io/iohk/ethereum/ledger/LedgerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/LedgerSpec.scala
@@ -242,6 +242,43 @@ class LedgerSpec extends FlatSpec with PropertyChecks with Matchers {
     }
   }
 
+  it should "should handle pre-existing and new destination accounts when processing a contract init transaction" in new TestSetup {
+
+    val originAccount = Account(nonce = UInt256(0), balance = UInt256.MaxValue)
+    val worldWithoutPreexistingAccount = emptyWorld.saveAccount(originAddress, originAccount)
+
+    // In order to get contract address we need to increase the nonce as ledger will do within the first
+    // steps of execution
+    val contractAddress = worldWithoutPreexistingAccount
+      .saveAccount(originAddress, originAccount.increaseNonce)
+      .createAddress(originAddress)
+
+    val preExistingAccount = Account(nonce = UInt256(defaultTx.nonce), balance = 1000)
+    val worldWithPreexistingAccount = worldWithoutPreexistingAccount
+      .saveAccount(contractAddress, preExistingAccount)
+
+    val tx = defaultTx.copy(receivingAddress = None, value = 23)
+    val stx = SignedTransaction.sign(tx, keyPair, blockchainConfig.chainId)
+
+
+    val table = Table[InMemoryWorldStateProxy, BigInt](
+      ("Initial World", "Contract Account Balance"),
+      (worldWithoutPreexistingAccount, tx.value),
+      (worldWithPreexistingAccount, preExistingAccount.balance + tx.value)
+    )
+
+    forAll(table) { (initialWorld, contractAccountBalance) =>
+      val mockVM = new MockVM((pc: Ledger.PC) => {
+        pc.world.getGuaranteedAccount(contractAddress).balance shouldEqual contractAccountBalance
+        createResult(pc, defaultGasLimit, defaultGasLimit, 0, None, returnData = ByteString("contract code"))
+      })
+      val ledger = new LedgerImpl(mockVM, blockchainConfig)
+
+      ledger.executeTransaction(stx, defaultBlockHeader, initialWorld)
+    }
+  }
+
+
   trait TestSetup {
     val keyPair = generateKeyPair()
     val originAddress = Address(kec256(keyPair.getPublic.asInstanceOf[ECPublicKeyParameters].getQ.getEncoded(false)))


### PR DESCRIPTION
## Description

At Block #243826 When executing a contract init, tx fails because the account already exists

## Fix

As stated in YP EIP-150 REVISION eq 86 the destination address might have already received funds .

This leads up to #244793 execution.