### PR TITLE
[EC-168] Isolate failing edge case found in property test for evm op code RETURN

### DIFF
--- a/src/main/scala/io/iohk/ethereum/vm/Memory.scala
+++ b/src/main/scala/io/iohk/ethereum/vm/Memory.scala
@@ -1,6 +1,7 @@
 package io.iohk.ethereum.vm
 
 import akka.util.ByteString
+import org.spongycastle.util.encoders.Hex
 
 object Memory {
 
@@ -84,6 +85,6 @@ class Memory private(private val underlying: ByteString) {
 
   override def hashCode: Int = underlying.hashCode()
 
-  override def toString: String = underlying.toString.replace("ByteString", this.getClass.getSimpleName)
+  override def toString: String = s"${this.getClass.getSimpleName}(${Hex.toHexString(underlying.toArray[Byte])})"
 
 }

--- a/src/test/scala/io/iohk/ethereum/vm/OpCodeFunSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/vm/OpCodeFunSpec.scala
@@ -622,9 +622,24 @@ class OpCodeFunSpec extends FunSuite with OpCodeTesting with Matchers with Prope
       val stateOut = executeOp(op, stateIn)
 
       withStackVerification(op, stateIn, stateOut) {
+        val (Seq(offset), _) = stateIn.stack.pop(1)
+        val (data, mem1) = stateIn.memory.load(offset, 0)
+
+        mem1.size should be >= stateIn.memory.size
+
+        val expectedState = stateIn.withStack(stateOut.stack).withMemory(mem1).withReturnData(data).halt
+        stateOut shouldEqual expectedState
+      }
+
+      withStackVerification(op, stateIn, stateOut) {
         val (Seq(offset, size), _) = stateIn.stack.pop(2)
         val (data, mem1) = stateIn.memory.load(offset, size)
-        mem1.size should be >= (offset + size).toInt
+
+        if(size == UInt256.Zero){
+          mem1.size should be >= stateIn.memory.size
+        }else{
+          mem1.size should be >= (offset + size).toInt
+        }
 
         val expectedState = stateIn.withStack(stateOut.stack).withMemory(mem1).withReturnData(data).halt
         stateOut shouldEqual expectedState

--- a/src/test/scala/io/iohk/ethereum/vm/OpCodeFunSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/vm/OpCodeFunSpec.scala
@@ -622,16 +622,6 @@ class OpCodeFunSpec extends FunSuite with OpCodeTesting with Matchers with Prope
       val stateOut = executeOp(op, stateIn)
 
       withStackVerification(op, stateIn, stateOut) {
-        val (Seq(offset), _) = stateIn.stack.pop(1)
-        val (data, mem1) = stateIn.memory.load(offset, 0)
-
-        mem1.size should be >= stateIn.memory.size
-
-        val expectedState = stateIn.withStack(stateOut.stack).withMemory(mem1).withReturnData(data).halt
-        stateOut shouldEqual expectedState
-      }
-
-      withStackVerification(op, stateIn, stateOut) {
         val (Seq(offset, size), _) = stateIn.stack.pop(2)
         val (data, mem1) = stateIn.memory.load(offset, size)
 

--- a/src/test/scala/io/iohk/ethereum/vm/OpCodeFunSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/vm/OpCodeFunSpec.scala
@@ -625,9 +625,9 @@ class OpCodeFunSpec extends FunSuite with OpCodeTesting with Matchers with Prope
         val (Seq(offset, size), _) = stateIn.stack.pop(2)
         val (data, mem1) = stateIn.memory.load(offset, size)
 
-        if(size == UInt256.Zero){
-          mem1.size should be >= stateIn.memory.size
-        }else{
+        if (size.isZero) {
+          mem1.size shouldBe stateIn.memory.size
+        } else {
           mem1.size should be >= (offset + size).toInt
         }
 


### PR DESCRIPTION
This PR changes property test to correctly check memory size.
Corner case related to EC-168 is tested in https://github.com/input-output-hk/etc-client/blob/phase/3/txExecution/src/test/scala/io/iohk/ethereum/vm/MemorySpec.scala#L161