### PR TITLE
Fast sync download fix on restart	

### DIFF
--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/FastSync.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/FastSync.scala
@@ -162,10 +162,10 @@ trait FastSync {
       scheduler.schedule(persistStateSnapshotInterval, persistStateSnapshotInterval) {
         syncStateStorageActor ! SyncState(
           initialSyncState.targetBlock,
-          mptNodesQueue ++ requestedMptNodes.values.flatten.toSeq.distinct,
-          nonMptNodesQueue ++ requestedNonMptNodes.values.flatten.toSeq.distinct,
-          blockBodiesQueue ++ requestedBlockBodies.values.flatten.toSeq.distinct,
-          receiptsQueue ++ requestedReceipts.values.flatten.toSeq.distinct,
+          requestedMptNodes.values.flatten.toSeq.distinct ++ mptNodesQueue,
+          requestedNonMptNodes.values.flatten.toSeq.distinct ++ nonMptNodesQueue,
+          requestedBlockBodies.values.flatten.toSeq.distinct ++ blockBodiesQueue,
+          requestedReceipts.values.flatten.toSeq.distinct ++ receiptsQueue,
           downloadedNodesCount,
           bestBlockHeaderNumber)
       }


### PR DESCRIPTION
This fixes the issue when, after restarting during fast sync, some mpt nodes were "lost". Solution: we need to also save requested items in sync state (the ones that are not yet in db, but not in queues anymore).