### PR TITLE
RPC JSON: eth_blockNumber and eth_getTransactionByBlockHashAndIndex

### DIFF
--- a/src/main/scala/io/iohk/ethereum/jsonrpc/JsonMethodsImplicits.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/JsonMethodsImplicits.scala
@@ -62,7 +62,7 @@ object JsonMethodsImplicits {
     override def encodeJson(t: BestBlockNumberResponse): JValue = Extraction.decompose(t.bestBlockNumber)
   }
 
-    implicit val eth_getBlockTransactionCountByHash = new JsonDecoder[TxCountByBlockHashRequest] with JsonEncoder[TxCountByBlockHashResponse] {
+  implicit val eth_getBlockTransactionCountByHash = new JsonDecoder[TxCountByBlockHashRequest] with JsonEncoder[TxCountByBlockHashResponse] {
     override def decodeJson(params: Option[JArray]): Either[JsonRpcError, TxCountByBlockHashRequest] =
       params match {
         case Some(JArray((input: JString) :: Nil)) =>

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/JsonRpcController.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/JsonRpcController.scala
@@ -28,10 +28,16 @@ class JsonRpcController(web3Service: Web3Service, ethService: EthService) {
     request.method match {
       case "web3_sha3" => handle[Sha3Request, Sha3Response](web3Service.sha3, request)
       case "web3_clientVersion" => handle[ClientVersionRequest, ClientVersionResponse](web3Service.clientVersion, request)
+      case "eth_blockNumber" => handle[BlockByNumberRequest, BlockByNumberResponse](ethService.bestBlockNumber, request)
       case "eth_getBlockTransactionCountByHash" =>
         handle[TxCountByBlockHashRequest, TxCountByBlockHashResponse](ethService.getBlockTransactionCountByHash, request)
       case "eth_getBlockByHash" =>
         handle[BlockByBlockHashRequest, BlockByBlockHashResponse](ethService.getByBlockHash, request)
+      case "eth_getTransactionByBlockHashAndIndex" =>
+        handle[GetTransactionByBlockHashAndIndexRequest, GetTransactionByBlockHashAndIndexResponse](
+          ethService.getTransactionByBlockHashAndIndexRequest,
+          request
+        )
       case "eth_getUncleByBlockHashAndIndex" =>
         handle[UncleByBlockHashAndIndexRequest, UncleByBlockHashAndIndexResponse](ethService.getUncleByBlockHashAndIndex, request)
       case _ => Future.successful(errorResponse(request, MethodNotFound))

--- a/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
@@ -92,9 +92,9 @@ trait Web3ServiceBuilder {
 
 trait EthServiceBuilder {
 
-  self: BlockChainBuilder =>
+  self: BlockChainBuilder with StorageBuilder =>
 
-  lazy val ethService = new EthService(blockchain)
+  lazy val ethService = new EthService(blockchain, storagesInstance.storages.appStateStorage)
 }
 
 trait JSONRpcControllerBuilder {


### PR DESCRIPTION
## Description

Includes implementation of both `eth_blockNumber` and `eth_getTransactionByBlockHashAndIndex` methods. As `eth_getTransactionByBlockHashAndIndex` returns a transaction object, this PR is dependant on #179.