### PR TITLE
Fix race condition in test

### DIFF
--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/FastSyncBlockHeadersRequestHandlerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/FastSyncBlockHeadersRequestHandlerSpec.scala
@@ -55,14 +55,15 @@ class FastSyncBlockHeadersRequestHandlerSpec extends FlatSpec with Matchers {
     }
 
     resolverPeerTestProbe.expectMsg(PeerActor.SendMessage(request))
-    peerMessageBus.expectMsg(Subscribe(MessageClassifier(Set(BlockHeaders.code), PeerSelector.WithId(peer.id))))
-    peerMessageBus.expectMsg(Subscribe(MessageClassifier(Set(BlockHeaders.code), PeerSelector.WithId(resolverPeer.id))))
+    peerMessageBus.expectMsgAllOf(
+      Subscribe(MessageClassifier(Set(BlockHeaders.code), PeerSelector.WithId(peer.id))),
+      Subscribe(MessageClassifier(Set(BlockHeaders.code), PeerSelector.WithId(resolverPeer.id))))
 
     val responseHeaders = Seq(BlockHeader(testGenesisHash, ByteString(""), ByteString(""),
       ByteString(""), ByteString(""), ByteString(""),
       ByteString(""), 0, block, 0, 0, 0, ByteString(""), ByteString(""), ByteString("")))
 
-    peerMessageBus.reply(MessageFromPeer(BlockHeaders(responseHeaders), resolverPeer.id))
+    resolver ! MessageFromPeer(BlockHeaders(responseHeaders), resolverPeer.id)
 
     parent.expectMsg(SyncController.BlockHeadersToResolve(resolverPeer, responseHeaders))
 

--- a/src/test/scala/io/iohk/ethereum/transactions/PendingTransactionsManagerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/transactions/PendingTransactionsManagerSpec.scala
@@ -5,7 +5,7 @@ import java.net.InetSocketAddress
 import akka.actor.ActorSystem
 import akka.testkit.TestProbe
 import akka.util.{ByteString, Timeout}
-import io.iohk.ethereum.crypto
+import io.iohk.ethereum.{DefaultPatience, crypto}
 import io.iohk.ethereum.domain.{Address, SignedTransaction, Transaction}
 import io.iohk.ethereum.network.{Peer, PeerId, PeerManagerActor}
 import io.iohk.ethereum.network.PeerMessageBusActor.MessageFromPeer
@@ -22,7 +22,7 @@ import org.scalatest.concurrent.ScalaFutures
 
 import scala.concurrent.duration._
 
-class PendingTransactionsManagerSpec extends FlatSpec with Matchers with ScalaFutures {
+class PendingTransactionsManagerSpec extends FlatSpec with Matchers with ScalaFutures with DefaultPatience {
 
   implicit val timeout = Timeout(10.seconds)
 


### PR DESCRIPTION
This fixes (hopefully last) race condition that occurs in tests after switching to PeerMessageBus.