### PR TITLE
remove per-method ExecutionContext in EthService

### DIFF
--- a/src/main/scala/io/iohk/ethereum/jsonrpc/EthService.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/EthService.scala
@@ -7,7 +7,6 @@ import akka.actor.ActorRef
 import io.iohk.ethereum.domain.{BlockHeader, SignedTransaction}
 import io.iohk.ethereum.db.storage.AppStateStorage
 
-import scala.concurrent.ExecutionContext
 import akka.util.ByteString
 import io.iohk.ethereum.blockchain.sync.SyncController.MinedBlock
 import io.iohk.ethereum.crypto._
@@ -22,6 +21,7 @@ import io.iohk.ethereum.ommers.OmmersPool
 import org.spongycastle.util.encoders.Hex
 
 import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.{Failure, Success, Try}
 
 // scalastyle:off number.of.methods number.of.types
@@ -118,7 +118,7 @@ class EthService(
     *
     * @return Current block number the client is on.
     */
-  def bestBlockNumber(req: BestBlockNumberRequest)(implicit executionContext: ExecutionContext): ServiceResponse[BestBlockNumberResponse] = Future {
+  def bestBlockNumber(req: BestBlockNumberRequest): ServiceResponse[BestBlockNumberResponse] = Future {
     Right(BestBlockNumberResponse(appStateStorage.getBestBlockNumber()))
   }
 
@@ -128,8 +128,7 @@ class EthService(
     * @param request with the hash of the block requested
     * @return the number of txs that the block has or None if the client doesn't have the block requested
     */
-  def getBlockTransactionCountByHash(request: TxCountByBlockHashRequest)
-                                    (implicit executor: ExecutionContext): ServiceResponse[TxCountByBlockHashResponse] = Future {
+  def getBlockTransactionCountByHash(request: TxCountByBlockHashRequest): ServiceResponse[TxCountByBlockHashResponse] = Future {
     val txsCount = blockchain.getBlockBodyByHash(request.blockHash).map(_.transactionList.size)
     Right(TxCountByBlockHashResponse(txsCount))
   }
@@ -140,8 +139,7 @@ class EthService(
     * @param request with the hash of the block requested
     * @return the block requested or None if the client doesn't have the block
     */
-  def getByBlockHash(request: BlockByBlockHashRequest)
-                    (implicit executor: ExecutionContext): ServiceResponse[BlockByBlockHashResponse] = Future {
+  def getByBlockHash(request: BlockByBlockHashRequest): ServiceResponse[BlockByBlockHashResponse] = Future {
     val BlockByBlockHashRequest(blockHash, fullTxs) = request
     val blockOpt = blockchain.getBlockByHash(blockHash)
     val totalDifficulty = blockchain.getTotalDifficultyByHash(blockHash)
@@ -156,7 +154,7 @@ class EthService(
     *
     * @return the tx requested or None if the client doesn't have the block or if there's no tx in the that index
     */
-  def getTransactionByBlockHashAndIndexRequest(req: GetTransactionByBlockHashAndIndexRequest)(implicit executionContext: ExecutionContext)
+  def getTransactionByBlockHashAndIndexRequest(req: GetTransactionByBlockHashAndIndexRequest)
   : ServiceResponse[GetTransactionByBlockHashAndIndexResponse] = Future {
     import req._
     val maybeTransactionResponse = blockchain.getBlockByHash(blockHash).flatMap{
@@ -175,8 +173,7 @@ class EthService(
     * @param request with the hash of the block and the index of the uncle requested
     * @return the uncle that the block has at the given index or None if the client doesn't have the block or if there's no uncle in that index
     */
-  def getUncleByBlockHashAndIndex(request: UncleByBlockHashAndIndexRequest)
-                                 (implicit executor: ExecutionContext): ServiceResponse[UncleByBlockHashAndIndexResponse] = Future {
+  def getUncleByBlockHashAndIndex(request: UncleByBlockHashAndIndexRequest): ServiceResponse[UncleByBlockHashAndIndexResponse] = Future {
     val UncleByBlockHashAndIndexRequest(blockHash, uncleIndex) = request
     val uncleHeaderOpt = blockchain.getBlockBodyByHash(blockHash)
       .flatMap { body =>
@@ -202,8 +199,6 @@ class EthService(
 
     val blockNumber = appStateStorage.getBestBlockNumber() + 1
 
-    import scala.concurrent.ExecutionContext.Implicits.global
-
     getOmmersFromPool.zip(getTransactionsFromPool).map {
       case (ommers, pendingTxs) =>
         blockGenerator.generateBlockForMining(blockNumber, pendingTxs.signedTransactions, ommers.headers, miningConfig.coinbase) match {
@@ -221,7 +216,6 @@ class EthService(
   }
 
   private def getOmmersFromPool = {
-    import scala.concurrent.ExecutionContext.Implicits.global
     implicit val timeout = Timeout(miningConfig.poolingServicesTimeout)
 
     (ommersPool ? OmmersPool.GetOmmers).mapTo[OmmersPool.Ommers]
@@ -232,7 +226,6 @@ class EthService(
   }
 
   private def getTransactionsFromPool = {
-    import scala.concurrent.ExecutionContext.Implicits.global
     implicit val timeout = Timeout(miningConfig.poolingServicesTimeout)
 
     (pendingTransactionsManager ? PendingTransactionsManager.GetPendingTransactions).mapTo[PendingTransactions]


### PR DESCRIPTION
A custom ExecutionContext may be useful at some point, but it should be defined at class level, not per each single method in `EthService`. 

For now we stick with `global`. If we want to customise it in the future, the refactor will be easy - add class parameter, and provide it in `NodeBuilder`.