### PR TITLE
PeerMessageBus refactor

### DIFF
--- a/src/main/scala/io/iohk/ethereum/network/PeerMessageBusActor.scala
+++ b/src/main/scala/io/iohk/ethereum/network/PeerMessageBusActor.scala
@@ -38,8 +38,7 @@ object PeerMessageBusActor {
     override def subscribe(subscriber: ActorRef, to: Classifier): Boolean = {
       val newSubscriptions = subscriptions.get((subscriber, to.peerSelector)) match {
         case Some(messageCodes) =>
-          if (messageCodes == to.messageCodes) subscriptions
-          else subscriptions + ((subscriber, to.peerSelector) -> (messageCodes ++ to.messageCodes))
+          subscriptions + ((subscriber, to.peerSelector) -> (messageCodes ++ to.messageCodes))
         case None =>  subscriptions + ((subscriber, to.peerSelector) -> to.messageCodes)
       }
       if(newSubscriptions == subscriptions) false

--- a/src/main/scala/io/iohk/ethereum/network/PeerMessageBusActor.scala
+++ b/src/main/scala/io/iohk/ethereum/network/PeerMessageBusActor.scala
@@ -54,7 +54,7 @@ object PeerMessageBusActor {
         val newMessageCodes = messageCodes -- from.messageCodes
         if (messageCodes == newMessageCodes) false
         else {
-          if(newMessageCodes.isEmpty) subscriptions = subscriptions - (subscriber -> from.peerSelector)
+          if(newMessageCodes.isEmpty) subscriptions = subscriptions - ((subscriber, from.peerSelector))
           else subscriptions = subscriptions + ((subscriber, from.peerSelector) -> newMessageCodes)
           true
         }

--- a/src/test/scala/io/iohk/ethereum/network/PeerMessageBusActorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/network/PeerMessageBusActorSpec.scala
@@ -53,4 +53,112 @@ class PeerMessageBusActorSpec extends FlatSpec with Matchers {
     probe1.expectNoMsg()
   }
 
+  it should "relay a single notification when subscribed twice to the same message code" in {
+    implicit val system = ActorSystem("test-system")
+
+    val peerMessageBusActor = system.actorOf(PeerMessageBusActor.props)
+
+    val probe1 = TestProbe()
+    peerMessageBusActor.tell(PeerMessageBusActor.Subscribe(MessageClassifier(Set(Ping.code, Ping.code), PeerSelector.WithId(PeerId("1")))), probe1.ref)
+    peerMessageBusActor.tell(PeerMessageBusActor.Subscribe(MessageClassifier(Set(Ping.code, Pong.code), PeerSelector.WithId(PeerId("1")))), probe1.ref)
+
+    val msgFromPeer = MessageFromPeer(Ping(), PeerId("1"))
+    peerMessageBusActor ! PeerMessageBusActor.Publish(msgFromPeer)
+
+    probe1.expectMsg(msgFromPeer)
+    probe1.expectNoMsg()
+  }
+
+  it should "allow to handle subscriptions using AllPeers and WithId PeerSelector at the same time" in {
+    implicit val system = ActorSystem("test-system")
+
+    val peerMessageBusActor = system.actorOf(PeerMessageBusActor.props)
+
+    val probe1 = TestProbe()
+    peerMessageBusActor.tell(PeerMessageBusActor.Subscribe(MessageClassifier(Set(Ping.code), PeerSelector.WithId(PeerId("1")))), probe1.ref)
+    peerMessageBusActor.tell(PeerMessageBusActor.Subscribe(MessageClassifier(Set(Ping.code), PeerSelector.AllPeers)), probe1.ref)
+
+    val msgFromPeer = MessageFromPeer(Ping(), PeerId("1"))
+    peerMessageBusActor ! PeerMessageBusActor.Publish(msgFromPeer)
+
+    // Receive a single notification
+    probe1.expectMsg(msgFromPeer)
+    probe1.expectNoMsg()
+
+    val msgFromPeer2 = MessageFromPeer(Ping(), PeerId("2"))
+    peerMessageBusActor ! PeerMessageBusActor.Publish(msgFromPeer2)
+
+    // Receive based on AllPeers subscription
+    probe1.expectMsg(msgFromPeer2)
+
+    peerMessageBusActor.tell(PeerMessageBusActor.Unsubscribe(MessageClassifier(Set(Ping.code), PeerSelector.AllPeers)), probe1.ref)
+    peerMessageBusActor ! PeerMessageBusActor.Publish(msgFromPeer)
+
+    // Still received after unsubscribing from AllPeers
+    probe1.expectMsg(msgFromPeer)
+  }
+
+  it should "allow to subscribe to new messages" in {
+    implicit val system = ActorSystem("test-system")
+
+    val peerMessageBusActor = system.actorOf(PeerMessageBusActor.props)
+
+    val probe1 = TestProbe()
+    peerMessageBusActor.tell(PeerMessageBusActor.Subscribe(MessageClassifier(Set(Ping.code), PeerSelector.WithId(PeerId("1")))), probe1.ref)
+    peerMessageBusActor.tell(PeerMessageBusActor.Subscribe(MessageClassifier(Set(Ping.code, Pong.code), PeerSelector.WithId(PeerId("1")))), probe1.ref)
+
+    val msgFromPeer = MessageFromPeer(Pong(), PeerId("1"))
+    peerMessageBusActor ! PeerMessageBusActor.Publish(msgFromPeer)
+
+    probe1.expectMsg(msgFromPeer)
+  }
+
+  it should "not change subscriptions when subscribing to empty set" in {
+    implicit val system = ActorSystem("test-system")
+
+    val peerMessageBusActor = system.actorOf(PeerMessageBusActor.props)
+
+    val probe1 = TestProbe()
+    peerMessageBusActor.tell(PeerMessageBusActor.Subscribe(MessageClassifier(Set(Ping.code), PeerSelector.WithId(PeerId("1")))), probe1.ref)
+    peerMessageBusActor.tell(PeerMessageBusActor.Subscribe(MessageClassifier(Set(), PeerSelector.WithId(PeerId("1")))), probe1.ref)
+
+    val msgFromPeer = MessageFromPeer(Ping(), PeerId("1"))
+    peerMessageBusActor ! PeerMessageBusActor.Publish(msgFromPeer)
+
+    probe1.expectMsg(msgFromPeer)
+  }
+
+  it should "allow to unsubscribe from messages" in {
+    implicit val system = ActorSystem("test-system")
+
+    val peerMessageBusActor = system.actorOf(PeerMessageBusActor.props)
+
+    val probe1 = TestProbe()
+    peerMessageBusActor.tell(PeerMessageBusActor.Subscribe(MessageClassifier(Set(Ping.code, Pong.code), PeerSelector.WithId(PeerId("1")))), probe1.ref)
+
+    val msgFromPeer1 = MessageFromPeer(Ping(), PeerId("1"))
+    val msgFromPeer2 = MessageFromPeer(Pong(), PeerId("1"))
+    peerMessageBusActor ! PeerMessageBusActor.Publish(msgFromPeer1)
+    peerMessageBusActor ! PeerMessageBusActor.Publish(msgFromPeer2)
+
+    probe1.expectMsg(msgFromPeer1)
+    probe1.expectMsg(msgFromPeer2)
+
+    peerMessageBusActor.tell(PeerMessageBusActor.Unsubscribe(MessageClassifier(Set(Pong.code), PeerSelector.WithId(PeerId("1")))), probe1.ref)
+
+    peerMessageBusActor ! PeerMessageBusActor.Publish(msgFromPeer1)
+    peerMessageBusActor ! PeerMessageBusActor.Publish(msgFromPeer2)
+
+    probe1.expectMsg(msgFromPeer1)
+    probe1.expectNoMsg()
+
+    peerMessageBusActor.tell(PeerMessageBusActor.Unsubscribe(), probe1.ref)
+
+    peerMessageBusActor ! PeerMessageBusActor.Publish(msgFromPeer1)
+    peerMessageBusActor ! PeerMessageBusActor.Publish(msgFromPeer2)
+
+    probe1.expectNoMsg()
+  }
+
 }
+


### PR DESCRIPTION
## Description

Peer message bus implementation changed in order to:

- Don't send the notification twice if a subscription is made with two `MessageClassifier` with same message code, eg: `MessageClassifier(1,2,3)` and `MessageClassifier(2)` should only trigger once
- Allow users to Unsubscribe by code message code instead of the entire `MessageClassifier`