### PR TITLE
Added eth_getBlockByNumber and eth_getUncleByBlockNumberAndIndex

### DIFF
--- a/src/main/scala/io/iohk/ethereum/jsonrpc/EthService.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/EthService.scala
@@ -233,10 +233,9 @@ class EthService(
   def getUncleByBlockNumberAndIndex(request: UncleByBlockNumberAndIndexRequest): ServiceResponse[UncleByBlockNumberAndIndexResponse] = Future {
     val UncleByBlockNumberAndIndexRequest(blockParam, uncleIndex) = request
     val uncleHeaderOpt = resolveBlock(blockParam).toOption
-      .flatMap { uncleBlock =>
-        val uncleBody = uncleBlock.body
-        if (uncleIndex >= 0 && uncleIndex < uncleBody.uncleNodesList.size)
-          Some(uncleBody.uncleNodesList.apply(uncleIndex.toInt))
+      .flatMap { block =>
+        if (uncleIndex >= 0 && uncleIndex < block.body.uncleNodesList.size)
+          Some(block.body.uncleNodesList.apply(uncleIndex.toInt))
         else
           None
       }

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/EthService.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/EthService.scala
@@ -163,7 +163,7 @@ class EthService(
     val blockOpt = blockchain.getBlockByHash(blockHash)
     val totalDifficulty = blockchain.getTotalDifficultyByHash(blockHash)
 
-    val blockResponseOpt = blockOpt.map(block => BlockResponse(block, fullTxs, totalDifficulty))
+    val blockResponseOpt = blockOpt.map(block => BlockResponse(block, totalDifficulty, fullTxs = fullTxs))
     Right(BlockByBlockHashResponse(blockResponseOpt))
   }
 
@@ -177,7 +177,7 @@ class EthService(
     val BlockByNumberRequest(blockParam, fullTxs) = request
     val blockResponseOpt = resolveBlock(blockParam).toOption.map { block =>
       val totalDifficulty = blockchain.getTotalDifficultyByHash(block.header.hash)
-      BlockResponse(block, fullTxs, totalDifficulty)
+      BlockResponse(block, totalDifficulty, fullTxs = fullTxs, pendingBlock = blockParam == BlockParam.Pending)
     }
     Right(BlockByNumberResponse(blockResponseOpt))
   }
@@ -219,7 +219,8 @@ class EthService(
     val totalDifficulty = uncleHeaderOpt.flatMap(uncleHeader => blockchain.getTotalDifficultyByHash(uncleHeader.hash))
 
     //The block in the response will not have any txs or uncles
-    val uncleBlockResponseOpt = uncleHeaderOpt.map { uncleHeader => BlockResponse(blockHeader = uncleHeader, totalDifficulty = totalDifficulty) }
+    val uncleBlockResponseOpt = uncleHeaderOpt.map { uncleHeader =>
+      BlockResponse(blockHeader = uncleHeader, totalDifficulty = totalDifficulty, pendingBlock = false) }
     Right(UncleByBlockHashAndIndexResponse(uncleBlockResponseOpt))
   }
 
@@ -242,7 +243,8 @@ class EthService(
     val totalDifficulty = uncleHeaderOpt.flatMap(uncleHeader => blockchain.getTotalDifficultyByHash(uncleHeader.hash))
 
     //The block in the response will not have any txs or uncles
-    val uncleBlockResponseOpt = uncleHeaderOpt.map { uncleHeader => BlockResponse(blockHeader = uncleHeader, totalDifficulty = totalDifficulty) }
+    val uncleBlockResponseOpt = uncleHeaderOpt.map { uncleHeader =>
+      BlockResponse(blockHeader = uncleHeader, totalDifficulty = totalDifficulty, pendingBlock = blockParam == BlockParam.Pending) }
     Right(UncleByBlockNumberAndIndexResponse(uncleBlockResponseOpt))
   }
 

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/JsonRpcController.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/JsonRpcController.scala
@@ -96,10 +96,14 @@ class JsonRpcController(
       handle[TxCountByBlockHashRequest, TxCountByBlockHashResponse](ethService.getBlockTransactionCountByHash, req)
     case req @ JsonRpcRequest(_, "eth_getBlockByHash", _, _) =>
       handle[BlockByBlockHashRequest, BlockByBlockHashResponse](ethService.getByBlockHash, req)
+    case req @ JsonRpcRequest(_, "eth_getBlockByNumber", _, _) =>
+      handle[BlockByNumberRequest, BlockByNumberResponse](ethService.getBlockByNumber, req)
     case req @ JsonRpcRequest(_, "eth_getTransactionByBlockHashAndIndex", _, _) =>
       handle[GetTransactionByBlockHashAndIndexRequest, GetTransactionByBlockHashAndIndexResponse](ethService.getTransactionByBlockHashAndIndexRequest, req)
     case req @ JsonRpcRequest(_, "eth_getUncleByBlockHashAndIndex", _, _) =>
       handle[UncleByBlockHashAndIndexRequest, UncleByBlockHashAndIndexResponse](ethService.getUncleByBlockHashAndIndex, req)
+    case req @ JsonRpcRequest(_, "eth_getUncleByBlockNumberAndIndex", _, _) =>
+      handle[UncleByBlockNumberAndIndexRequest, UncleByBlockNumberAndIndexResponse](ethService.getUncleByBlockNumberAndIndex, req)
     case req @ JsonRpcRequest(_, "eth_accounts", _, _) =>
       handle[ListAccountsRequest, ListAccountsResponse](personalService.listAccounts, req)
     case req @ JsonRpcRequest(_, "eth_sendRawTransaction", _, _) =>

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/EthServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/EthServiceSpec.scala
@@ -105,6 +105,55 @@ class EthServiceSpec extends FlatSpec with Matchers with ScalaFutures with MockF
     response.transactionResponse shouldBe Some(expectedTxResponse)
   }
 
+  it should "answer eth_getBlockByNumber with None when the requested block isn't in the blockchain" in new TestSetup {
+    val request = BlockByNumberRequest(BlockParam.WithNumber(blockToRequestNumber), fullTxs = true)
+    val response = Await.result(ethService.getBlockByNumber(request), Duration.Inf).right.get
+    response.blockResponse shouldBe None
+  }
+
+  it should "answer eth_getBlockByNumber with the block response correctly when it's totalDifficulty is in blockchain" in new TestSetup {
+    blockchain.save(blockToRequest)
+    blockchain.save(blockToRequestHash, blockTd)
+
+    val request = BlockByNumberRequest(BlockParam.WithNumber(blockToRequestNumber), fullTxs = true)
+    val response = Await.result(ethService.getBlockByNumber(request), Duration.Inf).right.get
+
+    val stxResponses = blockToRequest.body.transactionList.zipWithIndex.map { case (stx, txIndex) =>
+      TransactionResponse(stx, Some(blockToRequest.header), Some(txIndex))
+    }
+
+    response.blockResponse shouldBe Some(BlockResponse(blockToRequest, fullTxs = true, totalDifficulty = Some(blockTd)))
+    response.blockResponse.get.totalDifficulty shouldBe Some(blockTd)
+    response.blockResponse.get.transactions.right.toOption shouldBe Some(stxResponses)
+  }
+
+  it should "answer eth_getBlockByNumber with the block response correctly when it's totalDifficulty is not in blockchain" in new TestSetup {
+    blockchain.save(blockToRequest)
+
+    val request = BlockByNumberRequest(BlockParam.WithNumber(blockToRequestNumber), fullTxs = true)
+    val response = Await.result(ethService.getBlockByNumber(request), Duration.Inf).right.get
+
+    val stxResponses = blockToRequest.body.transactionList.zipWithIndex.map { case (stx, txIndex) =>
+      TransactionResponse(stx, Some(blockToRequest.header), Some(txIndex))
+    }
+
+    response.blockResponse shouldBe Some(BlockResponse(blockToRequest, fullTxs = true))
+    response.blockResponse.get.totalDifficulty shouldBe None
+    response.blockResponse.get.transactions.right.toOption shouldBe Some(stxResponses)
+  }
+
+  it should "answer eth_getBlockByNumber with the block response correctly when the txs should be hashed" in new TestSetup {
+    blockchain.save(blockToRequest)
+    blockchain.save(blockToRequestHash, blockTd)
+
+    val request = BlockByNumberRequest(BlockParam.WithNumber(blockToRequestNumber), fullTxs = true)
+    val response = Await.result(ethService.getBlockByNumber(request.copy(fullTxs = false)), Duration.Inf).right.get
+
+    response.blockResponse shouldBe Some(BlockResponse(blockToRequest, fullTxs = false, totalDifficulty = Some(blockTd)))
+    response.blockResponse.get.totalDifficulty shouldBe Some(blockTd)
+    response.blockResponse.get.transactions.left.toOption shouldBe Some(blockToRequest.body.transactionList.map(_.hash))
+  }
+
   it should "answer eth_getBlockByHash with None when the requested block isn't in the blockchain" in new TestSetup {
     val request = BlockByBlockHashRequest(blockToRequestHash, fullTxs = true)
     val response = Await.result(ethService.getByBlockHash(request), Duration.Inf).right.get
@@ -203,6 +252,62 @@ class EthServiceSpec extends FlatSpec with Matchers with ScalaFutures with MockF
     val uncleIndexToRequest = 0
     val request = UncleByBlockHashAndIndexRequest(blockToRequestHash, uncleIndexToRequest)
     val response = Await.result(ethService.getUncleByBlockHashAndIndex(request), Duration.Inf).right.get
+
+    response.uncleBlockResponse shouldBe Some(BlockResponse(uncle, Some(uncleTd)))
+    response.uncleBlockResponse.get.totalDifficulty shouldBe Some(uncleTd)
+    response.uncleBlockResponse.get.transactions shouldBe Left(Nil)
+    response.uncleBlockResponse.get.uncles shouldBe Nil
+  }
+
+  it should "answer eth_getUncleByBlockNumberAndIndex with None when the requested block isn't in the blockchain" in new TestSetup {
+    val uncleIndexToRequest = 0
+    val request = UncleByBlockNumberAndIndexRequest(BlockParam.WithNumber(blockToRequestNumber), uncleIndexToRequest)
+    val response = Await.result(ethService.getUncleByBlockNumberAndIndex(request), Duration.Inf).right.get
+    response.uncleBlockResponse shouldBe None
+  }
+
+  it should "answer eth_getUncleByBlockNumberAndIndex with None when there's no uncle" in new TestSetup {
+    blockchain.save(blockToRequest)
+
+    val uncleIndexToRequest = 0
+    val request = UncleByBlockNumberAndIndexRequest(BlockParam.WithNumber(blockToRequestNumber), uncleIndexToRequest)
+    val response = Await.result(ethService.getUncleByBlockNumberAndIndex(request), Duration.Inf).right.get
+
+    response.uncleBlockResponse shouldBe None
+  }
+
+  it should "answer eth_getUncleByBlockNumberAndIndex with None when there's no uncle in the requested index" in new TestSetup {
+    blockchain.save(blockToRequestWithUncles)
+
+    val uncleIndexToRequest = 0
+    val request = UncleByBlockNumberAndIndexRequest(BlockParam.WithNumber(blockToRequestNumber), uncleIndexToRequest)
+    val response1 = Await.result(ethService.getUncleByBlockNumberAndIndex(request.copy(uncleIndex = 1)), Duration.Inf).right.get
+    val response2 = Await.result(ethService.getUncleByBlockNumberAndIndex(request.copy(uncleIndex = -1)), Duration.Inf).right.get
+
+    response1.uncleBlockResponse shouldBe None
+    response2.uncleBlockResponse shouldBe None
+  }
+
+  it should "answer eth_getUncleByBlockNumberAndIndex correctly when the requested index has one but there's no total difficulty for it" in new TestSetup {
+    blockchain.save(blockToRequestWithUncles)
+
+    val uncleIndexToRequest = 0
+    val request = UncleByBlockNumberAndIndexRequest(BlockParam.WithNumber(blockToRequestNumber), uncleIndexToRequest)
+    val response = Await.result(ethService.getUncleByBlockNumberAndIndex(request), Duration.Inf).right.get
+
+    response.uncleBlockResponse shouldBe Some(BlockResponse(uncle, None))
+    response.uncleBlockResponse.get.totalDifficulty shouldBe None
+    response.uncleBlockResponse.get.transactions shouldBe Left(Nil)
+    response.uncleBlockResponse.get.uncles shouldBe Nil
+  }
+
+  it should "anwer eth_getUncleByBlockNumberAndIndex correctly when the requested index has one and there's total difficulty for it" in new TestSetup {
+    blockchain.save(blockToRequestWithUncles)
+    blockchain.save(uncle.hash, uncleTd)
+
+    val uncleIndexToRequest = 0
+    val request = UncleByBlockNumberAndIndexRequest(BlockParam.WithNumber(blockToRequestNumber), uncleIndexToRequest)
+    val response = Await.result(ethService.getUncleByBlockNumberAndIndex(request), Duration.Inf).right.get
 
     response.uncleBlockResponse shouldBe Some(BlockResponse(uncle, Some(uncleTd)))
     response.uncleBlockResponse.get.totalDifficulty shouldBe Some(uncleTd)
@@ -364,6 +469,7 @@ class EthServiceSpec extends FlatSpec with Matchers with ScalaFutures with MockF
       blockchainConfig, keyStore, pendingTransactionsManager.ref, syncingController.ref, ommersPool.ref)
 
     val blockToRequest = Block(Fixtures.Blocks.Block3125369.header, Fixtures.Blocks.Block3125369.body)
+    val blockToRequestNumber = blockToRequest.header.number
     val blockToRequestHash = blockToRequest.header.hash
     val blockTd = blockToRequest.header.difficulty
 

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerSpec.scala
@@ -204,6 +204,30 @@ class JsonRpcControllerSpec extends FlatSpec with Matchers with ScalaFutures wit
     response.result shouldBe Some(expectedBlockResponse)
   }
 
+  it should "handle eth_getBlockByNumber request" in new TestSetup {
+
+    val blockToRequest = Block(Fixtures.Blocks.Block3125369.header, Fixtures.Blocks.Block3125369.body)
+    val blockTd = blockToRequest.header.difficulty
+
+    blockchain.save(blockToRequest)
+    blockchain.save(blockToRequest.header.hash, blockTd)
+
+    val request = JsonRpcRequest(
+      "2.0",
+      "eth_getBlockByNumber",
+      Some(JArray(List(JString(s"0x${Hex.toHexString(blockToRequest.header.number.toByteArray)}"), JBool(false)))),
+      Some(JInt(1))
+    )
+    val response = Await.result(jsonRpcController.handleRequest(request), Duration.Inf)
+
+    val expectedBlockResponse = Extraction.decompose(BlockResponse(blockToRequest, fullTxs = false, totalDifficulty = Some(blockTd)))
+
+    response.jsonrpc shouldBe "2.0"
+    response.id shouldBe JInt(1)
+    response.error shouldBe None
+    response.result shouldBe Some(expectedBlockResponse)
+  }
+
   it should "handle eth_getUncleByBlockHashAndIndex request" in new TestSetup {
     val uncle = Fixtures.Blocks.DaoForkBlock.header
     val blockToRequest = Block(Fixtures.Blocks.Block3125369.header, BlockBody(Nil, Seq(uncle)))
@@ -215,6 +239,35 @@ class JsonRpcControllerSpec extends FlatSpec with Matchers with ScalaFutures wit
       "eth_getUncleByBlockHashAndIndex",
       Some(JArray(List(
         JString(s"0x${blockToRequest.header.hashAsHexString}"),
+        JString(s"0x${Hex.toHexString(BigInt(0).toByteArray)}")
+      ))),
+      Some(JInt(1))
+    )
+    val response = Await.result(jsonRpcController.handleRequest(request), Duration.Inf)
+
+    val expectedUncleBlockResponse = Extraction.decompose(BlockResponse(uncle, None))
+      .removeField {
+        case ("transactions", _) => true
+        case _ => false
+      }
+
+    response.jsonrpc shouldBe "2.0"
+    response.id shouldBe JInt(1)
+    response.error shouldBe None
+    response.result shouldBe Some(expectedUncleBlockResponse)
+  }
+
+  it should "handle eth_getUncleByBlockNumberAndIndex request" in new TestSetup {
+    val uncle = Fixtures.Blocks.DaoForkBlock.header
+    val blockToRequest = Block(Fixtures.Blocks.Block3125369.header, BlockBody(Nil, Seq(uncle)))
+
+    blockchain.save(blockToRequest)
+
+    val request: JsonRpcRequest = JsonRpcRequest(
+      "2.0",
+      "eth_getUncleByBlockNumberAndIndex",
+      Some(JArray(List(
+        JString(s"0x${Hex.toHexString(blockToRequest.header.number.toByteArray)}"),
         JString(s"0x${Hex.toHexString(BigInt(0).toByteArray)}")
       ))),
       Some(JInt(1))

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerSpec.scala
@@ -245,7 +245,7 @@ class JsonRpcControllerSpec extends FlatSpec with Matchers with ScalaFutures wit
     )
     val response = Await.result(jsonRpcController.handleRequest(request), Duration.Inf)
 
-    val expectedUncleBlockResponse = Extraction.decompose(BlockResponse(uncle, None))
+    val expectedUncleBlockResponse = Extraction.decompose(BlockResponse(uncle, None, pendingBlock = false))
       .removeField {
         case ("transactions", _) => true
         case _ => false
@@ -274,7 +274,7 @@ class JsonRpcControllerSpec extends FlatSpec with Matchers with ScalaFutures wit
     )
     val response = Await.result(jsonRpcController.handleRequest(request), Duration.Inf)
 
-    val expectedUncleBlockResponse = Extraction.decompose(BlockResponse(uncle, None))
+    val expectedUncleBlockResponse = Extraction.decompose(BlockResponse(uncle, None, pendingBlock = false))
       .removeField {
         case ("transactions", _) => true
         case _ => false


### PR DESCRIPTION
## Description

Includes `eth_getBlockByNumber` and `eth_getUncleByBlockNumberAndIndex` JSON RPC methods.

**Note:** Although according to https://github.com/ethereum/wiki/wiki/JSON-RPC#returns-26 `number`, `hash`, `nonce` and `logsBloom` should be `null` when the block tag is `Pending`, to keep the compatibility with geth the parameters selected as `null` were chosen as mentioned in https://github.com/ethereumproject/go-ethereum/blob/master/eth/api.go#L578.