### PR TITLE
[EC-198] eth_estimateGas

### DIFF
--- a/src/main/scala/io/iohk/ethereum/jsonrpc/EthJsonMethodsImplicits.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/EthJsonMethodsImplicits.scala
@@ -213,11 +213,15 @@ object EthJsonMethodsImplicits extends JsonMethodsImplicits {
       } yield CallTx(
         from = from,
         to = to,
-        gas = gas.getOrElse(0),
+        gas = gas,
         gasPrice = gasPrice.getOrElse(0),
         value = value.getOrElse(0),
         data = data.getOrElse(ByteString("")))
     }
+  }
+
+  implicit val eth_estimateGas = new JsonEncoder[EstimateGasResponse] {
+    override def encodeJson(t: EstimateGasResponse): JValue = encodeAsHex(t.gas)
   }
 
   implicit val eth_getCode = new JsonDecoder[GetCodeRequest] with JsonEncoder[GetCodeResponse] {

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/EthService.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/EthService.scala
@@ -386,7 +386,8 @@ class EthService(
       }
     }
     val tx = Transaction(0, req.tx.gasPrice, gasLimit, toAddress, req.tx.value, req.tx.data)
-    val stx = SignedTransaction(tx, ECDSASignature(0, 0, 0.toByte), fromAddress)
+    val fakeSignature = ECDSASignature(0, 0, 0.toByte)
+    val stx = SignedTransaction(tx, fakeSignature, fromAddress)
 
     resolveBlock(req.block).map { block =>
       ledger.simulateTransaction(stx, block.header, blockchainStorages)

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/JsonRpcController.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/JsonRpcController.scala
@@ -77,6 +77,7 @@ class JsonRpcController(
   }
 
   // scalastyle:off cyclomatic.complexity
+  // scalastyle:off method.length
   private def handleEthRequest: PartialFunction[JsonRpcRequest, Future[JsonRpcResponse]] = {
     case req @ JsonRpcRequest(_, "eth_protocolVersion", _, _) =>
       handle[ProtocolVersionRequest, ProtocolVersionResponse](ethService.protocolVersion, req)

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/JsonRpcController.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/JsonRpcController.scala
@@ -110,6 +110,8 @@ class JsonRpcController(
       handle[SendTransactionRequest, SendTransactionResponse](personalService.sendTransaction, req)
     case req @ JsonRpcRequest(_, "eth_call", _, _) =>
       handle[CallRequest, CallResponse](ethService.call, req)
+    case req @ JsonRpcRequest(_, "eth_estimateGas", _, _) =>
+      handle[CallRequest, EstimateGasResponse](ethService.estimateGas, req)
     case req @ JsonRpcRequest(_, "eth_getCode", _, _) =>
       handle[GetCodeRequest, GetCodeResponse](ethService.getCode, req)
     case req @ JsonRpcRequest(_, "eth_getUncleCountByBlockNumber", _, _) =>

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/EthServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/EthServiceSpec.scala
@@ -271,10 +271,26 @@ class EthServiceSpec extends FlatSpec with Matchers with ScalaFutures with MockF
     val tx = CallTx(
       Some(ByteString(Hex.decode("da714fe079751fa7a1ad80b76571ea6ec52a446c"))),
       Some(ByteString(Hex.decode("abbb6bebfa05aa13e908eaa492bd7a8343760477"))),
-      1, 2, 3, ByteString(""))
+      Some(1), 2, 3, ByteString(""))
     val response = ethService.call(CallRequest(tx, BlockParam.Latest))
 
     response.futureValue shouldEqual Right(CallResponse(ByteString("return_value")))
+  }
+
+  it should "execute estimateGas and return a value" in new TestSetup {
+    blockchain.save(blockToRequest)
+    (appStateStorage.getBestBlockNumber _).expects().returning(blockToRequest.header.number)
+
+    val txResult = TxResult(InMemoryWorldStateProxy(storagesInstance.storages), 123, Nil, ByteString("return_value"))
+    (ledger.simulateTransaction _).expects(*, *, *).returning(txResult)
+
+    val tx = CallTx(
+      Some(ByteString(Hex.decode("da714fe079751fa7a1ad80b76571ea6ec52a446c"))),
+      Some(ByteString(Hex.decode("abbb6bebfa05aa13e908eaa492bd7a8343760477"))),
+      Some(1), 2, 3, ByteString(""))
+    val response = ethService.estimateGas(CallRequest(tx, BlockParam.Latest))
+
+    response.futureValue shouldEqual Right(EstimateGasResponse(123))
   }
 
   it should "get uncle count by block number" in new TestSetup {

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerSpec.scala
@@ -549,6 +549,32 @@ class JsonRpcControllerSpec extends FlatSpec with Matchers with ScalaFutures wit
     response.result shouldBe Some(JString("0x617364"))
   }
 
+  it should "eth_estimateGas" in new TestSetup {
+    val mockEthService = mock[EthService]
+    override val jsonRpcController = new JsonRpcController(web3Service, netService, mockEthService, personalService, config)
+
+    (mockEthService.estimateGas _).expects(*).returning(Future.successful(Right(EstimateGasResponse(2310))))
+
+    val json = JArray(List(
+      JObject(
+        "from" -> "0xabbb6bebfa05aa13e908eaa492bd7a8343760477",
+        "to" -> "0xda714fe079751fa7a1ad80b76571ea6ec52a446c",
+        "gas" -> "0x12",
+        "gasPrice" -> "0x123",
+        "value" -> "0x99",
+        "data" -> "0xFF44"
+      ),
+      JString("latest")
+    ))
+    val rpcRequest = JsonRpcRequest("2.0", "eth_estimateGas", Some(json), Some(1))
+    val response = jsonRpcController.handleRequest(rpcRequest).futureValue
+
+    response.jsonrpc shouldBe "2.0"
+    response.id shouldBe JInt(1)
+    response.error shouldBe None
+    response.result shouldBe Some(JString("0x906"))
+  }
+
   it should "eth_getCode" in new TestSetup {
     val mockEthService = mock[EthService]
     override val jsonRpcController = new JsonRpcController(web3Service, netService, mockEthService, personalService, config)


### PR DESCRIPTION
## Description

`eth_estimateGas` implementation based on the same code as `eth_call`. As this is a the first approach, `EC-199` was created in order to do further investigation to check if we also need to do something like https://github.com/ethereum/go-ethereum/pull/3587 (which is implemented in parity too  https://github.com/paritytech/parity/blob/e6a31e7543e33b925908c8abc424060a28127290/ethcore/src/client/client.rs#L1045)
