### PR TITLE
Implemented eth_getTransactionByHash

### DIFF
--- a/src/it/scala/io/iohk/ethereum/txExecTest/util/DumpChainApp.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/util/DumpChainApp.scala
@@ -6,6 +6,7 @@ import akka.util.ByteString
 import com.typesafe.config.ConfigFactory
 import io.iohk.ethereum.db.components.{SharedLevelDBDataSources, Storages}
 import io.iohk.ethereum.db.storage.AppStateStorage
+import io.iohk.ethereum.db.storage.TransactionMappingStorage.TransactionLocation
 import io.iohk.ethereum.domain.{Blockchain, _}
 import io.iohk.ethereum.network.EtcMessageHandler.EtcPeerInfo
 import io.iohk.ethereum.network.PeerManagerActor.PeerConfiguration
@@ -121,4 +122,6 @@ object DumpChainApp extends App{
     def getAccount(address: Address, blockNumber: BigInt): Option[Account] = ???
 
     override def getAccountStorageAt(rootHash: ByteString, position: BigInt): ByteString = ???
+
+    override def getTransactionLocation(txHash: ByteString): Option[TransactionLocation] = ???
   }

--- a/src/it/scala/io/iohk/ethereum/txExecTest/util/FixtureProvider.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/util/FixtureProvider.scala
@@ -42,6 +42,7 @@ object FixtureProvider {
       override val blockBodiesStorage: BlockBodiesStorage = new BlockBodiesStorage(EphemDataSource())
       override val totalDifficultyStorage: TotalDifficultyStorage = new TotalDifficultyStorage(EphemDataSource())
       override val nodeStorage: NodeStorage = new NodeStorage(EphemDataSource())
+      override val transactionMappingStorage: TransactionMappingStorage = new TransactionMappingStorage(EphemDataSource())
     }
 
     val blocksToInclude = fixtures.blockByNumber.toSeq.sortBy { case (number, _) => number }.takeWhile { case (number, _) => number <= blockNumber }

--- a/src/main/scala/io/iohk/ethereum/db/components/DataSourcesComponent.scala
+++ b/src/main/scala/io/iohk/ethereum/db/components/DataSourcesComponent.scala
@@ -26,6 +26,8 @@ trait DataSourcesComponent {
 
     val fastSyncStateDataSource: DataSource
 
+    val transactionMappingDataSource: DataSource
+
     def closeAll(): Unit
 
   }

--- a/src/main/scala/io/iohk/ethereum/db/components/SharedEphemDataSources.scala
+++ b/src/main/scala/io/iohk/ethereum/db/components/SharedEphemDataSources.scala
@@ -25,6 +25,8 @@ trait SharedEphemDataSources extends DataSourcesComponent {
 
     override val appStateDataSource: DataSource = ephemDataSource
 
+    override val transactionMappingDataSource: DataSource = ephemDataSource
+
     override def closeAll(): Unit = ()
   }
 

--- a/src/main/scala/io/iohk/ethereum/db/components/SharedIodbDataSources.scala
+++ b/src/main/scala/io/iohk/ethereum/db/components/SharedIodbDataSources.scala
@@ -27,6 +27,8 @@ trait SharedIodbDataSources extends DataSourcesComponent {
 
     override val appStateDataSource: DataSource = dataSource
 
+    override val transactionMappingDataSource: DataSource = dataSource
+
     override def closeAll(): Unit = dataSource.close()
   }
 }

--- a/src/main/scala/io/iohk/ethereum/db/components/SharedLevelDBDataSources.scala
+++ b/src/main/scala/io/iohk/ethereum/db/components/SharedLevelDBDataSources.scala
@@ -27,6 +27,8 @@ trait SharedLevelDBDataSources extends DataSourcesComponent {
 
     override val appStateDataSource: DataSource = dataSource
 
+    override val transactionMappingDataSource: DataSource = dataSource
+
     override def closeAll(): Unit = dataSource.close()
   }
 }

--- a/src/main/scala/io/iohk/ethereum/db/components/Storages.scala
+++ b/src/main/scala/io/iohk/ethereum/db/components/Storages.scala
@@ -34,6 +34,8 @@ object Storages {
 
       override val appStateStorage: AppStateStorage = new AppStateStorage(dataSources.appStateDataSource)
 
+      override val transactionMappingStorage: TransactionMappingStorage = new TransactionMappingStorage(dataSources.transactionMappingDataSource)
+
     }
 
   }
@@ -69,6 +71,8 @@ object Storages {
         new TotalDifficultyStorage(dataSources.totalDifficultyDataSource)
 
       override val appStateStorage: AppStateStorage = new AppStateStorage(dataSources.appStateDataSource)
+
+      override val transactionMappingStorage: TransactionMappingStorage = new TransactionMappingStorage(dataSources.transactionMappingDataSource)
     }
   }
 }

--- a/src/main/scala/io/iohk/ethereum/db/components/StoragesComponent.scala
+++ b/src/main/scala/io/iohk/ethereum/db/components/StoragesComponent.scala
@@ -28,5 +28,7 @@ trait StoragesComponent {
     val appStateStorage: AppStateStorage
 
     val fastSyncStateStorage: FastSyncStateStorage
+
+    val transactionMappingStorage: TransactionMappingStorage
   }
 }

--- a/src/main/scala/io/iohk/ethereum/db/storage/KeyValueStorage.scala
+++ b/src/main/scala/io/iohk/ethereum/db/storage/KeyValueStorage.scala
@@ -50,4 +50,5 @@ object Namespaces {
   val AppStateNamespace: IndexedSeq[Byte] = IndexedSeq[Byte]('s'.toByte)
   val HeightsNamespace: IndexedSeq[Byte] = IndexedSeq[Byte]('i'.toByte)
   val FastSyncStateNamespace: IndexedSeq[Byte] = IndexedSeq[Byte]('h'.toByte)
+  val TransactionMappingNamespace: IndexedSeq[Byte] = IndexedSeq[Byte]('l'.toByte)
 }

--- a/src/main/scala/io/iohk/ethereum/db/storage/TransactionMappingStorage.scala
+++ b/src/main/scala/io/iohk/ethereum/db/storage/TransactionMappingStorage.scala
@@ -1,0 +1,29 @@
+package io.iohk.ethereum.db.storage
+
+import java.nio.ByteBuffer
+
+import akka.util.ByteString
+import io.iohk.ethereum.db.dataSource.DataSource
+import io.iohk.ethereum.db.storage.TransactionMappingStorage.{TransactionLocation, TxHash}
+import boopickle.Default._
+
+class TransactionMappingStorage(val dataSource: DataSource) extends KeyValueStorage[TxHash, TransactionLocation, TransactionMappingStorage] {
+
+  val namespace: IndexedSeq[Byte] = Namespaces.TransactionMappingNamespace
+  def keySerializer: TxHash => IndexedSeq[Byte] = identity
+  def valueSerializer: TransactionLocation => IndexedSeq[Byte] = Pickle.intoBytes(_).array()
+  def valueDeserializer: IndexedSeq[Byte] => TransactionLocation =
+    bytes => Unpickle[TransactionLocation].fromBytes(ByteBuffer.wrap(bytes.toArray[Byte]))
+
+  implicit val byteStringPickler: Pickler[ByteString] = transformPickler[ByteString, Array[Byte]](ByteString(_))(_.toArray[Byte])
+
+  protected def apply(dataSource: DataSource): TransactionMappingStorage = new TransactionMappingStorage(dataSource)
+
+}
+
+object TransactionMappingStorage {
+  type TxHash = IndexedSeq[Byte]
+
+  case class TransactionLocation(blockHash: ByteString, txIndex: Int)
+
+}

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/EthJsonMethodsImplicits.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/EthJsonMethodsImplicits.scala
@@ -144,6 +144,20 @@ object EthJsonMethodsImplicits extends JsonMethodsImplicits {
       Extraction.decompose(t.blockResponse)
   }
 
+  implicit val eth_getTransactionByHash =
+    new JsonDecoder[GetTransactionByHashRequest] with JsonEncoder[GetTransactionByHashResponse] {
+      override def decodeJson(params: Option[JArray]): Either[JsonRpcError, GetTransactionByHashRequest] = params match {
+        case Some(JArray(JString(txHash) :: Nil)) =>
+          for {
+            parsedTxHash <- extractHash(txHash)
+          } yield GetTransactionByHashRequest(parsedTxHash)
+        case _ => Left(InvalidParams())
+      }
+
+      override def encodeJson(t: GetTransactionByHashResponse): JValue =
+        Extraction.decompose(t.txResponse)
+    }
+
   implicit val eth_getTransactionByBlockHashAndIndex =
     new JsonDecoder[GetTransactionByBlockHashAndIndexRequest] with JsonEncoder[GetTransactionByBlockHashAndIndexResponse] {
       override def decodeJson(params: Option[JArray]): Either[JsonRpcError, GetTransactionByBlockHashAndIndexRequest] = params match {

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/EthService.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/EthService.scala
@@ -4,7 +4,6 @@ import java.time.Duration
 import java.util.Date
 import java.util.concurrent.atomic.AtomicReference
 import java.util.function.UnaryOperator
-
 import java.util.Date
 import java.util.concurrent.atomic.AtomicReference
 
@@ -17,6 +16,7 @@ import io.iohk.ethereum.db.storage.AppStateStorage
 import akka.util.ByteString
 import io.iohk.ethereum.blockchain.sync.SyncController.MinedBlock
 import io.iohk.ethereum.crypto._
+import io.iohk.ethereum.db.storage.TransactionMappingStorage.TransactionLocation
 import io.iohk.ethereum.keystore.KeyStore
 import io.iohk.ethereum.ledger.{InMemoryWorldStateProxy, Ledger}
 import io.iohk.ethereum.mining.BlockGenerator
@@ -65,6 +65,9 @@ object EthService {
 
   case class GetMiningRequest()
   case class GetMiningResponse(isMining: Boolean)
+
+  case class GetTransactionByHashRequest(txHash: ByteString)
+  case class GetTransactionByHashResponse(txResponse: Option[TransactionResponse])
 
   case class GetTransactionByBlockNumberAndIndexRequest(block: BlockParam, transactionIndex: BigInt)
   case class GetTransactionByBlockNumberAndIndexResponse(transactionResponse: Option[TransactionResponse])
@@ -204,6 +207,30 @@ class EthService(
       BlockResponse(block, totalDifficulty, fullTxs = fullTxs, pendingBlock = pending)
     }
     Right(BlockByNumberResponse(blockResponseOpt))
+  }
+
+  /**
+    * Implements the eth_getTransactionByHash method that fetches a requested tx.
+    * The tx requested will be fetched from the pending tx pool or from the already executed txs (depending on the tx state)
+    *
+    * @param req with the tx requested (by it's hash)
+    * @return the tx requested or None if the client doesn't have the tx
+    */
+  def getTransactionByHash(req: GetTransactionByHashRequest): ServiceResponse[GetTransactionByHashResponse] = {
+    val maybeTxPendingResponse: Future[Option[TransactionResponse]] = getTransactionsFromPool.map{
+      _.signedTransactions.find(_.hash == req.txHash).map(TransactionResponse(_)) }
+
+    val maybeTxResponse: Future[Option[TransactionResponse]] = maybeTxPendingResponse.flatMap{ txPending =>
+      Future { txPending.orElse{
+        for {
+          TransactionLocation(blockHash, txIndex) <- blockchain.getTransactionLocation(req.txHash)
+          Block(header, body) <- blockchain.getBlockByHash(blockHash)
+          stx <- body.transactionList.lift(txIndex)
+        } yield TransactionResponse(stx, Some(header), Some(txIndex))
+      }}
+    }
+
+    maybeTxResponse.map(txResponse => Right(GetTransactionByHashResponse(txResponse)))
   }
 
   /**

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/JsonRpcController.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/JsonRpcController.scala
@@ -136,6 +136,8 @@ class JsonRpcController(
       handle[GetStorageAtRequest, GetStorageAtResponse](ethService.getStorageAt, req)
     case req @ JsonRpcRequest(_, "eth_getTransactionCount", _, _) =>
       handle[GetTransactionCountRequest, GetTransactionCountResponse](ethService.getTransactionCount, req)
+    case req @ JsonRpcRequest(_, "eth_getTransactionByHash", _, _) =>
+      handle[GetTransactionByHashRequest, GetTransactionByHashResponse](ethService.getTransactionByHash, req)
   }
 
   private def handlePersonalRequest: PartialFunction[JsonRpcRequest, Future[JsonRpcResponse]] = {

--- a/src/test/scala/io/iohk/ethereum/db/storage/TransactionMappingStorageSuite.scala
+++ b/src/test/scala/io/iohk/ethereum/db/storage/TransactionMappingStorageSuite.scala
@@ -1,0 +1,56 @@
+package io.iohk.ethereum.db.storage
+
+import io.iohk.ethereum.ObjectGenerators
+import io.iohk.ethereum.db.dataSource.EphemDataSource
+import io.iohk.ethereum.db.storage.TransactionMappingStorage.TransactionLocation
+import org.scalacheck.Gen
+import org.scalatest.FunSuite
+import org.scalatest.prop.PropertyChecks
+
+class TransactionMappingStorageSuite extends FunSuite with PropertyChecks with ObjectGenerators {
+  test("TotalDifficultyStorage insert") {
+    forAll(Gen.listOf(byteStringOfLengthNGen(32))){ txByteArrayHashes =>
+      val txHashes = txByteArrayHashes.distinct
+      val blockHashesList = Gen.listOfN(txByteArrayHashes.length, byteStringOfLengthNGen(32)).sample.get
+      val txIndexList = Gen.listOfN(txByteArrayHashes.length, intGen).sample.get
+      val txLocationList = blockHashesList.zip(txIndexList).map{ case (blockHash, txIndex) =>
+        TransactionLocation(blockHash, txIndex) }
+
+      val initialTxMappingStorage = new TransactionMappingStorage(EphemDataSource())
+      val txMappingStorage = txHashes.zip(txLocationList).foldLeft(initialTxMappingStorage){
+        case (recTxMappingStorage, (txHash, txLocation)) =>
+          recTxMappingStorage.put(txHash, txLocation)
+      }
+
+      txHashes.zip(txLocationList).foreach{case (txHash, txLocation) => assert(txMappingStorage.get(txHash).contains(txLocation)) }
+    }
+  }
+
+  test("TotalDifficultyStorage delete") {
+    forAll(Gen.listOf(byteStringOfLengthNGen(32))){ txByteArrayHashes =>
+      val txHashes = txByteArrayHashes.distinct
+      val blockHashesList = Gen.listOfN(txByteArrayHashes.length, byteStringOfLengthNGen(32)).sample.get
+      val txIndexList = Gen.listOfN(txByteArrayHashes.length, intGen).sample.get
+      val txLocationList = blockHashesList.zip(txIndexList).map{ case (blockHash, txIndex) =>
+        TransactionLocation(blockHash, txIndex) }
+      val txHashAndLocationPair = txHashes.zip(txLocationList)
+
+      //Total difficulty of blocks is inserted
+      val initialTxMappingStorage = new TransactionMappingStorage(EphemDataSource())
+      val txMappingStorage = txHashAndLocationPair.foldLeft(initialTxMappingStorage){
+        case (recTxMappingStorage, (txHash, txLocation)) =>
+          recTxMappingStorage.put(txHash, txLocation)
+      }
+
+      //Total difficulty of blocks is deleted
+      val (toDelete, toLeave) = txHashAndLocationPair.splitAt(Gen.choose(0, txHashAndLocationPair.size).sample.get)
+      val txMappingStorageAfterDelete = toDelete.foldLeft(txMappingStorage){
+        case (recTxMappingStorage, (txHash, _)) =>
+          recTxMappingStorage.remove(txHash)
+      }
+
+      toLeave.foreach{case (txHash, txLocation) => assert(txMappingStorageAfterDelete.get(txHash).contains(txLocation)) }
+      toDelete.foreach{ case (txHash, _) => assert(txMappingStorageAfterDelete.get(txHash).isEmpty) }
+    }
+  }
+}

--- a/src/test/scala/io/iohk/ethereum/db/storage/TransactionMappingStorageSuite.scala
+++ b/src/test/scala/io/iohk/ethereum/db/storage/TransactionMappingStorageSuite.scala
@@ -8,7 +8,7 @@ import org.scalatest.FunSuite
 import org.scalatest.prop.PropertyChecks
 
 class TransactionMappingStorageSuite extends FunSuite with PropertyChecks with ObjectGenerators {
-  test("TotalDifficultyStorage insert") {
+  test("TransactionMappingStorage insert") {
     forAll(Gen.listOf(byteStringOfLengthNGen(32))){ txByteArrayHashes =>
       val txHashes = txByteArrayHashes.distinct
       val blockHashesList = Gen.listOfN(txByteArrayHashes.length, byteStringOfLengthNGen(32)).sample.get
@@ -26,7 +26,7 @@ class TransactionMappingStorageSuite extends FunSuite with PropertyChecks with O
     }
   }
 
-  test("TotalDifficultyStorage delete") {
+  test("TransactionMappingStorage delete") {
     forAll(Gen.listOf(byteStringOfLengthNGen(32))){ txByteArrayHashes =>
       val txHashes = txByteArrayHashes.distinct
       val blockHashesList = Gen.listOfN(txByteArrayHashes.length, byteStringOfLengthNGen(32)).sample.get
@@ -35,14 +35,14 @@ class TransactionMappingStorageSuite extends FunSuite with PropertyChecks with O
         TransactionLocation(blockHash, txIndex) }
       val txHashAndLocationPair = txHashes.zip(txLocationList)
 
-      //Total difficulty of blocks is inserted
+      //Mapping of tx to blocks is inserted
       val initialTxMappingStorage = new TransactionMappingStorage(EphemDataSource())
       val txMappingStorage = txHashAndLocationPair.foldLeft(initialTxMappingStorage){
         case (recTxMappingStorage, (txHash, txLocation)) =>
           recTxMappingStorage.put(txHash, txLocation)
       }
 
-      //Total difficulty of blocks is deleted
+      //Mapping of tx to blocks is deleted
       val (toDelete, toLeave) = txHashAndLocationPair.splitAt(Gen.choose(0, txHashAndLocationPair.size).sample.get)
       val txMappingStorageAfterDelete = toDelete.foldLeft(txMappingStorage){
         case (recTxMappingStorage, (txHash, _)) =>

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/EthServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/EthServiceSpec.scala
@@ -673,7 +673,7 @@ class EthServiceSpec extends FlatSpec with Matchers with ScalaFutures with MockF
     response.futureValue shouldEqual Right(GetTransactionCountResponse(BigInt(999)))
   }
 
-  it should "handle get transaction by hash if the tx is not on the blockchain" in new TestSetup {
+  it should "handle get transaction by hash if the tx is not on the blockchain and not in the tx pool" in new TestSetup {
     val request = GetTransactionByHashRequest(txToRequestHash)
     val response = ethService.getTransactionByHash(request)
 

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/EthServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/EthServiceSpec.scala
@@ -24,6 +24,7 @@ import io.iohk.ethereum.ledger.Ledger.TxResult
 import io.iohk.ethereum.ledger.{InMemoryWorldStateProxy, Ledger}
 import io.iohk.ethereum.mining.BlockGenerator
 import io.iohk.ethereum.mpt.{ByteArrayEncoder, ByteArraySerializable, HashByteArraySerializable, MerklePatriciaTrie}
+import io.iohk.ethereum.transactions.PendingTransactionsManager.PendingTransactions
 import io.iohk.ethereum.utils.BlockchainConfig
 import io.iohk.ethereum.validators.Validators
 import io.iohk.ethereum.vm.UInt256
@@ -656,6 +657,40 @@ class EthServiceSpec extends FlatSpec with Matchers with ScalaFutures with MockF
     response.futureValue shouldEqual Right(GetTransactionCountResponse(BigInt(999)))
   }
 
+  it should "handle get transaction by hash if the tx is not on the blockchain" in new TestSetup {
+    val request = GetTransactionByHashRequest(txToRequestHash)
+    val response = ethService.getTransactionByHash(request)
+
+    pendingTransactionsManager.expectMsg(PendingTransactionsManager.GetPendingTransactions)
+    pendingTransactionsManager.reply(PendingTransactions(Nil))
+
+    response.futureValue shouldEqual Right(GetTransactionByHashResponse(None))
+  }
+
+  it should "handle get transaction by hash if the tx is still pending" in new TestSetup {
+    val request = GetTransactionByHashRequest(txToRequestHash)
+    val response = ethService.getTransactionByHash(request)
+
+    pendingTransactionsManager.expectMsg(PendingTransactionsManager.GetPendingTransactions)
+    pendingTransactionsManager.reply(PendingTransactions(Seq(txToRequest)))
+
+    response.futureValue shouldEqual Right(GetTransactionByHashResponse(Some(TransactionResponse(txToRequest))))
+  }
+
+  it should "handle get transaction by hash if the tx was already executed" in new TestSetup {
+    val blockWithTx = Block(Fixtures.Blocks.Block3125369.header, Fixtures.Blocks.Block3125369.body)
+    blockchain.save(blockWithTx)
+
+    val request = GetTransactionByHashRequest(txToRequestHash)
+    val response = ethService.getTransactionByHash(request)
+
+    pendingTransactionsManager.expectMsg(PendingTransactionsManager.GetPendingTransactions)
+    pendingTransactionsManager.reply(PendingTransactions(Nil))
+
+    response.futureValue shouldEqual Right(GetTransactionByHashResponse(Some(
+      TransactionResponse(txToRequest, Some(blockWithTx.header), Some(0)))))
+  }
+
   trait TestSetup extends MockFactory {
     val storagesInstance = new SharedEphemDataSources with Storages.DefaultStorages
     val blockchain = BlockchainImpl(storagesInstance.storages)
@@ -717,6 +752,9 @@ class EthServiceSpec extends FlatSpec with Matchers with ScalaFutures with MockF
     val seedHash = ByteString(Hex.decode("00" * 32))
     val powHash = ByteString(Hex.decode("f5877d30b85d6cd0f80d2c4711e3cfb7d386e331f801f903d9ca52fc5e8f7cc2"))
     val target = ByteString((BigInt(2).pow(256) / difficulty).toByteArray)
+
+    val txToRequest = Fixtures.Blocks.Block3125369.body.transactionList.head
+    val txToRequestHash = txToRequest.hash
   }
 
 }


### PR DESCRIPTION
## Description

Includes the implementation of the `eth_getTransactionByHash` JSON RPC method.
In order to do so, a `TransactionMappingStorage` was created which stores the mapping `TxHash -> (BlockHash, TxIndex)`.