### PR TITLE
Basic Json Rpc batch requests support

### DIFF
--- a/src/main/scala/io/iohk/ethereum/jsonrpc/http/JsonRpcHttpServer.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/http/JsonRpcHttpServer.scala
@@ -33,10 +33,12 @@ class JsonRpcHttpServer(jsonRpcController: JsonRpcController, config: JsonRpcHtt
       .result()
 
   val route: Route = {
-    (pathEndOrSingleSlash & post & entity(as[JsonRpcRequest])) { request =>
-      handleRequest(request)
-    } ~ (pathEndOrSingleSlash & post & entity(as[Seq[JsonRpcRequest]])) { request =>
-      handleBatchRequest(request)
+    (pathEndOrSingleSlash & post) {
+      entity(as[JsonRpcRequest]) { request =>
+        handleRequest(request)
+      } ~ entity(as[Seq[JsonRpcRequest]]) { request =>
+        handleBatchRequest(request)
+      }
     }
   }
 


### PR DESCRIPTION
## Description

While testing using Mist I've found that there are a lot batch requests being performed even if this is not stated it must be supported by clients in documentation. 

After implementing it, Mist stopped throwing errors and noticed some fixes. For example: accounts and balances are updated when added or mining.

### Notes
- It's a basic implementation but seems to be working as parity does. 
- It doesn't check if two requests with same Id are sent in the same batch request (parity doesn't neither). Same case if the items within the batch array are the same
- Does not implement any limit / restriction on the amount of items a batch request might contain. Maybe we need to create a new task for this