### PR TITLE
Fixes in eth_estimateGas

### DIFF
--- a/src/main/scala/io/iohk/ethereum/jsonrpc/EthJsonMethodsImplicits.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/EthJsonMethodsImplicits.scala
@@ -272,36 +272,19 @@ object EthJsonMethodsImplicits extends JsonMethodsImplicits {
       }
 
     def encodeJson(t: CallResponse): JValue = encodeAsHex(t.returnData)
-
-    def extractCall(obj: JObject): Either[JsonRpcError, CallTx] = {
-      def toEitherOpt[A, B](opt: Option[Either[A, B]]): Either[A, Option[B]] =
-        opt.map(_.right.map(Some.apply)).getOrElse(Right(None))
-
-      def optionalQuantity(input: JValue): Either[JsonRpcError, Option[BigInt]] =
-        input match {
-          case JNothing => Right(None)
-          case o => extractQuantity(o).map(Some(_))
-        }
-
-      for {
-        from <- toEitherOpt((obj \ "from").extractOpt[String].map(extractBytes))
-        to <- toEitherOpt((obj \ "to").extractOpt[String].map(extractBytes))
-        gas <- optionalQuantity(obj \ "gas")
-        gasPrice <- optionalQuantity(obj \ "gasPrice")
-        value <- optionalQuantity(obj \ "value")
-        data <- toEitherOpt((obj \ "data").extractOpt[String].map(extractBytes))
-      } yield CallTx(
-        from = from,
-        to = to,
-        gas = gas,
-        gasPrice = gasPrice.getOrElse(0),
-        value = value.getOrElse(0),
-        data = data.getOrElse(ByteString("")))
-    }
   }
 
-  implicit val eth_estimateGas = new JsonEncoder[EstimateGasResponse] {
+  implicit val eth_estimateGas = new JsonDecoder[CallRequest] with JsonEncoder[EstimateGasResponse] {
     override def encodeJson(t: EstimateGasResponse): JValue = encodeAsHex(t.gas)
+
+    override def decodeJson(params: Option[JArray]): Either[JsonRpcError, CallRequest] =
+      withoutBlockParam.applyOrElse(params, eth_call.decodeJson)
+
+    def withoutBlockParam: PartialFunction[Option[JArray], Either[JsonRpcError, CallRequest]] = {
+      case Some(JArray((txObj: JObject) :: Nil)) =>
+        extractCall(txObj).map(CallRequest(_, BlockParam.Latest))
+    }
+
   }
 
   implicit val eth_getCode = new JsonDecoder[GetCodeRequest] with JsonEncoder[GetCodeResponse] {
@@ -412,6 +395,32 @@ object EthJsonMethodsImplicits extends JsonMethodsImplicits {
         case _ =>
           Left(InvalidParams())
       }
+  }
+
+  def extractCall(obj: JObject): Either[JsonRpcError, CallTx] = {
+    def toEitherOpt[A, B](opt: Option[Either[A, B]]): Either[A, Option[B]] =
+      opt.map(_.right.map(Some.apply)).getOrElse(Right(None))
+
+    def optionalQuantity(input: JValue): Either[JsonRpcError, Option[BigInt]] =
+      input match {
+        case JNothing => Right(None)
+        case o => extractQuantity(o).map(Some(_))
+      }
+
+    for {
+      from <- toEitherOpt((obj \ "from").extractOpt[String].map(extractBytes))
+      to <- toEitherOpt((obj \ "to").extractOpt[String].map(extractBytes))
+      gas <- optionalQuantity(obj \ "gas")
+      gasPrice <- optionalQuantity(obj \ "gasPrice")
+      value <- optionalQuantity(obj \ "value")
+      data <- toEitherOpt((obj \ "data").extractOpt[String].map(extractBytes))
+    } yield CallTx(
+      from = from,
+      to = to,
+      gas = gas,
+      gasPrice = gasPrice.getOrElse(0),
+      value = value.getOrElse(0),
+      data = data.getOrElse(ByteString("")))
   }
 
 }

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/JsonMethodsImplicits.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/JsonMethodsImplicits.scala
@@ -38,7 +38,7 @@ trait JsonMethodsImplicits {
     }.toEither.left.map(_ => InvalidParams())
 
   private def decode(s: String): Either[JsonRpcError, Array[Byte]] = {
-    if(!s.startsWith("0x")) Left(InvalidParams())
+    if(!s.isEmpty && !s.startsWith("0x")) Left(InvalidParams())
     else decodeWithoutHexPrefix(s.drop("0x".length))
   }
 

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/JsonRpcController.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/JsonRpcController.scala
@@ -125,9 +125,9 @@ class JsonRpcController(
     case req @ JsonRpcRequest(_, "eth_sendTransaction", _, _) =>
       handle[SendTransactionRequest, SendTransactionResponse](personalService.sendTransaction, req)
     case req @ JsonRpcRequest(_, "eth_call", _, _) =>
-      handle[CallRequest, CallResponse](ethService.call, req)
+      handle[CallRequest, CallResponse](ethService.call, req)(eth_call, eth_call)
     case req @ JsonRpcRequest(_, "eth_estimateGas", _, _) =>
-      handle[CallRequest, EstimateGasResponse](ethService.estimateGas, req)
+      handle[CallRequest, EstimateGasResponse](ethService.estimateGas, req)(eth_estimateGas, eth_estimateGas)
     case req @ JsonRpcRequest(_, "eth_getCode", _, _) =>
       handle[GetCodeRequest, GetCodeResponse](ethService.getCode, req)
     case req @ JsonRpcRequest(_, "eth_getUncleCountByBlockNumber", _, _) =>

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerSpec.scala
@@ -28,6 +28,7 @@ import org.json4s.JsonAST._
 import org.json4s.JsonDSL._
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
+import org.scalatest.prop.PropertyChecks
 import org.scalatest.{FlatSpec, Matchers}
 import org.spongycastle.util.encoders.Hex
 
@@ -35,7 +36,7 @@ import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
 
 // scalastyle:off file.size.limit
-class JsonRpcControllerSpec extends FlatSpec with Matchers with ScalaFutures with DefaultPatience with Eventually {
+class JsonRpcControllerSpec extends FlatSpec with Matchers with PropertyChecks with ScalaFutures with DefaultPatience with Eventually {
 
   implicit val formats: Formats = DefaultFormats.preservingEmptyValues + OptionNoneToJNullSerializer +
     QuantitiesSerializer + UnformattedDataJsonSerializer
@@ -623,26 +624,35 @@ class JsonRpcControllerSpec extends FlatSpec with Matchers with ScalaFutures wit
     val mockEthService = mock[EthService]
     override val jsonRpcController = new JsonRpcController(web3Service, netService, mockEthService, personalService, config)
 
-    (mockEthService.estimateGas _).expects(*).returning(Future.successful(Right(EstimateGasResponse(2310))))
+    (mockEthService.estimateGas _).expects(*).anyNumberOfTimes().returning(Future.successful(Right(EstimateGasResponse(2310))))
 
-    val json = JArray(List(
-      JObject(
-        "from" -> "0xabbb6bebfa05aa13e908eaa492bd7a8343760477",
-        "to" -> "0xda714fe079751fa7a1ad80b76571ea6ec52a446c",
-        "gas" -> "0x12",
-        "gasPrice" -> "0x123",
-        "value" -> "0x99",
-        "data" -> "0xFF44"
-      ),
-      JString("latest")
-    ))
-    val rpcRequest = JsonRpcRequest("2.0", "eth_estimateGas", Some(json), Some(1))
-    val response = jsonRpcController.handleRequest(rpcRequest).futureValue
+    val callObj = JObject(
+      "from" -> "0xabbb6bebfa05aa13e908eaa492bd7a8343760477",
+      "to" -> "0xda714fe079751fa7a1ad80b76571ea6ec52a446c",
+      "gas" -> "0x12",
+      "gasPrice" -> "0x123",
+      "value" -> "0x99",
+      "data" -> "0xFF44"
+    )
+    val callObjWithoutData = callObj.replace(List("data"), "")
 
-    response.jsonrpc shouldBe "2.0"
-    response.id shouldBe JInt(1)
-    response.error shouldBe None
-    response.result shouldBe Some(JString("0x906"))
+    val table = Table(
+      "Requests",
+      JArray(List(callObj, JString("latest"))),
+      JArray(List(callObj)),
+      JArray(List(callObjWithoutData))
+    )
+
+    forAll(table) { json =>
+      val rpcRequest = JsonRpcRequest("2.0", "eth_estimateGas", Some(json), Some(1))
+      val response = jsonRpcController.handleRequest(rpcRequest).futureValue
+
+      response.jsonrpc shouldBe "2.0"
+      response.id shouldBe JInt(1)
+      response.error shouldBe None
+      response.result shouldBe Some(JString("0x906"))
+    }
+
   }
 
   it should "eth_getCode" in new TestSetup {


### PR DESCRIPTION
## Description

When testing using Mist, the following requests are performed to `eth_estimateGas` endpoint and weren't supported by our implementation:

- Optional block parameter: `{"jsonrpc":"2.0","id":"6aed168f-91b6-485f-8ac1-86969de52e49","method":"eth_estimateGas","params":[{"from":"0xa797e6b221246a61141c7d04dfe2047e5b3ba620","to":"0x480d874B16C952efC6584F7A61bf3E8c38e39EDd","value":"0x578c6b4cf1583a8000","data":"0xaaaa","gas":"0x4c4b40"}]}`
- Allow data to be sent as "": `{"jsonrpc":"2.0","id":"6aed168f-91b6-485f-8ac1-86969de52e49","method":"eth_estimateGas","params":[{"from":"0xa797e6b221246a61141c7d04dfe2047e5b3ba620","to":"0x480d874B16C952efC6584F7A61bf3E8c38e39EDd","value":"0x578c6b4cf1583a8000","data":"","gas":"0x4c4b40"}, "latest"]}`