### PR TITLE
[EC-210] Fix negative blocks left (Mist)

### DIFF
--- a/src/main/scala/io/iohk/ethereum/jsonrpc/EthJsonMethodsImplicits.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/EthJsonMethodsImplicits.scala
@@ -246,7 +246,10 @@ object EthJsonMethodsImplicits extends JsonMethodsImplicits {
   implicit val eth_syncing = new JsonDecoder[SyncingRequest] with JsonEncoder[SyncingResponse] {
     def decodeJson(params: Option[JArray]): Either[JsonRpcError, SyncingRequest] = Right(SyncingRequest())
 
-    def encodeJson(t: SyncingResponse): JValue = Extraction.decompose(t)
+    def encodeJson(t: SyncingResponse): JValue = t.syncStatus match {
+      case Some(syncStatus) => Extraction.decompose(syncStatus)
+      case None => false
+    }
   }
 
   implicit val eth_sendRawTransaction = new JsonDecoder[SendRawTransactionRequest] with JsonEncoder[SendRawTransactionResponse] {

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/EthServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/EthServiceSpec.scala
@@ -331,17 +331,26 @@ class EthServiceSpec extends FlatSpec with Matchers with ScalaFutures with MockF
     response.uncleBlockResponse.get.uncles shouldBe Nil
   }
 
-  it should "return syncing info" in new TestSetup {
+  it should "return syncing info if the peer is syncing" in new TestSetup {
     (appStateStorage.getSyncStartingBlock _).expects().returning(999)
     (appStateStorage.getEstimatedHighestBlock _).expects().returning(10000)
     (appStateStorage.getBestBlockNumber _).expects().returning(200)
     val response = ethService.syncing(SyncingRequest()).futureValue.right.get
 
-    response shouldEqual SyncingResponse(
+    response shouldEqual SyncingResponse(Some(EthService.SyncingStatus(
       startingBlock = 999,
       currentBlock = 200,
       highestBlock = 10000
-    )
+    )))
+  }
+
+  it should "return no syncing info if the peer is not syncing" in new TestSetup {
+    (appStateStorage.getSyncStartingBlock _).expects().returning(999)
+    (appStateStorage.getEstimatedHighestBlock _).expects().returning(1000)
+    (appStateStorage.getBestBlockNumber _).expects().returning(1000)
+    val response = ethService.syncing(SyncingRequest()).futureValue.right.get
+
+    response shouldEqual SyncingResponse(None)
   }
 
   it should "return requested work" in new TestSetup {


### PR DESCRIPTION
## Description
If the network consists of only our node, we are currently getting messages like -200 blocks left on Mist for synchronization, which is caused by our highest block estimation using only `NewBlocks` messages received from other peers, and this information is not available when our node is the only one.

## Fix
Changed `eth_syncing` implementation to return that our node is not syncing when the highest estimated block (from peer information) is less or equal to the best block on our node.