### PR TITLE
[EC-184] Pending block parameter

### DIFF
--- a/src/main/scala/io/iohk/ethereum/jsonrpc/EthService.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/EthService.scala
@@ -486,13 +486,15 @@ class EthService(
 
   def submitWork(req: SubmitWorkRequest): ServiceResponse[SubmitWorkResponse] = {
     reportActive()
-    blockGenerator.getPrepared(req.powHeaderHash) match {
-      case Some(pendingBlock) if appStateStorage.getBestBlockNumber() <= pendingBlock.block.header.number =>
-        import pendingBlock._
-        syncingController ! MinedBlock(block.copy(header = block.header.copy(nonce = req.nonce, mixHash = req.mixHash)))
-        Future.successful(Right(SubmitWorkResponse(true)))
-      case _ =>
-        Future.successful(Right(SubmitWorkResponse(false)))
+    Future {
+      blockGenerator.getPrepared(req.powHeaderHash) match {
+        case Some(pendingBlock) if appStateStorage.getBestBlockNumber() <= pendingBlock.block.header.number =>
+          import pendingBlock._
+          syncingController ! MinedBlock(block.copy(header = block.header.copy(nonce = req.nonce, mixHash = req.mixHash)))
+          Right(SubmitWorkResponse(true))
+        case _ =>
+          Right(SubmitWorkResponse(false))
+      }
     }
   }
 

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/EthService.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/EthService.scala
@@ -692,7 +692,10 @@ class EthService(
       case BlockParam.WithNumber(blockNumber) => getBlock(blockNumber).map(ResolvedBlock(_, pending = false))
       case BlockParam.Earliest => getBlock(0).map(ResolvedBlock(_, pending = false))
       case BlockParam.Latest => getBlock(appStateStorage.getBestBlockNumber()).map(ResolvedBlock(_, pending = false))
-      case BlockParam.Pending => getBlock(appStateStorage.getBestBlockNumber()).map(ResolvedBlock(_, pending = true))
+      case BlockParam.Pending =>
+        blockGenerator.getPending.map(ResolvedBlock(_, pending = true))
+          .map(Right.apply)
+          .getOrElse(resolveBlock(BlockParam.Latest))
     }
   }
 

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/FilterManager.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/FilterManager.scala
@@ -7,6 +7,8 @@ import io.iohk.ethereum.domain._
 import io.iohk.ethereum.jsonrpc.EthService.BlockParam
 import io.iohk.ethereum.keystore.KeyStore
 import io.iohk.ethereum.ledger.BloomFilter
+import io.iohk.ethereum.mining.BlockGenerator
+import io.iohk.ethereum.network.p2p.messages.PV62.BlockBody
 import io.iohk.ethereum.transactions.PendingTransactionsManager
 import io.iohk.ethereum.transactions.PendingTransactionsManager.PendingTransaction
 import io.iohk.ethereum.utils.FilterConfig
@@ -19,6 +21,7 @@ import scala.util.Random
 
 class FilterManager(
     blockchain: Blockchain,
+    blockGenerator: BlockGenerator,
     appStateStorage: AppStateStorage,
     keyStore: KeyStore,
     pendingTransactionsManager: ActorRef,
@@ -114,9 +117,13 @@ class FilterManager(
         logsSoFar
       } else {
         blockchain.getBlockHeaderByNumber(currentBlockNumber) match {
-          case Some(blockHeader) if bytesToCheckInBloomFilter.isEmpty || BloomFilter.containsAnyOf(blockHeader.logsBloom, bytesToCheckInBloomFilter) =>
-            blockchain.getReceiptsByHash(blockHeader.hash) match {
-              case Some(receipts) => recur(currentBlockNumber + 1, toBlockNumber, logsSoFar ++ getLogsFromBlock(filter, blockHeader, receipts))
+          case Some(header) if bytesToCheckInBloomFilter.isEmpty || BloomFilter.containsAnyOf(header.logsBloom, bytesToCheckInBloomFilter) =>
+            blockchain.getReceiptsByHash(header.hash) match {
+              case Some(receipts) => recur(
+                currentBlockNumber + 1,
+                toBlockNumber,
+                logsSoFar ++ getLogsFromBlock(filter, Block(header, blockchain.getBlockBodyByHash(header.hash).get), receipts)
+              )
               case None => logsSoFar
             }
           case Some(_) => recur(currentBlockNumber + 1, toBlockNumber, logsSoFar)
@@ -125,13 +132,19 @@ class FilterManager(
       }
     }
 
+    val bestBlockNumber = appStateStorage.getBestBlockNumber()
+
     val fromBlockNumber =
-      startingBlockNumber.getOrElse(resolveBlockNumber(filter.fromBlock.getOrElse(BlockParam.Latest), appStateStorage))
+      startingBlockNumber.getOrElse(resolveBlockNumber(filter.fromBlock.getOrElse(BlockParam.Latest), bestBlockNumber))
 
     val toBlockNumber =
-      resolveBlockNumber(filter.toBlock.getOrElse(BlockParam.Latest), appStateStorage)
+      resolveBlockNumber(filter.toBlock.getOrElse(BlockParam.Latest), bestBlockNumber)
 
-    recur(fromBlockNumber, toBlockNumber, Nil)
+    val logs = recur(fromBlockNumber, toBlockNumber, Nil)
+
+    if(filter.toBlock.contains(BlockParam.Pending))
+      logs ++ blockGenerator.getPending.map(p => getLogsFromBlock(filter, p.block, p.receipts)).getOrElse(Nil)
+    else logs
   }
 
   private def getFilterChanges(id: BigInt): Unit = {
@@ -164,7 +177,7 @@ class FilterManager(
     }
   }
 
-  private def getLogsFromBlock(filter: LogFilter, blockHeader: BlockHeader, receipts: Seq[Receipt]): Seq[Log] = {
+  private def getLogsFromBlock(filter: LogFilter, block: Block, receipts: Seq[Receipt]): Seq[Log] = {
     val bytesToCheckInBloomFilter = filter.address.map(a => Seq(a.bytes)).getOrElse(Nil) ++ filter.topics.flatten
 
     receipts.zipWithIndex.foldLeft(Seq[Log]()) { case (logsSoFar, (receipt, txIndex)) =>
@@ -172,14 +185,13 @@ class FilterManager(
         logsSoFar ++ receipt.logs.zipWithIndex
         .filter { case (log, _) => filter.address.forall(_ == log.loggerAddress) && topicsMatch(log.logTopics, filter.topics) }
         .map { case (log, logIndex) =>
-          val blockBody = blockchain.getBlockBodyByHash(blockHeader.hash).get
-          val tx = blockBody.transactionList(txIndex)
+          val tx = block.body.transactionList(txIndex)
           Log(
             logIndex = logIndex,
             transactionIndex = txIndex,
             transactionHash = tx.hash,
-            blockHash = blockHeader.hash,
-            blockNumber = blockHeader.number,
+            blockHash = block.header.hash,
+            blockNumber = block.header.number,
             address = log.loggerAddress,
             data = log.data,
             topics = log.logTopics)
@@ -223,23 +235,24 @@ class FilterManager(
 
   private def generateId(): BigInt = Math.abs(Random.nextLong())
 
-  private def resolveBlockNumber(blockParam: BlockParam, appStateStorage: AppStateStorage): BigInt = {
+  private def resolveBlockNumber(blockParam: BlockParam, bestBlockNumber: BigInt): BigInt = {
     blockParam match {
       case BlockParam.WithNumber(blockNumber) => blockNumber
       case BlockParam.Earliest => 0
-      case BlockParam.Latest => appStateStorage.getBestBlockNumber()
-      case BlockParam.Pending => appStateStorage.getBestBlockNumber() + 1
+      case BlockParam.Latest => bestBlockNumber
+      case BlockParam.Pending => bestBlockNumber
     }
   }
 }
 
 object FilterManager {
   def props(blockchain: Blockchain,
+            blockGenerator: BlockGenerator,
             appStateStorage: AppStateStorage,
             keyStore: KeyStore,
             pendingTransactionsManager: ActorRef,
             config: FilterConfig): Props =
-    Props(new FilterManager(blockchain, appStateStorage, keyStore, pendingTransactionsManager, config))
+    Props(new FilterManager(blockchain, blockGenerator, appStateStorage, keyStore, pendingTransactionsManager, config))
 
   sealed trait Filter {
     def id: BigInt

--- a/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
@@ -180,13 +180,23 @@ trait PendingTransactionsManagerBuilder {
 trait FilterManagerBuilder {
   self: ActorSystemBuilder
     with BlockChainBuilder
+    with BlockGeneratorBuilder
     with StorageBuilder
     with KeyStoreBuilder
     with PendingTransactionsManagerBuilder
     with FilterConfigBuilder =>
 
   lazy val filterManager: ActorRef =
-    actorSystem.actorOf(FilterManager.props(blockchain, storagesInstance.storages.appStateStorage, keyStore, pendingTransactionsManager, filterConfig))
+    actorSystem.actorOf(
+      FilterManager.props(
+        blockchain,
+        blockGenerator,
+        storagesInstance.storages.appStateStorage,
+        keyStore,
+        pendingTransactionsManager,
+        filterConfig
+      )
+    )
 }
 
 trait BlockGeneratorBuilder {

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/EthServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/EthServiceSpec.scala
@@ -112,7 +112,7 @@ class EthServiceSpec extends FlatSpec with Matchers with ScalaFutures with MockF
     (blockGenerator.getPending _).expects().returns(Some(PendingBlock(blockToRequest, Nil)))
 
     val request = BlockByNumberRequest(BlockParam.Pending, fullTxs = true)
-    val response = Await.result(ethService.getBlockByNumber(request), Duration.Inf).right.get
+    val response = ethService.getBlockByNumber(request).futureValue.right.get
 
     response.blockResponse.isDefined should be (true)
     val blockResponse = response.blockResponse.get
@@ -132,7 +132,7 @@ class EthServiceSpec extends FlatSpec with Matchers with ScalaFutures with MockF
     (appStateStorage.getBestBlockNumber _).expects().returning(blockToRequest.header.number)
 
     val request = BlockByNumberRequest(BlockParam.Pending, fullTxs = true)
-    val response = Await.result(ethService.getBlockByNumber(request), Duration.Inf).right.get
+    val response = ethService.getBlockByNumber(request).futureValue.right.get
     response.blockResponse.get.hash.get shouldEqual blockToRequest.header.hash
   }
 

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/FilterManagerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/FilterManagerSpec.scala
@@ -16,6 +16,7 @@ import io.iohk.ethereum.DefaultPatience
 import io.iohk.ethereum.crypto.ECDSASignature
 import io.iohk.ethereum.jsonrpc.FilterManager.LogFilterLogs
 import io.iohk.ethereum.ledger.BloomFilter
+import io.iohk.ethereum.mining.{BlockGenerator, PendingBlock}
 import io.iohk.ethereum.network.p2p.messages.PV62.BlockBody
 import io.iohk.ethereum.transactions.PendingTransactionsManager
 import io.iohk.ethereum.transactions.PendingTransactionsManager.PendingTransaction
@@ -29,7 +30,15 @@ class FilterManagerSpec extends FlatSpec with Matchers with ScalaFutures with De
   implicit val timeout = Timeout(5.seconds)
 
   "FilterManager" should "handle log filter logs and changes" in new TestSetup {
-    val filterManager = TestActorRef[FilterManager](Props(new FilterManager(blockchain, appStateStorage, keyStore, pendingTransactionsManager.ref, config, Some(time.scheduler))))
+    val filterManager = TestActorRef[FilterManager](Props(new FilterManager(
+      blockchain,
+      blockGenerator,
+      appStateStorage,
+      keyStore,
+      pendingTransactionsManager.ref,
+      config,
+      Some(time.scheduler)))
+    )
 
     val address = Address("0x1234")
     val topics = Seq(Seq(), Seq(ByteString(Hex.decode("4567"))))
@@ -55,9 +64,9 @@ class FilterManagerSpec extends FlatSpec with Matchers with ScalaFutures with De
       logsBloom = BloomFilter.create(Nil))
 
     (appStateStorage.getBestBlockNumber _).expects().returning(3).twice()
-    (blockchain.getBlockHeaderByNumber _).expects(BigInt(1)).returning(Some(bh1))
-    (blockchain.getBlockHeaderByNumber _).expects(BigInt(2)).returning(Some(bh2))
-    (blockchain.getBlockHeaderByNumber _).expects(BigInt(3)).returning(Some(bh3))
+    (blockchain.getBlockHeaderByNumber _).expects(bh1.number).returning(Some(bh1))
+    (blockchain.getBlockHeaderByNumber _).expects(bh2.number).returning(Some(bh2))
+    (blockchain.getBlockHeaderByNumber _).expects(bh3.number).returning(Some(bh3))
 
     val bb2 = BlockBody(
       transactionList = Seq(SignedTransaction(
@@ -159,8 +168,112 @@ class FilterManagerSpec extends FlatSpec with Matchers with ScalaFutures with De
     changesResp2.logs.size shouldBe 1
   }
 
+  it should "handle pending block filter" in new TestSetup {
+    val filterManager = TestActorRef[FilterManager](Props(new FilterManager(
+      blockchain,
+      blockGenerator,
+      appStateStorage,
+      keyStore,
+      pendingTransactionsManager.ref,
+      config,
+      Some(time.scheduler)))
+    )
+
+    val address = Address("0x1234")
+    val topics = Seq(Seq(), Seq(ByteString(Hex.decode("4567"))))
+
+    (appStateStorage.getBestBlockNumber _).expects().returning(3)
+
+    val createResp =
+      (filterManager ? FilterManager.NewLogFilter(Some(BlockParam.WithNumber(1)), Some(BlockParam.Pending), Some(address), topics))
+        .mapTo[FilterManager.NewFilterResponse].futureValue
+
+    val logs = Seq(TxLogEntry(Address("0x1234"), Seq(ByteString("can be any"), ByteString(Hex.decode("4567"))), ByteString(Hex.decode("99aaff"))))
+    val bh = blockHeader.copy(
+      number = 1,
+      logsBloom = BloomFilter.create(logs))
+
+    (appStateStorage.getBestBlockNumber _).expects().returning(1).anyNumberOfTimes()
+    (blockchain.getBlockHeaderByNumber _).expects(bh.number).returning(Some(bh))
+    val bb = BlockBody(
+      transactionList = Seq(SignedTransaction(
+        tx = Transaction(
+          nonce = 0,
+          gasPrice = 123,
+          gasLimit = 123,
+          receivingAddress = Address("0x1234"),
+          value = 0,
+          payload = ByteString()),
+        signature = ECDSASignature(0, 0, 0.toByte),
+        senderAddress = Address("0x0099"))),
+      uncleNodesList = Nil)
+
+    (blockchain.getBlockBodyByHash _).expects(bh.hash).returning(Some(bb))
+    (blockchain.getReceiptsByHash _).expects(bh.hash).returning(Some(Seq(Receipt(
+      postTransactionStateHash = ByteString(),
+      cumulativeGasUsed = 0,
+      logsBloomFilter = BloomFilter.create(logs),
+      logs = logs))))
+
+
+
+    val logs2 = Seq(TxLogEntry(Address("0x1234"), Seq(ByteString("another log"), ByteString(Hex.decode("4567"))), ByteString(Hex.decode("99aaff"))))
+    val bh2 = blockHeader.copy(
+      number = 2,
+      logsBloom = BloomFilter.create(logs2))
+    val blockTransactions2 = Seq(SignedTransaction(
+      tx = Transaction(
+        nonce = 0,
+        gasPrice = 321,
+        gasLimit = 321,
+        receivingAddress = Address("0x1234"),
+        value = 0,
+        payload = ByteString()),
+      signature = ECDSASignature(0, 0, 0.toByte),
+      senderAddress = Address("0x9900"))
+    )
+    val block2 = Block(bh2, BlockBody(blockTransactions2, Nil))
+    (blockGenerator.getPending _).expects().returning(Some(
+      PendingBlock(
+        block2,
+        Seq(Receipt(
+            postTransactionStateHash = ByteString(),
+            cumulativeGasUsed = 0,
+            logsBloomFilter = BloomFilter.create(logs2),
+            logs = logs2)
+          )
+        )
+      )
+    )
+
+    val logsResp =
+      (filterManager ? FilterManager.GetFilterLogs(createResp.id))
+        .mapTo[FilterManager.LogFilterLogs].futureValue
+
+    logsResp.logs.size shouldBe 2
+    logsResp.logs.head shouldBe FilterManager.Log(
+      logIndex = 0,
+      transactionIndex = 0,
+      transactionHash = bb.transactionList.head.hash,
+      blockHash = bh.hash,
+      blockNumber = bh.number,
+      address = Address(0x1234),
+      data = ByteString(Hex.decode("99aaff")),
+      topics = logs.head.logTopics)
+
+    logsResp.logs(1) shouldBe FilterManager.Log(
+      logIndex = 0,
+      transactionIndex = 0,
+      transactionHash = block2.body.transactionList.head.hash,
+      blockHash = block2.header.hash,
+      blockNumber = block2.header.number,
+      address = Address(0x1234),
+      data = ByteString(Hex.decode("99aaff")),
+      topics = logs2.head.logTopics)
+  }
+
   it should "handle block filter" in new TestSetup {
-    val filterManager = TestActorRef[FilterManager](Props(new FilterManager(blockchain, appStateStorage, keyStore, pendingTransactionsManager.ref, config, Some(time.scheduler))))
+    val filterManager = TestActorRef[FilterManager](Props(new FilterManager(blockchain, blockGenerator, appStateStorage, keyStore, pendingTransactionsManager.ref, config, Some(time.scheduler))))
 
     (appStateStorage.getBestBlockNumber _).expects().returning(3).twice()
 
@@ -194,7 +307,7 @@ class FilterManagerSpec extends FlatSpec with Matchers with ScalaFutures with De
   }
 
   it should "handle pending transactions filter" in new TestSetup {
-    val filterManager = TestActorRef[FilterManager](Props(new FilterManager(blockchain, appStateStorage, keyStore, pendingTransactionsManager.ref, config, Some(time.scheduler))))
+    val filterManager = TestActorRef[FilterManager](Props(new FilterManager(blockchain, blockGenerator, appStateStorage, keyStore, pendingTransactionsManager.ref, config, Some(time.scheduler))))
 
     (appStateStorage.getBestBlockNumber _).expects().returning(3).twice()
 
@@ -232,7 +345,7 @@ class FilterManagerSpec extends FlatSpec with Matchers with ScalaFutures with De
   }
 
   it should "timeout unused filter" in new TestSetup {
-    val filterManager = TestActorRef[FilterManager](Props(new FilterManager(blockchain, appStateStorage, keyStore, pendingTransactionsManager.ref, config, Some(time.scheduler))))
+    val filterManager = TestActorRef[FilterManager](Props(new FilterManager(blockchain, blockGenerator, appStateStorage, keyStore, pendingTransactionsManager.ref, config, Some(time.scheduler))))
 
     (appStateStorage.getBestBlockNumber _).expects().returning(3).twice()
 
@@ -295,6 +408,7 @@ class FilterManagerSpec extends FlatSpec with Matchers with ScalaFutures with De
     val blockchain = mock[Blockchain]
     val appStateStorage = mock[AppStateStorage]
     val keyStore = mock[KeyStore]
+    val blockGenerator = mock[BlockGenerator]
     val pendingTransactionsManager = TestProbe()
 
     val blockHeader = BlockHeader(

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/FilterManagerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/FilterManagerSpec.scala
@@ -30,15 +30,6 @@ class FilterManagerSpec extends FlatSpec with Matchers with ScalaFutures with De
   implicit val timeout = Timeout(5.seconds)
 
   "FilterManager" should "handle log filter logs and changes" in new TestSetup {
-    val filterManager = TestActorRef[FilterManager](Props(new FilterManager(
-      blockchain,
-      blockGenerator,
-      appStateStorage,
-      keyStore,
-      pendingTransactionsManager.ref,
-      config,
-      Some(time.scheduler)))
-    )
 
     val address = Address("0x1234")
     val topics = Seq(Seq(), Seq(ByteString(Hex.decode("4567"))))
@@ -169,15 +160,6 @@ class FilterManagerSpec extends FlatSpec with Matchers with ScalaFutures with De
   }
 
   it should "handle pending block filter" in new TestSetup {
-    val filterManager = TestActorRef[FilterManager](Props(new FilterManager(
-      blockchain,
-      blockGenerator,
-      appStateStorage,
-      keyStore,
-      pendingTransactionsManager.ref,
-      config,
-      Some(time.scheduler)))
-    )
 
     val address = Address("0x1234")
     val topics = Seq(Seq(), Seq(ByteString(Hex.decode("4567"))))
@@ -273,7 +255,6 @@ class FilterManagerSpec extends FlatSpec with Matchers with ScalaFutures with De
   }
 
   it should "handle block filter" in new TestSetup {
-    val filterManager = TestActorRef[FilterManager](Props(new FilterManager(blockchain, blockGenerator, appStateStorage, keyStore, pendingTransactionsManager.ref, config, Some(time.scheduler))))
 
     (appStateStorage.getBestBlockNumber _).expects().returning(3).twice()
 
@@ -307,7 +288,6 @@ class FilterManagerSpec extends FlatSpec with Matchers with ScalaFutures with De
   }
 
   it should "handle pending transactions filter" in new TestSetup {
-    val filterManager = TestActorRef[FilterManager](Props(new FilterManager(blockchain, blockGenerator, appStateStorage, keyStore, pendingTransactionsManager.ref, config, Some(time.scheduler))))
 
     (appStateStorage.getBestBlockNumber _).expects().returning(3).twice()
 
@@ -345,7 +325,6 @@ class FilterManagerSpec extends FlatSpec with Matchers with ScalaFutures with De
   }
 
   it should "timeout unused filter" in new TestSetup {
-    val filterManager = TestActorRef[FilterManager](Props(new FilterManager(blockchain, blockGenerator, appStateStorage, keyStore, pendingTransactionsManager.ref, config, Some(time.scheduler))))
 
     (appStateStorage.getBestBlockNumber _).expects().returning(3).twice()
 
@@ -427,6 +406,18 @@ class FilterManagerSpec extends FlatSpec with Matchers with ScalaFutures with De
       extraData = ByteString(Hex.decode("426974636f696e2069732054484520426c6f636b636861696e2e")),
       mixHash = ByteString(Hex.decode("c6d695926546d3d679199303a6d1fc983fe3f09f44396619a24c4271830a7b95")),
       nonce = ByteString(Hex.decode("62bc3dca012c1b27")))
+
+    val filterManager = TestActorRef[FilterManager](Props(
+      new FilterManager(
+        blockchain,
+        blockGenerator,
+        appStateStorage,
+        keyStore,
+        pendingTransactionsManager.ref,
+        config,
+        Some(time.scheduler))
+      )
+    )
   }
 
 }

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerSpec.scala
@@ -19,7 +19,7 @@ import org.json4s.{DefaultFormats, Extraction, Formats}
 import io.iohk.ethereum.jsonrpc.NetService.{ListeningResponse, PeerCountResponse, VersionResponse}
 import io.iohk.ethereum.keystore.KeyStore
 import io.iohk.ethereum.ledger.{BloomFilter, Ledger}
-import io.iohk.ethereum.mining.BlockGenerator
+import io.iohk.ethereum.mining.{BlockGenerator, PendingBlock}
 import io.iohk.ethereum.ommers.OmmersPool
 import io.iohk.ethereum.ommers.OmmersPool.Ommers
 import io.iohk.ethereum.transactions.PendingTransactionsManager
@@ -451,7 +451,7 @@ class JsonRpcControllerSpec extends FlatSpec with Matchers with PropertyChecks w
 
     (appStateStorage.getBestBlockNumber _).expects().returns(1)
     (blockGenerator.generateBlockForMining _).expects(*, *, *, *)
-      .returns(Right(Block(blockHeader, BlockBody(Nil, Nil))))
+      .returns(Right(PendingBlock(Block(blockHeader, BlockBody(Nil, Nil)), Nil)))
 
     val request: JsonRpcRequest = JsonRpcRequest(
       "2.0",
@@ -486,7 +486,7 @@ class JsonRpcControllerSpec extends FlatSpec with Matchers with PropertyChecks w
 
     (appStateStorage.getBestBlockNumber _).expects().returns(1)
     (blockGenerator.generateBlockForMining _).expects(*, *, *, *)
-      .returns(Right(Block(blockHeader, BlockBody(Nil, Nil))))
+      .returns(Right(PendingBlock(Block(blockHeader, BlockBody(Nil, Nil)), Nil)))
 
     val request: JsonRpcRequest = JsonRpcRequest(
       "2.0",
@@ -522,7 +522,7 @@ class JsonRpcControllerSpec extends FlatSpec with Matchers with PropertyChecks w
 
     (blockGenerator.getPrepared _)
       .expects(ByteString(Hex.decode(headerPowHash)))
-      .returns(Some(Block(blockHeader, BlockBody(Nil, Nil))))
+      .returns(Some(PendingBlock(Block(blockHeader, BlockBody(Nil, Nil)), Nil)))
     (appStateStorage.getBestBlockNumber _).expects().returns(1)
 
     val request: JsonRpcRequest = JsonRpcRequest(

--- a/src/test/scala/io/iohk/ethereum/mining/BlockGeneratorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/mining/BlockGeneratorSpec.scala
@@ -1,5 +1,7 @@
 package io.iohk.ethereum.mining
 
+import java.time.Instant
+
 import akka.util.ByteString
 import io.iohk.ethereum.crypto
 import io.iohk.ethereum.blockchain.data.GenesisDataLoader
@@ -52,6 +54,22 @@ class BlockGeneratorSpec extends FlatSpec with Matchers with PropertyChecks with
     fulBlock.right.foreach(b => ledger.executeBlock(b, blockchainStorages.storages, validators) shouldBe a[Right[_, Seq[Receipt]]])
   }
 
+  it should "return the pending block as the one with highest timestamp between generated ones" in new Envirnoment {
+    val result: Either[BlockPreparationError, Block] = blockGenerator.generateBlockForMining(1, Seq(signedTransaction), Nil, Address(testAddress))
+    result shouldBe a[Right[_, Block]]
+
+    blockTimestampProvider.advance(result.right.get.header.unixTimestamp + 10)
+
+    val result2: Either[BlockPreparationError, Block] = blockGenerator.generateBlockForMining(1, Seq(signedTransaction2), Nil, Address(testAddress))
+    result2 shouldBe a[Right[_, Block]]
+
+    blockGenerator.getPending shouldEqual Some(result2.right.get)
+  }
+
+  it should "return None if there are no pending blocks" in new Envirnoment {
+    blockGenerator.getPending shouldEqual None
+  }
+
   trait Envirnoment {
 
     val testAddress = 42
@@ -70,6 +88,8 @@ class BlockGeneratorSpec extends FlatSpec with Matchers with PropertyChecks with
       value = txTransfer,
       payload = ByteString.empty)
     val signedTransaction: SignedTransaction = SignedTransaction.sign(transaction, keyPair, Some(0x3d.toByte))
+
+    val signedTransaction2: SignedTransaction = SignedTransaction.sign(transaction.copy(gasPrice = 2), keyPair, Some(0x3d.toByte))
 
     val blockchainStorages = new SharedEphemDataSources with Storages.DefaultStorages
     val blockchainConfig = new BlockchainConfig {
@@ -110,6 +130,16 @@ class BlockGeneratorSpec extends FlatSpec with Matchers with PropertyChecks with
       override val poolingServicesTimeout: FiniteDuration = 3.seconds
     }
 
-    val blockGenerator = new BlockGenerator(blockchainStorages.storages, blockchainConfig, miningConfig, ledger, validators)
+    val blockTimestampProvider = new FakeBlockTimestampProvider
+
+    val blockGenerator = new BlockGenerator(blockchainStorages.storages, blockchainConfig, miningConfig, ledger, validators, blockTimestampProvider)
   }
+}
+
+class FakeBlockTimestampProvider extends BlockTimestampProvider {
+  private var timestamp = Instant.now.getEpochSecond
+
+  def advance(seconds: Long): Unit = timestamp += seconds
+
+  override def getEpochSecond: Long = timestamp
 }


### PR DESCRIPTION
## Description

This PR implements the `pending` block filter which is used in several RPC methods as defined [here](https://github.com/ethereum/wiki/wiki/JSON-RPC#the-default-block-parameter)

## Notes

- When block is queried and there is no pending, latest is returned as done in other clients
- Receipts are now saved in `BlockGenerator` as they are needed when having `pending` filter when calculating logs are needed
- Maybe `FilterManagerSpec` tests needs some more :heart: but I think this should be done in a separate task