### PR TITLE
[EC-223] Fix how default tx nonce is obtained when sending x_sendTransaction

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -63,8 +63,12 @@ etc-client {
     }
   }
 
-  mining {
+  txPool {
     tx-pool-size = 1000
+    pending-tx-manager-query-timeout = 5.seconds
+  }
+
+  mining {
     ommers-pool-size = 30
     block-cashe-size = 30
     coinbase = "0011223344556677889900112233445566778899"
@@ -130,7 +134,6 @@ etc-client {
   filter {
     filter-timeout = 10.minutes
     filter-manager-query-timeout = 3.seconds
-    pending-transactions-manager-query-timeout = 5.seconds
   }
 
 }

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/FilterManager.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/FilterManager.scala
@@ -11,7 +11,7 @@ import io.iohk.ethereum.mining.BlockGenerator
 import io.iohk.ethereum.network.p2p.messages.PV62.BlockBody
 import io.iohk.ethereum.transactions.PendingTransactionsManager
 import io.iohk.ethereum.transactions.PendingTransactionsManager.PendingTransaction
-import io.iohk.ethereum.utils.FilterConfig
+import io.iohk.ethereum.utils.{FilterConfig, TxPoolConfig}
 
 import scala.annotation.tailrec
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -25,7 +25,8 @@ class FilterManager(
     appStateStorage: AppStateStorage,
     keyStore: KeyStore,
     pendingTransactionsManager: ActorRef,
-    config: FilterConfig,
+    filterConfig: FilterConfig,
+    txPoolConfig: TxPoolConfig,
     externalSchedulerOpt: Option[Scheduler] = None)
   extends Actor {
 
@@ -45,7 +46,7 @@ class FilterManager(
 
   var filterTimeouts: Map[BigInt, Cancellable] = Map.empty
 
-  implicit val timeout = Timeout(config.pendingTransactionsManagerQueryTimeout)
+  implicit val timeout = Timeout(txPoolConfig.pendingTxManagerQueryTimeout)
 
   override def receive: Receive = {
     case NewLogFilter(fromBlock, toBlock, address, topics) => addFilterAndSendResponse(LogFilter(generateId(), fromBlock, toBlock, address, topics))
@@ -62,7 +63,7 @@ class FilterManager(
 
   private def resetTimeout(id: BigInt): Unit = {
     filterTimeouts.get(id).foreach(_.cancel())
-    val timeoutCancellable = scheduler.scheduleOnce(config.filterTimeout, self, FilterTimeout(id))
+    val timeoutCancellable = scheduler.scheduleOnce(filterConfig.filterTimeout, self, FilterTimeout(id))
     filterTimeouts += (id -> timeoutCancellable)
   }
 
@@ -251,8 +252,9 @@ object FilterManager {
             appStateStorage: AppStateStorage,
             keyStore: KeyStore,
             pendingTransactionsManager: ActorRef,
-            config: FilterConfig): Props =
-    Props(new FilterManager(blockchain, blockGenerator, appStateStorage, keyStore, pendingTransactionsManager, config))
+            filterConfig: FilterConfig,
+            txPoolConfig: TxPoolConfig): Props =
+    Props(new FilterManager(blockchain, blockGenerator, appStateStorage, keyStore, pendingTransactionsManager, filterConfig, txPoolConfig))
 
   sealed trait Filter {
     def id: BigInt

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/PersonalService.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/PersonalService.scala
@@ -12,7 +12,7 @@ import io.iohk.ethereum.keystore.{KeyStore, Wallet}
 import io.iohk.ethereum.jsonrpc.JsonRpcErrors._
 import io.iohk.ethereum.transactions.PendingTransactionsManager
 import io.iohk.ethereum.transactions.PendingTransactionsManager.{AddTransactions, PendingTransactionsResponse}
-import io.iohk.ethereum.utils.MiningConfig
+import io.iohk.ethereum.utils.TxPoolConfig
 
 import scala.collection.mutable
 import scala.concurrent.Future
@@ -61,7 +61,7 @@ class PersonalService(
   blockchain: Blockchain,
   txPool: ActorRef,
   appStateStorage: AppStateStorage,
-  miningConfig: MiningConfig) {
+  txPoolConfig: TxPoolConfig) {
 
   private val unlockedWallets: mutable.Map[Address, Wallet] = mutable.Map.empty
 
@@ -142,7 +142,7 @@ class PersonalService(
   }
 
   private def sendTransaction(request: TransactionRequest, wallet: Wallet): Future[ByteString] = {
-    implicit val timeout = Timeout(miningConfig.poolingServicesTimeout)
+    implicit val timeout = Timeout(txPoolConfig.pendingTxManagerQueryTimeout)
 
     val pendingTxsFuture = (txPool ? PendingTransactionsManager.GetPendingTransactions).mapTo[PendingTransactionsResponse]
     val latestPendingTxNonceFuture: Future[Option[BigInt]] = pendingTxsFuture.map { pendingTxs =>

--- a/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
@@ -30,6 +30,10 @@ trait BlockchainConfigBuilder {
   lazy val blockchainConfig = BlockchainConfig(Config.config)
 }
 
+trait TxPoolConfigBuilder {
+  lazy val txPoolConfig = TxPoolConfig(Config.config)
+}
+
 trait MiningConfigBuilder {
   lazy val miningConfig = MiningConfig(Config.config)
 }
@@ -171,10 +175,10 @@ trait PendingTransactionsManagerBuilder {
     with PeerManagerActorBuilder
     with EtcPeerManagerActorBuilder
     with PeerEventBusBuilder
-    with MiningConfigBuilder =>
+    with TxPoolConfigBuilder =>
 
   lazy val pendingTransactionsManager: ActorRef = actorSystem.actorOf(PendingTransactionsManager.props(
-    miningConfig, peerManager, etcPeerManager, peerEventBus))
+    txPoolConfig, peerManager, etcPeerManager, peerEventBus))
 }
 
 trait FilterManagerBuilder {
@@ -184,7 +188,8 @@ trait FilterManagerBuilder {
     with StorageBuilder
     with KeyStoreBuilder
     with PendingTransactionsManagerBuilder
-    with FilterConfigBuilder =>
+    with FilterConfigBuilder
+    with TxPoolConfigBuilder =>
 
   lazy val filterManager: ActorRef =
     actorSystem.actorOf(
@@ -194,7 +199,8 @@ trait FilterManagerBuilder {
         storagesInstance.storages.appStateStorage,
         keyStore,
         pendingTransactionsManager,
-        filterConfig
+        filterConfig,
+        txPoolConfig
       )
     )
 }
@@ -233,10 +239,10 @@ trait PersonalServiceBuilder {
     BlockChainBuilder with
     PendingTransactionsManagerBuilder with
     StorageBuilder with
-    MiningConfigBuilder =>
+    TxPoolConfigBuilder =>
 
   lazy val personalService = new PersonalService(keyStore, blockchain, pendingTransactionsManager,
-    storagesInstance.storages.appStateStorage, miningConfig)
+    storagesInstance.storages.appStateStorage, txPoolConfig)
 }
 
 trait KeyStoreBuilder {
@@ -367,3 +373,4 @@ trait Node extends NodeKeyBuilder
   with BlockchainHostBuilder
   with FilterManagerBuilder
   with FilterConfigBuilder
+  with TxPoolConfigBuilder

--- a/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
@@ -229,10 +229,14 @@ trait EthServiceBuilder {
 }
 
 trait PersonalServiceBuilder {
-  self: KeyStoreBuilder with BlockChainBuilder with PendingTransactionsManagerBuilder with StorageBuilder =>
+  self: KeyStoreBuilder with
+    BlockChainBuilder with
+    PendingTransactionsManagerBuilder with
+    StorageBuilder with
+    MiningConfigBuilder =>
 
   lazy val personalService = new PersonalService(keyStore, blockchain, pendingTransactionsManager,
-    storagesInstance.storages.appStateStorage)
+    storagesInstance.storages.appStateStorage, miningConfig)
 }
 
 trait KeyStoreBuilder {

--- a/src/main/scala/io/iohk/ethereum/utils/Config.scala
+++ b/src/main/scala/io/iohk/ethereum/utils/Config.scala
@@ -133,7 +133,6 @@ object Config {
 trait FilterConfig {
   val filterTimeout: FiniteDuration
   val filterManagerQueryTimeout: FiniteDuration
-  val pendingTransactionsManagerQueryTimeout: FiniteDuration
 }
 
 object FilterConfig {
@@ -143,13 +142,27 @@ object FilterConfig {
     new FilterConfig {
       val filterTimeout: FiniteDuration = filterConfig.getDuration("filter-timeout").toMillis.millis
       val filterManagerQueryTimeout: FiniteDuration = filterConfig.getDuration("filter-manager-query-timeout").toMillis.millis
-      val pendingTransactionsManagerQueryTimeout: FiniteDuration = filterConfig.getDuration("pending-transactions-manager-query-timeout").toMillis.millis
+    }
+  }
+}
+
+trait TxPoolConfig {
+  val txPoolSize: Int
+  val pendingTxManagerQueryTimeout: FiniteDuration
+}
+
+object TxPoolConfig {
+  def apply(etcClientConfig: com.typesafe.config.Config): TxPoolConfig = {
+    val txPoolConfig = etcClientConfig.getConfig("txPool")
+
+    new TxPoolConfig {
+      val txPoolSize: Int = txPoolConfig.getInt("tx-pool-size")
+      val pendingTxManagerQueryTimeout: FiniteDuration = txPoolConfig.getDuration("pending-tx-manager-query-timeout").toMillis.millis
     }
   }
 }
 
 trait MiningConfig {
-  val txPoolSize: Int
   val ommersPoolSize: Int
   val blockCacheSize: Int
   val coinbase: Address
@@ -164,7 +177,6 @@ object MiningConfig {
       val coinbase: Address = Address(Hex.decode(miningConfig.getString("coinbase")))
       val blockCacheSize: Int = miningConfig.getInt("block-cashe-size")
       val ommersPoolSize: Int = miningConfig.getInt("ommers-pool-size")
-      val txPoolSize: Int = miningConfig.getInt("tx-pool-size")
       val poolingServicesTimeout: FiniteDuration = miningConfig.getDuration("pooling-services-timeout").toMillis.millis
     }
   }

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/EthServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/EthServiceSpec.scala
@@ -777,14 +777,12 @@ class EthServiceSpec extends FlatSpec with Matchers with ScalaFutures with MockF
       override val coinbase: Address = Address(42)
       override val blockCacheSize: Int = 30
       override val ommersPoolSize: Int = 30
-      override val txPoolSize: Int = 30
       override val poolingServicesTimeout: FiniteDuration = Timeouts.normalTimeout
     }
 
     val filterConfig = new FilterConfig {
       override val filterTimeout: FiniteDuration = Timeouts.normalTimeout
       override val filterManagerQueryTimeout: FiniteDuration = Timeouts.normalTimeout
-      override val pendingTransactionsManagerQueryTimeout: FiniteDuration = Timeouts.normalTimeout
     }
 
     val ethService = new EthService(storagesInstance.storages, blockGenerator, appStateStorage, miningConfig, ledger,

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerSpec.scala
@@ -1303,14 +1303,12 @@ class JsonRpcControllerSpec extends FlatSpec with Matchers with PropertyChecks w
       override val coinbase: Address = Address(Hex.decode("42" * 20))
       override val blockCacheSize: Int = 30
       override val ommersPoolSize: Int = 30
-      override val txPoolSize: Int = 30
       override val poolingServicesTimeout: FiniteDuration = Timeouts.normalTimeout
     }
 
     val filterConfig = new FilterConfig {
       override val filterTimeout: FiniteDuration = Timeouts.normalTimeout
       override val filterManagerQueryTimeout: FiniteDuration = Timeouts.normalTimeout
-      override val pendingTransactionsManagerQueryTimeout: FiniteDuration = Timeouts.normalTimeout
     }
 
     val appStateStorage = mock[AppStateStorage]

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/PersonalServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/PersonalServiceSpec.scala
@@ -12,7 +12,7 @@ import io.iohk.ethereum.jsonrpc.PersonalService._
 import io.iohk.ethereum.keystore.{KeyStore, Wallet}
 import io.iohk.ethereum.keystore.KeyStore.{DecryptionFailed, IOError}
 import io.iohk.ethereum.transactions.PendingTransactionsManager.{AddTransactions, GetPendingTransactions, PendingTransaction, PendingTransactionsResponse}
-import io.iohk.ethereum.utils.MiningConfig
+import io.iohk.ethereum.utils.{MiningConfig, TxPoolConfig}
 import org.scalamock.matchers.Matcher
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.concurrent.ScalaFutures
@@ -294,19 +294,16 @@ class PersonalServiceSpec extends FlatSpec with Matchers with MockFactory with S
 
     implicit val system = ActorSystem("personal-service-test")
 
-    val miningConfig = new MiningConfig {
-      override val coinbase: Address = Address(42)
-      override val blockCacheSize: Int = 30
-      override val ommersPoolSize: Int = 30
+    val txPoolConfig = new TxPoolConfig {
       override val txPoolSize: Int = 30
-      override val poolingServicesTimeout: FiniteDuration = Timeouts.normalTimeout
+      override val pendingTxManagerQueryTimeout: FiniteDuration = Timeouts.normalTimeout
     }
 
     val keyStore = mock[KeyStore]
     val blockchain = mock[Blockchain]
     val txPool = TestProbe()
     val appStateStorage = mock[AppStateStorage]
-    val personal = new PersonalService(keyStore, blockchain, txPool.ref, appStateStorage, miningConfig)
+    val personal = new PersonalService(keyStore, blockchain, txPool.ref, appStateStorage, txPoolConfig)
 
     def array[T](arr: Array[T]): Matcher[Array[T]] =
       argThat((_: Array[T]) sameElements arr)

--- a/src/test/scala/io/iohk/ethereum/mining/BlockGeneratorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/mining/BlockGeneratorSpec.scala
@@ -147,7 +147,6 @@ class BlockGeneratorSpec extends FlatSpec with Matchers with PropertyChecks with
       override val coinbase: Address = Address(42)
       override val blockCacheSize: Int = 30
       override val ommersPoolSize: Int = 30
-      override val txPoolSize: Int = 30
       override val poolingServicesTimeout: FiniteDuration = Timeouts.normalTimeout
     }
 

--- a/src/test/scala/io/iohk/ethereum/ommers/OmmersPoolSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/ommers/OmmersPoolSpec.scala
@@ -56,7 +56,6 @@ class OmmersPoolSpec extends FlatSpec with Matchers with MockFactory {
 
     val miningConfig = new MiningConfig {
       override val ommersPoolSize: Int = 3
-      override val txPoolSize: Int = 30
       override val coinbase: Address = Address(2)
       override val poolingServicesTimeout: FiniteDuration = Timeouts.normalTimeout
       override val blockCacheSize: Int = 4

--- a/src/test/scala/io/iohk/ethereum/transactions/PendingTransactionsManagerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/transactions/PendingTransactionsManagerSpec.scala
@@ -16,7 +16,7 @@ import akka.pattern.ask
 import io.iohk.ethereum.network.PeerActor.Status.Handshaked
 import io.iohk.ethereum.network.PeerEventBusActor.PeerEvent.MessageFromPeer
 import io.iohk.ethereum.network.PeerManagerActor.Peers
-import io.iohk.ethereum.utils.MiningConfig
+import io.iohk.ethereum.utils.{MiningConfig, TxPoolConfig}
 import org.scalatest.concurrent.ScalaFutures
 
 import scala.concurrent.duration._
@@ -123,20 +123,17 @@ class PendingTransactionsManagerSpec extends FlatSpec with Matchers with ScalaFu
     val peer3TestProbe = TestProbe()
     val peer3 = Peer(new InetSocketAddress("127.0.0.3", 9000), peer3TestProbe.ref)
 
-    val miningConfig = new MiningConfig {
+    val txPoolConfig = new TxPoolConfig {
       override val txPoolSize: Int = 300
       //unused
-      override val coinbase: Address = Address(2)
-      override val blockCacheSize: Int = 30
-      override val ommersPoolSize: Int = 30
-      override val poolingServicesTimeout: FiniteDuration = Timeouts.veryLongTimeout
+      override val pendingTxManagerQueryTimeout: FiniteDuration = Timeouts.veryLongTimeout
     }
 
     val peerManager = TestProbe()
     val etcPeerManager = TestProbe()
     val peerMessageBus = TestProbe()
     val pendingTransactionsManager = system.actorOf(
-      PendingTransactionsManager.props(miningConfig, peerManager.ref, etcPeerManager.ref, peerMessageBus.ref))
+      PendingTransactionsManager.props(txPoolConfig, peerManager.ref, etcPeerManager.ref, peerMessageBus.ref))
   }
 
 }


### PR DESCRIPTION
## Description

Currently, if 2 transactions (from the same sender) are sent without mining started (or if they arrive between the mining of 2 blocks), and the last one to arrive doesn't have a nonce field set, it will not included to the blockchain.
This happens when using both `eth_sendTransaction` and `personal_sendTransaction`, and it can be seen by using Mist as it doesn't set the nonce field when sending a tx. This can be reproduced by either:
* Starting the miner after the txs were sent.
* Increasing the mining difficulty to allow to send the txs so that they are attempted to be included in the same block.

## Fix
The pending txs of the same sender are considered when setting the nonce of tx sent.