### PR TITLE
[EC-238] Fixed FIXMEs in the codebase

### DIFF
--- a/src/it/scala/io/iohk/ethereum/txExecTest/util/DumpChainApp.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/util/DumpChainApp.scala
@@ -11,6 +11,7 @@ import io.iohk.ethereum.domain.{Blockchain, _}
 import io.iohk.ethereum.network.PeerManagerActor.PeerConfiguration
 import io.iohk.ethereum.network.EtcPeerManagerActor.PeerInfo
 import io.iohk.ethereum.network.handshaker.{EtcHandshaker, EtcHandshakerConfiguration, Handshaker}
+import io.iohk.ethereum.network.p2p.EthereumMessageDecoder
 import io.iohk.ethereum.network.p2p.messages.{PV62, PV63}
 import io.iohk.ethereum.network.{ForkResolver, PeerEventBusActor, PeerManagerActor}
 import io.iohk.ethereum.nodebuilder.{AuthHandshakerBuilder, NodeKeyBuilder, SecureRandomBuilder}
@@ -77,7 +78,8 @@ object DumpChainApp extends App with NodeKeyBuilder with SecureRandomBuilder wit
       bootstrapNodes = Set(node),
       peerMessageBus,
       handshaker = handshaker,
-      authHandshaker = authHandshaker), "peer-manager")
+      authHandshaker = authHandshaker,
+      messageDecoder = EthereumMessageDecoder), "peer-manager")
     actorSystem.actorOf(DumpChainActor.props(peerManager,peerMessageBus,startBlock,maxBlocks), "dumper")
   }
 

--- a/src/main/scala/io/iohk/ethereum/db/components/StoragesComponent.scala
+++ b/src/main/scala/io/iohk/ethereum/db/components/StoragesComponent.scala
@@ -19,7 +19,7 @@ trait StoragesComponent {
 
     val mptNodeStorage: MptNodeStorage
 
-    val nodeStorage: NodeStorage //FIXME This storage is similar to MPTNodesStorage but
+    val nodeStorage: NodeStorage //FIXME This storage is similar to MPTNodesStorage, should we keep only one? [EC-147]
 
     val evmCodeStorage: EvmCodeStorage
 

--- a/src/main/scala/io/iohk/ethereum/ledger/InMemorySimpleMapProxy.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/InMemorySimpleMapProxy.scala
@@ -49,7 +49,7 @@ class InMemorySimpleMapProxy[K, V, I <: SimpleMap[K, V, I]] private(val inner: I
     * @param key
     * @return Option object with value if there exists one.
     */
-  def get(key: K): Option[V] = cache.getOrElse(key, inner.get(key)) //FIXME We can cache retrieved values too
+  def get(key: K): Option[V] = cache.getOrElse(key, inner.get(key))
 
   def wrapped: I = inner
 

--- a/src/main/scala/io/iohk/ethereum/ledger/Ledger.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/Ledger.scala
@@ -361,7 +361,9 @@ class LedgerImpl(vm: VM, blockchainConfig: BlockchainConfig) extends Ledger with
     * The contract storage should be cleared during pruning as nodes could be used in other tries.
     * The contract code is also not deleted as there can be contracts with the exact same code, making it risky to delete
     * the code of an account in case it is shared with another one.
-    * FIXME: Should we keep track of this for deletion? Maybe during pruning we can also prune contract code.
+    * FIXME: [EC-242]
+    *   Should we delete the storage associated with the deleted accounts?
+    *   Should we keep track of duplicated contracts for deletion?
     *
     * @param addressesToDelete
     * @param worldStateProxy

--- a/src/main/scala/io/iohk/ethereum/network/PeerEventBusActor.scala
+++ b/src/main/scala/io/iohk/ethereum/network/PeerEventBusActor.scala
@@ -49,7 +49,6 @@ object PeerEventBusActor {
     override type Event = PeerEvent
     override type Classifier = SubscriptionClassifier
 
-    //FIXME Remove both var
     private var messageSubscriptions: Map[(Subscriber, PeerSelector), Set[Int]] = Map.empty
     private var connectionSubscriptions: Seq[Subscription] = Nil
 

--- a/src/main/scala/io/iohk/ethereum/network/PeerManagerActor.scala
+++ b/src/main/scala/io/iohk/ethereum/network/PeerManagerActor.scala
@@ -17,7 +17,7 @@ import io.iohk.ethereum.network.PeerEventBusActor.PeerEvent.PeerDisconnected
 import io.iohk.ethereum.network.PeerEventBusActor.Publish
 import io.iohk.ethereum.network.handshaker.Handshaker
 import io.iohk.ethereum.network.handshaker.Handshaker.HandshakeResult
-import io.iohk.ethereum.network.p2p.MessageSerializable
+import io.iohk.ethereum.network.p2p.{MessageDecoder, MessageSerializable}
 import io.iohk.ethereum.network.rlpx.AuthHandshaker
 import io.iohk.ethereum.utils.{Config, NodeStatus}
 
@@ -202,18 +202,20 @@ object PeerManagerActor {
                                   peerConfiguration: PeerConfiguration,
                                   peerEventBus: ActorRef,
                                   handshaker: Handshaker[R],
-                                  authHandshaker: AuthHandshaker): Props =
+                                  authHandshaker: AuthHandshaker,
+                                  messageDecoder: MessageDecoder): Props =
     Props(new PeerManagerActor(peerEventBus, peerConfiguration,
-      peerFactory(nodeStatusHolder, peerConfiguration, peerEventBus, handshaker, authHandshaker)))
+      peerFactory(nodeStatusHolder, peerConfiguration, peerEventBus, handshaker, authHandshaker, messageDecoder)))
 
   def props[R <: HandshakeResult](nodeStatusHolder: Agent[NodeStatus],
                                   peerConfiguration: PeerConfiguration,
                                   bootstrapNodes: Set[String],
                                   peerMessageBus: ActorRef,
                                   handshaker: Handshaker[R],
-                                  authHandshaker: AuthHandshaker): Props =
+                                  authHandshaker: AuthHandshaker,
+                                  messageDecoder: MessageDecoder): Props =
     Props(new PeerManagerActor(peerMessageBus, peerConfiguration,
-      peerFactory = peerFactory(nodeStatusHolder, peerConfiguration, peerMessageBus, handshaker, authHandshaker),
+      peerFactory = peerFactory(nodeStatusHolder, peerConfiguration, peerMessageBus, handshaker, authHandshaker, messageDecoder),
       bootstrapNodes = bootstrapNodes)
     )
 
@@ -221,11 +223,12 @@ object PeerManagerActor {
                                         peerConfiguration: PeerConfiguration,
                                         peerEventBus: ActorRef,
                                         handshaker: Handshaker[R],
-                                        authHandshaker: AuthHandshaker): (ActorContext, InetSocketAddress) => ActorRef = {
+                                        authHandshaker: AuthHandshaker,
+                                        messageDecoder: MessageDecoder): (ActorContext, InetSocketAddress) => ActorRef = {
     (ctx, addr) =>
       val id = addr.toString.filterNot(_ == '/')
       ctx.actorOf(PeerActor.props(addr, nodeStatusHolder, peerConfiguration, peerEventBus,
-        handshaker, authHandshaker), id)
+        handshaker, authHandshaker, messageDecoder), id)
   }
 
   trait PeerConfiguration {

--- a/src/main/scala/io/iohk/ethereum/network/p2p/Message.scala
+++ b/src/main/scala/io/iohk/ethereum/network/p2p/Message.scala
@@ -1,6 +1,9 @@
 package io.iohk.ethereum.network.p2p
 
 import akka.util.ByteString
+import io.iohk.ethereum.network.p2p.Message.Version
+
+import scala.util.Try
 
 object Message {
   type Version = Int
@@ -21,6 +24,11 @@ trait MessageSerializable extends Message {
 
 }
 
-trait MessageDecoder {
+trait MessageDecoder { self =>
   def fromBytes(`type`: Int, payload: Array[Byte], protocolVersion: Message.Version): Message
+
+  def orElse(otherMessageDecoder: MessageDecoder): MessageDecoder = new MessageDecoder {
+    override def fromBytes(`type`: Int, payload: Array[Byte], protocolVersion: Version): Message =
+      Try{ self.fromBytes(`type`, payload, protocolVersion) }.getOrElse( otherMessageDecoder.fromBytes(`type`, payload, protocolVersion))
+  }
 }

--- a/src/main/scala/io/iohk/ethereum/network/p2p/MessageDecoders.scala
+++ b/src/main/scala/io/iohk/ethereum/network/p2p/MessageDecoders.scala
@@ -23,14 +23,22 @@ import io.iohk.ethereum.network.p2p.messages.WireProtocol._
 import io.iohk.ethereum.network.p2p.messages.{PV61 => pv61, PV62 => pv62, PV63 => pv63}
 import io.iohk.ethereum.network.p2p.messages.Versions._
 
+object NetworkMessageDecoder extends MessageDecoder {
+
+  override def fromBytes(`type`: Int, payload: Array[Byte], protocolVersion: Version): Message = (protocolVersion, `type`) match {
+    case (_, Disconnect.code) => payload.toDisconnect
+    case (_, Ping.code) => payload.toPing
+    case (_, Pong.code) => payload.toPong
+    case _ => throw new RuntimeException(s"Unknown message type: ${`type`}")
+  }
+
+}
+
 object EthereumMessageDecoder extends MessageDecoder {
 
   override def fromBytes(`type`: Int, payload: Array[Byte], protocolVersion: Version): Message = (protocolVersion, `type`) match {
     //wire protocol
     case (_, Hello.code) => payload.toHello
-    case (_, Disconnect.code) => payload.toDisconnect
-    case (_, Ping.code) => payload.toPing
-    case (_, Pong.code) => payload.toPong
 
     //common
     case (_, Status.code) => payload.toStatus

--- a/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
@@ -23,6 +23,7 @@ import io.iohk.ethereum.utils._
 import scala.concurrent.ExecutionContext.Implicits.global
 import io.iohk.ethereum.network._
 import io.iohk.ethereum.network.handshaker.{EtcHandshaker, EtcHandshakerConfiguration, Handshaker}
+import io.iohk.ethereum.network.p2p.EthereumMessageDecoder
 import io.iohk.ethereum.network.rlpx.AuthHandshaker
 import io.iohk.ethereum.transactions.PendingTransactionsManager
 import io.iohk.ethereum.validators._
@@ -132,7 +133,8 @@ trait PeerManagerActorBuilder {
     Config.Network.peer,
     peerEventBus,
     handshaker,
-    authHandshaker), "peer-manager")
+    authHandshaker,
+    EthereumMessageDecoder), "peer-manager")
 
 }
 

--- a/src/main/scala/io/iohk/ethereum/validators/BlockHeaderValidator.scala
+++ b/src/main/scala/io/iohk/ethereum/validators/BlockHeaderValidator.scala
@@ -132,7 +132,7 @@ class BlockHeaderValidatorImpl(blockchainConfig: BlockchainConfig) extends Block
     * @param blockHeader BlockHeader to validate.
     * @return BlockHeader if valid, an [[HeaderPoWError]] otherwise
     */
-  //FIXME: Simple PoW validation without using DAG
+  //FIXME: Simple PoW validation without using DAG [EC-88]
   private def validatePoW(blockHeader: BlockHeader): Either[BlockHeaderError, BlockHeader] = {
     val powBoundary = BigInt(2).pow(256) / blockHeader.difficulty
     val powValue = BigInt(1, calculatePoWValue(blockHeader).toArray)

--- a/src/main/scala/io/iohk/ethereum/validators/BlockValidator.scala
+++ b/src/main/scala/io/iohk/ethereum/validators/BlockValidator.scala
@@ -46,7 +46,6 @@ object BlockValidator extends BlockValidator {
     * @return Block if valid, a Some otherwise
     */
   private def validateOmmersHash(block: Block): Either[BlockError, Block] = {
-    // FIXME Can we avoid encoding ommers again?
     import io.iohk.ethereum.network.p2p.messages.PV62.BlockHeaderImplicits._
     val encodedOmmers: Array[Byte] = block.body.uncleNodesList.toBytes
     if (kec256(encodedOmmers) sameElements block.header.ommersHash) Right(block)

--- a/src/main/scala/io/iohk/ethereum/vm/OpCode.scala
+++ b/src/main/scala/io/iohk/ethereum/vm/OpCode.scala
@@ -691,8 +691,8 @@ case object CREATE extends OpCode(0xf0, 3, 1, _.G_create) {
         callDepth = state.env.callDepth + 1
       )
 
-      //to avoid calculating this twice, we could adjust state.gas prior to execution in OpCode#execute
-      //not sure how this would affect other opcodes
+      //FIXME: to avoid calculating this twice, we could adjust state.gas prior to execution in OpCode#execute
+      //not sure how this would affect other opcodes [EC-243]
       val availableGas = state.gas - (constGasFn(state.config.feeSchedule) + varGas(state))
       val startGas = state.config.gasCap(availableGas)
 
@@ -826,7 +826,7 @@ sealed abstract class CallOp(code: Int, delta: Int, alpha: Int) extends OpCode(c
     val memCostOut = state.config.calcMemCost(state.memory.size, outOffset, outSize)
     val memCost: BigInt = memCostIn max memCostOut
 
-    // FIXME: these are calculated twice (for gas and exec), especially account existence. Can we do better?
+    // FIXME: these are calculated twice (for gas and exec), especially account existence. Can we do better? [EC-243]
     val gExtra: BigInt = gasExtra(state, endowment, Address(to))
     val gCap: BigInt = gasCap(state, gas, gExtra)
     memCost + gCap + gExtra

--- a/src/test/scala/io/iohk/ethereum/network/p2p/messages/MessagesSerializationSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/network/p2p/messages/MessagesSerializationSpec.scala
@@ -2,7 +2,7 @@ package io.iohk.ethereum.network.p2p.messages
 
 import akka.util.ByteString
 import io.iohk.ethereum.Fixtures
-import io.iohk.ethereum.network.p2p.EthereumMessageDecoder
+import io.iohk.ethereum.network.p2p.{EthereumMessageDecoder, NetworkMessageDecoder}
 import io.iohk.ethereum.network.p2p.messages.CommonMessages.{NewBlock, SignedTransactions, Status}
 import io.iohk.ethereum.network.p2p.messages.PV61.BlockHashesFromNumber
 import io.iohk.ethereum.network.p2p.messages.PV62._
@@ -125,7 +125,9 @@ class MessagesSerializationSpec
     }
   }
 
+  val messageDecoder = NetworkMessageDecoder orElse EthereumMessageDecoder
+
   def verify[T](msg: T, encode: T => Array[Byte], code: Int, version: Int): Unit =
-    EthereumMessageDecoder.fromBytes(code, encode(msg), version) shouldEqual msg
+    messageDecoder.fromBytes(code, encode(msg), version) shouldEqual msg
 
 }

--- a/src/test/scala/io/iohk/ethereum/network/p2p/messages/NewBlockSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/network/p2p/messages/NewBlockSpec.scala
@@ -9,10 +9,14 @@ import org.scalatest.prop.PropertyChecks
 import org.scalatest.FunSuite
 import org.spongycastle.util.encoders.Hex
 import NewBlock._
+import io.iohk.ethereum.nodebuilder.SecureRandomBuilder
 
-class NewBlockSpec extends FunSuite with PropertyChecks  with ObjectGenerators {
+class NewBlockSpec extends FunSuite with PropertyChecks  with ObjectGenerators with SecureRandomBuilder {
+
+  val chainId = Hex.decode("3d").head
+
   test("NewBlock messages are encoded and decoded properly") {
-    forAll(newBlockGen) { newBlock =>
+    forAll(newBlockGen(secureRandom, Some(chainId))) { newBlock =>
       val encoded: Array[Byte] = newBlock.toBytes
       val decoded: NewBlock = encoded.toNewBlock
       assert(decoded == newBlock)

--- a/src/test/scala/io/iohk/ethereum/rlp/RLPSuite.scala
+++ b/src/test/scala/io/iohk/ethereum/rlp/RLPSuite.scala
@@ -461,7 +461,6 @@ class RLPSuite extends FunSuite
     }
   }
 
-
   test("SimpleBlock encoding") {
     val tx0 = TestSimpleTransaction(1, "cat")
     val tx1 = TestSimpleTransaction(2, "dog")
@@ -618,7 +617,7 @@ class RLPSuite extends FunSuite
       -> "a1010000000000000000000000000000000000000000000000000000000000000000"
   )
 
-  //FIXME this is used to test nested objects encoding. We can think of replacing this with eth real implementation
+  //The following classes are used for a simplifying testing for nested objects (allowing using simple RLPEncoder and RLPDecoder)
   private case class TestSimpleTransaction(id: Int, name: String)
 
   private object TestSimpleTransaction {


### PR DESCRIPTION
## Description

Includes fixes to several `FIXME`s in the codebase. The remaining `FIXME`s were analyzed (with conclusions in task). The fixed `FIXME`s in this PR are:
- *BlockValidator: Can we avoid encoding ommers again? -> Removed FIXME*: This would require rethinking how messages are received from other peers, so as to leave the bytes of the messages cached, as Parity does. It doesn't seem worth the changes needed, as it would only improve the encoding of the ommers (for example, Geth doesn't implement this optimization), so the FIXME was removed.
- *InMemorySimpleMapProxy: We can cache retrieved values too -> Removed FIXME*: The optimization makes sense but it would require either: making the cache a var or returning a new InMemorySimpleMapProxy but it would unnecesary overcomplicate the interface. Due to this the `FIXME` was removed.
- *ObjectGenerators: Add use of tx generator when we are able to sign txs -> Fixed FIXME*: Changed `NewBlock` generator to include txs.
- *PeerActor: This message decoder should be configurable -> Fixed FIXME*: Made `MessageDecoder` configurable on `PeerActor` and when creating `PeerManagerActor`.
- *PeerEventBusActor: Remove both var -> Removed FIXME*: Removing both var doesn't fit well into the interface used by ActorEventBus (for example `ActorEventBus` requires `subscribe` being as `def subscribe(subscriber: ActorRef, to: Classifier): Boolean`). Due to this the `FIXME` was removed.
- *RLPSuite: this is used to test nested objects encoding. We can think of replacing this with eth real implementation -> Removed FIXME*: Removed `FIXME` as it makes sense to have a simple test for nested objects encoding, real block encoding should be tested somewhere else if it already isn't.