### PR TITLE
[EC-245] Fixed how node key is restored

### DIFF
--- a/src/main/scala/io/iohk/ethereum/network/package.scala
+++ b/src/main/scala/io/iohk/ethereum/network/package.scala
@@ -31,8 +31,8 @@ package object network {
       val keysValuePair = generateKeyPair(secureRandom)
 
       //Write keys to file
-      val (_, priv) = keyPairToByteArrays(keysValuePair)
-      file.getParentFile.mkdirs()
+      val (priv, _) = keyPairToByteArrays(keysValuePair)
+      require(file.getParentFile.exists() || file.getParentFile.mkdirs(), "Key's file parent directory creation failed")
       val writer = new PrintWriter(filePath)
       try {
         writer.write(Hex.toHexString(priv))

--- a/src/test/scala/io/iohk/ethereum/network/AsymmetricCipherKeyPairLoaderSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/network/AsymmetricCipherKeyPairLoaderSpec.scala
@@ -1,0 +1,56 @@
+package io.iohk.ethereum.network
+
+import java.io.File
+import java.nio.file.Files
+
+import io.iohk.ethereum.network
+import io.iohk.ethereum.nodebuilder.SecureRandomBuilder
+import org.scalatest.{FlatSpec, Matchers}
+import org.spongycastle.crypto.AsymmetricCipherKeyPair
+import org.spongycastle.crypto.params.{ECPrivateKeyParameters, ECPublicKeyParameters}
+
+class AsymmetricCipherKeyPairLoaderSpec extends FlatSpec with Matchers with SecureRandomBuilder {
+
+  def withFilePath(testCode: String => Any): Unit = {
+    val path = Files.createTempFile("key-", "").toAbsolutePath.toString
+    require(new File(path).delete(), "File deletion before test failed")
+    try {
+      testCode(path)
+    } finally {
+      val file = new File(path)
+      assert(!file.exists() || file.delete(), "File deletion after test failed")
+    }
+  }
+
+  def equalKeyPairs(keyPair1: AsymmetricCipherKeyPair, keyPair2: AsymmetricCipherKeyPair): Boolean = {
+    //Compare public keys
+    val publicKeyParam1 = keyPair1.getPublic.asInstanceOf[ECPublicKeyParameters]
+    val publicKeyParam2 = keyPair2.getPublic.asInstanceOf[ECPublicKeyParameters]
+    val equalPublicKey =
+      publicKeyParam1.getQ == publicKeyParam2.getQ &&
+        publicKeyParam1.getParameters == publicKeyParam2.getParameters &&
+        publicKeyParam1.isPrivate == publicKeyParam2.isPrivate
+
+    //Compare private keys
+    val privateKeyParam1 = keyPair1.getPrivate.asInstanceOf[ECPrivateKeyParameters]
+    val privateKeyParam2 = keyPair2.getPrivate.asInstanceOf[ECPrivateKeyParameters]
+    val equalPrivateKey =
+      privateKeyParam1.getD == privateKeyParam2.getD &&
+        privateKeyParam1.getParameters == privateKeyParam2.getParameters &&
+        privateKeyParam1.isPrivate == privateKeyParam2.isPrivate
+
+    equalPrivateKey && equalPublicKey
+  }
+
+  it should "correctly save the AsymmetricCipherKeyPairLoader" in {
+    withFilePath { path =>
+      //Create key pair
+      val newKeyPair = network.loadAsymmetricCipherKeyPair(path, secureRandom)
+
+      //Read key pair from file
+      val obtainedKeyPair = network.loadAsymmetricCipherKeyPair(path, secureRandom)
+
+      assert(equalKeyPairs(newKeyPair, obtainedKeyPair))
+    }
+  }
+}


### PR DESCRIPTION
## Description
In the scenario that the the node keys were already generated (in a previous execution of our client), when loaded and used to sign any message (using `ECDSASignature.sign(forSig, keyPair, None)`), a `null` exception happened.

## Fix
This exception was caused by not restoring properly the node keys, as the public key was being used as the private key, which was fixed in this PR.