### PR TITLE
Fix bugs related to code deposit gas check within CREATE opcode

### DIFF
--- a/src/test/scala/io/iohk/ethereum/vm/CreateOpcodeSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/vm/CreateOpcodeSpec.scala
@@ -71,9 +71,9 @@ class CreateOpcodeSpec extends WordSpec with Matchers {
     val context: PC = ProgramContext(env, Address(0), 2 * gasRequiredForCreation, initWorld, config)
   }
 
-  case class CreateResult(context: PC = fxt.context, value: UInt256 = fxt.endowment, createCode: Assembly = fxt.createCode) {
-    val mem = Memory.empty.store(0, createCode.code)
-    val stack = Stack.empty().push(Seq[UInt256](createCode.code.size, 0, value))
+  case class CreateResult(context: PC = fxt.context, value: UInt256 = fxt.endowment, createCode: ByteString = fxt.createCode.code) {
+    val mem = Memory.empty.store(0, createCode)
+    val stack = Stack.empty().push(Seq[UInt256](createCode.size, 0, value))
     val stateIn: PS = ProgramState(context).withStack(stack).withMemory(mem)
     val stateOut: PS = CREATE.execute(stateIn)
 
@@ -131,11 +131,30 @@ class CreateOpcodeSpec extends WordSpec with Matchers {
     }
 
     "initialization code runs normally but there's not enough gas to deposit code" should {
-      val context: PC = fxt.context.copy(startGas = G_create + fxt.gasRequiredForInit + fxt.depositGas / 2)
+      val depositGas = fxt.depositGas * 101 / 100
+      val availableGasDepth0 = fxt.gasRequiredForInit + depositGas
+      val availableGasDepth1 = config.gasCap(availableGasDepth0)
+      val gasUsedInInit = fxt.gasRequiredForInit + fxt.depositGas
+
+      require(
+        gasUsedInInit < availableGasDepth0 && gasUsedInInit > availableGasDepth1,
+        "Regression: capped startGas in the VM at depth 1, should be used a base for code deposit gas check"
+      )
+
+      val context: PC = fxt.context.copy(startGas = G_create + fxt.gasRequiredForInit + depositGas)
       val result = CreateResult(context = context)
 
-      "throw OOG" in {
-        result.stateOut.error shouldEqual Some(OutOfGas)
+      "consume all gas passed to the init code" in {
+        val expectedGas = G_create + config.gasCap(context.startGas - G_create)
+        result.stateOut.gasUsed shouldEqual expectedGas
+      }
+
+      "not modify world state" in {
+        result.world shouldEqual context.world
+      }
+
+      "return 0" in {
+        result.returnValue shouldEqual 0
       }
     }
 
@@ -179,7 +198,7 @@ class CreateOpcodeSpec extends WordSpec with Matchers {
     val gasRequiredForCreation = gasRequiredForInit + G_create
 
     val context: PC = fxt.context.copy(startGas = 2 * gasRequiredForCreation)
-    val result = CreateResult(context = context, createCode = fxt.initWithSelfDestruct)
+    val result = CreateResult(context = context, createCode = fxt.initWithSelfDestruct.code)
 
     "refund the correct amount of gas" in {
       result.stateOut.gasRefund shouldBe result.stateOut.config.feeSchedule.R_selfdestruct
@@ -194,7 +213,7 @@ class CreateOpcodeSpec extends WordSpec with Matchers {
     val gasRequiredForCreation = gasRequiredForInit + G_create
 
     val context: PC = fxt.context.copy(startGas = 2 * gasRequiredForCreation)
-    val call = CreateResult(context = context, createCode = fxt.initWithSstoreWithClear)
+    val call = CreateResult(context = context, createCode = fxt.initWithSstoreWithClear.code)
 
     "refund the correct amount of gas" in {
       call.stateOut.gasRefund shouldBe call.stateOut.config.feeSchedule.R_sclear

--- a/src/universal/conf/application.ini
+++ b/src/universal/conf/application.ini
@@ -1,1 +1,1 @@
--Dconfig.file=./conf/grothendieck.conf -Dlogback.configurationFile=./conf/logback.xml
+-Dconfig.file=./conf/grothendieck.conf -Dlogback.configurationFile=./conf/logback.xml -Xss10M


### PR DESCRIPTION
There were 2 bugs:
- wrong value of gas was used as a base for code deposit gas check (value available in VM @ depth0, instead of the capped value in VM @ depth1 - init code)
- OOG was thrown, instead of consuming all gas passed to the VM @ depth1 (it's that VM that throws OOG, and in the parent VM it simply manifests as all gas used)

Additionally, JVM stack size was increased for the distribution. 