### PR TITLE
Static analysis tools fixes

### DIFF
--- a/src/it/scala/io/iohk/ethereum/txExecTest/util/DumpChainApp.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/util/DumpChainApp.scala
@@ -87,7 +87,6 @@ object DumpChainApp extends App with NodeKeyBuilder with SecureRandomBuilder wit
 
     val peerManager = actorSystem.actorOf(PeerManagerActor.props(
       peerDiscoveryManager = actorSystem.deadLetters, // TODO: fixme
-      nodeStatusHolder = nodeStatusHolder,
       peerConfiguration = peerConfig,
       peerMessageBus = peerMessageBus,
       knownNodesManager = actorSystem.deadLetters, // TODO: fixme

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/EthService.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/EthService.scala
@@ -17,7 +17,7 @@ import io.iohk.ethereum.crypto._
 import io.iohk.ethereum.db.storage.TransactionMappingStorage.TransactionLocation
 import io.iohk.ethereum.jsonrpc.FilterManager.{FilterChanges, FilterLogs, LogFilterLogs, TxLog}
 import io.iohk.ethereum.keystore.KeyStore
-import io.iohk.ethereum.ledger.{InMemoryWorldStateProxy, Ledger}
+import io.iohk.ethereum.ledger.Ledger
 import io.iohk.ethereum.mining.BlockGenerator
 import io.iohk.ethereum.utils._
 import io.iohk.ethereum.transactions.PendingTransactionsManager
@@ -33,7 +33,6 @@ import org.spongycastle.util.encoders.Hex
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.{Failure, Success, Try}
-import scala.concurrent.duration._
 
 // scalastyle:off number.of.methods number.of.types
 object EthService {
@@ -174,7 +173,6 @@ class EthService(
     blockGenerator: BlockGenerator,
     appStateStorage: AppStateStorage,
     miningConfig: MiningConfig,
-    txPoolConfig: TxPoolConfig,
     ledger: Ledger,
     keyStore: KeyStore,
     pendingTransactionsManager: ActorRef,

--- a/src/main/scala/io/iohk/ethereum/network/PeerActor.scala
+++ b/src/main/scala/io/iohk/ethereum/network/PeerActor.scala
@@ -241,9 +241,7 @@ class PeerActor[R <: HandshakeResult](
 }
 
 object PeerActor {
-  // scalastyle:off parameter.number
   def props[R <: HandshakeResult](peerAddress: InetSocketAddress,
-                                  nodeStatusHolder: Agent[NodeStatus],
                                   peerConfiguration: PeerConfiguration,
                                   peerEventBus: ActorRef,
                                   knownNodesManager: ActorRef,
@@ -253,17 +251,17 @@ object PeerActor {
                                   messageDecoder: MessageDecoder): Props =
     Props(new PeerActor(
       peerAddress,
-      rlpxConnectionFactory(nodeStatusHolder().key, authHandshaker, messageDecoder, peerConfiguration.rlpxConfiguration),
+      rlpxConnectionFactory(authHandshaker, messageDecoder, peerConfiguration.rlpxConfiguration),
       peerConfiguration,
       peerEventBus,
       knownNodesManager,
       incomingConnection,
       initHandshaker = handshaker))
 
-  def rlpxConnectionFactory(nodeKey: AsymmetricCipherKeyPair, authHandshaker: AuthHandshaker,
-                            messageDecoder: MessageDecoder, rlpxConfiguration: RLPxConfiguration): ActorContext => ActorRef = { ctx =>
+  def rlpxConnectionFactory(authHandshaker: AuthHandshaker, messageDecoder: MessageDecoder,
+                            rlpxConfiguration: RLPxConfiguration): ActorContext => ActorRef = { ctx =>
     ctx.actorOf(
-      RLPxConnectionHandler.props(nodeKey, NetworkMessageDecoder orElse messageDecoder, Versions.PV63, authHandshaker, rlpxConfiguration),
+      RLPxConnectionHandler.props(NetworkMessageDecoder orElse messageDecoder, Versions.PV63, authHandshaker, rlpxConfiguration),
       "rlpx-connection")
   }
 

--- a/src/main/scala/io/iohk/ethereum/network/PeerManagerActor.scala
+++ b/src/main/scala/io/iohk/ethereum/network/PeerManagerActor.scala
@@ -168,8 +168,7 @@ class PeerManagerActor(
 }
 
 object PeerManagerActor {
-  def props[R <: HandshakeResult](nodeStatusHolder: Agent[NodeStatus],
-                                  peerDiscoveryManager: ActorRef,
+  def props[R <: HandshakeResult](peerDiscoveryManager: ActorRef,
                                   peerConfiguration: PeerConfiguration,
                                   peerMessageBus: ActorRef,
                                   knownNodesManager: ActorRef,
@@ -178,10 +177,9 @@ object PeerManagerActor {
                                   messageDecoder: MessageDecoder): Props =
     Props(new PeerManagerActor(peerMessageBus, peerDiscoveryManager, peerConfiguration,
       knownNodesManager = knownNodesManager,
-      peerFactory = peerFactory(nodeStatusHolder, peerConfiguration, peerMessageBus, knownNodesManager, handshaker, authHandshaker, messageDecoder)))
+      peerFactory = peerFactory(peerConfiguration, peerMessageBus, knownNodesManager, handshaker, authHandshaker, messageDecoder)))
 
-  def peerFactory[R <: HandshakeResult](nodeStatusHolder: Agent[NodeStatus],
-                                        peerConfiguration: PeerConfiguration,
+  def peerFactory[R <: HandshakeResult](peerConfiguration: PeerConfiguration,
                                         peerEventBus: ActorRef,
                                         knownNodesManager: ActorRef,
                                         handshaker: Handshaker[R],
@@ -189,7 +187,7 @@ object PeerManagerActor {
                                         messageDecoder: MessageDecoder): (ActorContext, InetSocketAddress, Boolean) => ActorRef = {
     (ctx, addr, incomingConnection) =>
       val id = addr.toString.filterNot(_ == '/')
-      ctx.actorOf(PeerActor.props(addr, nodeStatusHolder, peerConfiguration, peerEventBus,
+      ctx.actorOf(PeerActor.props(addr, peerConfiguration, peerEventBus,
         knownNodesManager, incomingConnection, handshaker, authHandshaker, messageDecoder), id)
   }
 

--- a/src/main/scala/io/iohk/ethereum/network/discovery/PeerDiscoveryManager.scala
+++ b/src/main/scala/io/iohk/ethereum/network/discovery/PeerDiscoveryManager.scala
@@ -91,7 +91,7 @@ class PeerDiscoveryManager(
         val to = Endpoint(toNodeId, toAddr.getPort, toAddr.getPort)
         sendMessage(Ping(ProtocolVersion, from, to, expirationTimestamp), toAddr)
       case _ =>
-        log.warning(s"UDP server not running. Not sending ping message.")
+        log.warning("UDP server not running. Not sending ping message.")
     }
   }
 

--- a/src/main/scala/io/iohk/ethereum/network/rlpx/RLPxConnectionHandler.scala
+++ b/src/main/scala/io/iohk/ethereum/network/rlpx/RLPxConnectionHandler.scala
@@ -9,7 +9,6 @@ import akka.util.ByteString
 import io.iohk.ethereum.network.p2p.{Message, MessageDecoder, MessageSerializable}
 import io.iohk.ethereum.network.rlpx.RLPxConnectionHandler.RLPxConfiguration
 import io.iohk.ethereum.utils.ByteUtils
-import org.spongycastle.crypto.AsymmetricCipherKeyPair
 import org.spongycastle.util.encoders.Hex
 
 import scala.collection.immutable.Queue
@@ -28,7 +27,6 @@ import scala.util.{Failure, Success, Try}
   * 4. once handshake is done (and secure connection established) actor can send/receive messages (`handshaked` state)
   */
 class RLPxConnectionHandler(
-    nodeKey: AsymmetricCipherKeyPair,
     messageDecoder: MessageDecoder,
     protocolVersion: Message.Version,
     authHandshaker: AuthHandshaker,
@@ -239,9 +237,9 @@ class RLPxConnectionHandler(
 }
 
 object RLPxConnectionHandler {
-  def props(nodeKey: AsymmetricCipherKeyPair, messageDecoder: MessageDecoder, protocolVersion: Int,
+  def props(messageDecoder: MessageDecoder, protocolVersion: Int,
             authHandshaker: AuthHandshaker, rlpxConfiguration: RLPxConfiguration): Props =
-    Props(new RLPxConnectionHandler(nodeKey, messageDecoder, protocolVersion, authHandshaker,
+    Props(new RLPxConnectionHandler(messageDecoder, protocolVersion, authHandshaker,
       messageCodecFactory, rlpxConfiguration))
 
   def messageCodecFactory(secrets: Secrets, messageDecoder: MessageDecoder,

--- a/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
@@ -32,7 +32,6 @@ import io.iohk.ethereum.transactions.PendingTransactionsManager
 import io.iohk.ethereum.validators._
 import io.iohk.ethereum.vm.VM
 import io.iohk.ethereum.ommers.OmmersPool
-import io.iohk.ethereum.utils.Config.DbConfig
 
 trait BlockchainConfigBuilder {
   lazy val blockchainConfig = BlockchainConfig(Config.config)
@@ -163,7 +162,6 @@ trait PeerEventBusBuilder {
 trait PeerManagerActorBuilder {
 
   self: ActorSystemBuilder
-    with NodeStatusBuilder
     with HandshakerBuilder
     with PeerEventBusBuilder
     with AuthHandshakerBuilder
@@ -174,7 +172,6 @@ trait PeerManagerActorBuilder {
   lazy val peerConfiguration = Config.Network.peer
 
   lazy val peerManager = actorSystem.actorOf(PeerManagerActor.props(
-    nodeStatusHolder,
     peerDiscoveryManager,
     Config.Network.peer,
     peerEventBus,
@@ -290,12 +287,11 @@ trait EthServiceBuilder {
     SyncControllerBuilder with
     OmmersPoolBuilder with
     MiningConfigBuilder with
-    TxPoolConfigBuilder with
     FilterManagerBuilder with
     FilterConfigBuilder =>
 
   lazy val ethService = new EthService(storagesInstance.storages, blockGenerator, storagesInstance.storages.appStateStorage, miningConfig,
-    txPoolConfig, ledger, keyStore, pendingTransactionsManager, syncController, ommersPool, filterManager, filterConfig, blockchainConfig)
+    ledger, keyStore, pendingTransactionsManager, syncController, ommersPool, filterManager, filterConfig, blockchainConfig)
 }
 
 trait PersonalServiceBuilder {

--- a/src/main/scala/io/iohk/ethereum/utils/Config.scala
+++ b/src/main/scala/io/iohk/ethereum/utils/Config.scala
@@ -251,7 +251,7 @@ case class MonetaryPolicyConfig(
   firstEraBlockReward: BigInt
 ) {
   require(rewardRedutionRate >= 0.0 && rewardRedutionRate <= 1.0,
-    s"reward-reduction-rate should be a value in range [0.0, 1.0]")
+    "reward-reduction-rate should be a value in range [0.0, 1.0]")
 }
 
 object MonetaryPolicyConfig {

--- a/src/main/scala/io/iohk/ethereum/vm/OpCode.scala
+++ b/src/main/scala/io/iohk/ethereum/vm/OpCode.scala
@@ -653,7 +653,7 @@ sealed abstract class LogOp(code: Int, val i: Int) extends OpCode(code, i + 2, 0
   }
 
   protected def varGas[W <: WorldStateProxy[W, S], S <: Storage[S]](state: ProgramState[W, S]): BigInt = {
-    val (Seq(offset, size, _*), stack1) = state.stack.pop(delta)
+    val (Seq(offset, size, _*), _) = state.stack.pop(delta)
     val memCost = state.config.calcMemCost(state.memory.size, offset, size)
     val logCost = state.config.feeSchedule.G_logdata * size + i * state.config.feeSchedule.G_logtopic
     memCost + logCost

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/EthServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/EthServiceSpec.scala
@@ -782,17 +782,12 @@ class EthServiceSpec extends FlatSpec with Matchers with ScalaFutures with MockF
       override val ommerPoolQueryTimeout: FiniteDuration = Timeouts.normalTimeout
     }
 
-    val txPoolConfig = new TxPoolConfig {
-      val txPoolSize: Int = 1000
-      val pendingTxManagerQueryTimeout: FiniteDuration = Timeouts.normalTimeout
-    }
-
     val filterConfig = new FilterConfig {
       override val filterTimeout: FiniteDuration = Timeouts.normalTimeout
       override val filterManagerQueryTimeout: FiniteDuration = Timeouts.normalTimeout
     }
 
-    val ethService = new EthService(storagesInstance.storages, blockGenerator, appStateStorage, miningConfig, txPoolConfig, ledger,
+    val ethService = new EthService(storagesInstance.storages, blockGenerator, appStateStorage, miningConfig, ledger,
       keyStore, pendingTransactionsManager.ref, syncingController.ref, ommersPool.ref, filterManager.ref, filterConfig, blockchainConfig)
 
     val blockToRequest = Block(Fixtures.Blocks.Block3125369.header, Fixtures.Blocks.Block3125369.body)

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerSpec.scala
@@ -1308,11 +1308,6 @@ class JsonRpcControllerSpec extends FlatSpec with Matchers with PropertyChecks w
       override val ommerPoolQueryTimeout: FiniteDuration = Timeouts.normalTimeout
     }
 
-    val txPoolConfig = new TxPoolConfig {
-      val txPoolSize: Int = 1000
-      val pendingTxManagerQueryTimeout: FiniteDuration = Timeouts.normalTimeout
-    }
-
     val filterConfig = new FilterConfig {
       override val filterTimeout: FiniteDuration = Timeouts.normalTimeout
       override val filterManagerQueryTimeout: FiniteDuration = Timeouts.normalTimeout
@@ -1322,7 +1317,7 @@ class JsonRpcControllerSpec extends FlatSpec with Matchers with PropertyChecks w
     val web3Service = new Web3Service
     val netService = mock[NetService]
     val personalService = mock[PersonalService]
-    val ethService = new EthService(storagesInstance.storages, blockGenerator, appStateStorage, miningConfig, txPoolConfig, ledger,
+    val ethService = new EthService(storagesInstance.storages, blockGenerator, appStateStorage, miningConfig, ledger,
       keyStore, pendingTransactionsManager.ref, syncingController.ref, ommersPool.ref, filterManager.ref, filterConfig, blockchainConfig)
     val jsonRpcController = new JsonRpcController(web3Service, netService, ethService, personalService, config)
 

--- a/src/test/scala/io/iohk/ethereum/network/rlpx/RLPxConnectionHandlerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/network/rlpx/RLPxConnectionHandlerSpec.scala
@@ -4,7 +4,7 @@ import akka.actor.{ActorSystem, Props}
 import akka.io.Tcp
 import akka.testkit.{TestActorRef, TestProbe}
 import akka.util.ByteString
-import io.iohk.ethereum.{Timeouts, crypto}
+import io.iohk.ethereum.Timeouts
 import io.iohk.ethereum.network.p2p.Message.Version
 import io.iohk.ethereum.network.p2p.{MessageDecoder, MessageSerializable}
 import io.iohk.ethereum.network.p2p.messages.Versions
@@ -115,7 +115,6 @@ class RLPxConnectionHandlerSpec extends FlatSpec with Matchers with MockFactory 
     implicit val system = ActorSystem("RLPxHandlerSpec_System")
 
     //Mock parameters for RLPxConnectionHandler
-    val nodeKey = crypto.generateKeyPair(secureRandom)
     val mockMessageDecoder = new MessageDecoder {
       override def fromBytes(`type`: Int, payload: Array[Byte], protocolVersion: Version) =
         throw new Exception("Mock message decoder fails to decode all messages")
@@ -133,7 +132,7 @@ class RLPxConnectionHandlerSpec extends FlatSpec with Matchers with MockFactory 
     val rlpxConnectionParent = TestProbe()
     val rlpxConnection = TestActorRef(
       Props(new RLPxConnectionHandler(
-        nodeKey, mockMessageDecoder, protocolVersion, mockHandshaker, (_, _, _) => mockMessageCodec, rlpxConfiguration)),
+        mockMessageDecoder, protocolVersion, mockHandshaker, (_, _, _) => mockMessageCodec, rlpxConfiguration)),
       rlpxConnectionParent.ref)
 
     //Setup for RLPxConnection, after it the RLPxConnectionHandler is in a handshaked state


### PR DESCRIPTION
## Description

Includes fixes to several issues detected while running various static analysis tools.
The problems fixed were:
* Removed unused class constructors (`txPoolConfig` from `EthService` and `nodeKey` from `RLPxConnectionHandler`).
* Removed unused parameter when pattern matching on `LogOp`.
* Removed empty interpolated string (`s"..."`).
* Removed unused imports.