### PR TITLE
[EC-256] Regression test for fast sync

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -294,6 +294,10 @@ grothendieck {
     # same peer for previous blocks, until we find one that we have a parent for. This setting determines the batch size
     # of such query (number of blocks returned in a single query).
     block-resolving-depth = 20
+
+    # size of the list that keeps track of peers that are failing to provide us with mpt node
+    # we switch them to download only blockchain elements
+    fastsync-block-chain-only-peers-pool = 100
   }
 
   pruning {

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/FastSync.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/FastSync.scala
@@ -125,7 +125,7 @@ trait FastSync {
       val targetBlockHeaderOpt = blockHeaders.headers.find(header => header.number == targetBlockNumber)
       targetBlockHeaderOpt match {
         case Some(targetBlockHeader) =>
-          log.info("Starting block synchronization (fast mode)")
+          log.info(s"Starting block synchronization (fast mode), target block ${targetBlockHeader.number}")
           val initialSyncState = SyncState(targetBlockHeader,
             mptNodesQueue = Seq(StateMptNodeHash(targetBlockHeader.stateRoot)))
           startFastSync(initialSyncState)

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/FastSync.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/FastSync.scala
@@ -5,7 +5,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import akka.actor._
 import akka.util.ByteString
 import io.iohk.ethereum.domain.BlockHeader
-import io.iohk.ethereum.network.{EtcPeerManagerActor, Peer, PeerActor}
+import io.iohk.ethereum.network.{EtcPeerManagerActor, Peer}
 import io.iohk.ethereum.network.PeerEventBusActor.PeerEvent.MessageFromPeer
 import io.iohk.ethereum.network.PeerEventBusActor.{PeerSelector, Subscribe, Unsubscribe}
 import io.iohk.ethereum.network.PeerEventBusActor.SubscriptionClassifier.MessageClassifier
@@ -235,7 +235,7 @@ trait FastSync {
 
     private def handleFailingMptPeers: Receive ={
       case BlockChainOnlyDownload(peer) =>
-        blockChainOnlyPeers = blockChainOnlyPeers + peer
+        blockChainOnlyPeers = (blockChainOnlyPeers + peer).take(blockChainOnlyPeersPoolSize)
     }
 
     private def printStatus() = {

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/FastSync.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/FastSync.scala
@@ -239,7 +239,7 @@ trait FastSync {
 
     private def handleFailingMptPeers: Receive = {
       case MarkPeerBlockchainOnly(peer) => if (!blockChainOnlyPeers.contains(peer)) {
-        blockChainOnlyPeers = peer +: blockChainOnlyPeers.dropRight(1)
+        blockChainOnlyPeers = (peer +: blockChainOnlyPeers).take(blockChainOnlyPeersPoolSize)
       }
     }
 

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/FastSync.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/FastSync.scala
@@ -331,10 +331,12 @@ trait FastSync {
         val peers = unassignedPeers
         (peers -- blockChainOnlyPeers)
           .take(maxConcurrentRequests - assignedHandlers.size)
+          .toSeq.sortBy(_.ref.toString())
           .foreach(assignWork)
         peers
           .intersect(blockChainOnlyPeers)
           .take(maxConcurrentRequests - assignedHandlers.size)
+          .toSeq.sortBy(_.ref.toString())
           .foreach(assignBlockChainWork)
       }
     }

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/FastSync.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/FastSync.scala
@@ -304,6 +304,7 @@ trait FastSync {
       cleanup()
       appStateStorage.fastSyncDone()
       context become idle
+      blockChainOnlyPeers = Set.empty
       self ! FastSyncDone
     }
 

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/FastSyncNodesRequestHandler.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/FastSyncNodesRequestHandler.scala
@@ -25,7 +25,7 @@ class FastSyncNodesRequestHandler(
   override def handleResponseMsg(nodeData: NodeData): Unit = {
     if (nodeData.values.isEmpty) {
       log.debug(s"got empty mpt node response for known hashes switching to blockchain only: ${requestedHashes.map(h => Hex.toHexString(h.v.toArray[Byte]))}")
-      syncController ! BlockChainOnlyDownload(peer)
+      syncController ! MarkPeerBlockchainOnly(peer)
     }
 
     val receivedHashes = nodeData.values.map(v => ByteString(kec256(v.toArray[Byte])))

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/FastSyncNodesRequestHandler.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/FastSyncNodesRequestHandler.scala
@@ -24,8 +24,8 @@ class FastSyncNodesRequestHandler(
 
   override def handleResponseMsg(nodeData: NodeData): Unit = {
     if (nodeData.values.isEmpty) {
-      val reason = s"got empty mpt node response for known hashes: ${requestedHashes.map(h => Hex.toHexString(h.v.toArray[Byte]))}"
-      syncController ! BlacklistSupport.BlacklistPeer(peer.id, reason)
+      log.debug(s"got empty mpt node response for known hashes switching to blockchain only: ${requestedHashes.map(h => Hex.toHexString(h.v.toArray[Byte]))}")
+      syncController ! BlockChainOnlyDownload(peer)
     }
 
     val receivedHashes = nodeData.values.map(v => ByteString(kec256(v.toArray[Byte])))

--- a/src/main/scala/io/iohk/ethereum/utils/Config.scala
+++ b/src/main/scala/io/iohk/ethereum/utils/Config.scala
@@ -116,6 +116,7 @@ object Config {
 
     val checkForNewBlockInterval: FiniteDuration = syncConfig.getDuration("check-for-new-block-interval").toMillis.millis
     val blockResolveDepth: Int = syncConfig.getInt("block-resolving-depth")
+    val blockChainOnlyPeersPoolSize: Int = syncConfig.getInt("fastsync-block-chain-only-peers-pool")
   }
 
   trait DbConfig {

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/SyncControllerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/SyncControllerSpec.scala
@@ -81,8 +81,10 @@ class SyncControllerSpec extends FlatSpec with Matchers {
     )
     etcPeerManager.expectNoMsg()
 
-    peerMessageBus.expectMsg(Subscribe(MessageClassifier(Set(BlockHeaders.code), PeerSelector.WithId(peer2.id))))
-    peerMessageBus.expectMsg(Subscribe(MessageClassifier(Set(NodeData.code), PeerSelector.WithId(peer1.id))))
+    peerMessageBus.expectMsgAllOf(
+      Subscribe(MessageClassifier(Set(BlockHeaders.code), PeerSelector.WithId(peer2.id))),
+      Subscribe(MessageClassifier(Set(NodeData.code), PeerSelector.WithId(peer1.id)))
+    )
   }
 
   it should "download target block, request state, blocks and finish when downloaded" in new TestSetup() {

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/SyncControllerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/SyncControllerSpec.scala
@@ -69,21 +69,17 @@ class SyncControllerSpec extends FlatSpec with Matchers {
     peerMessageBus.expectMsg(Subscribe(MessageClassifier(Set(BlockHeaders.code), PeerSelector.WithId(peer2.id))))
     etcPeerManager.expectMsg(
       EtcPeerManagerActor.SendMessage(GetBlockHeaders(Left(expectedTargetBlock), 1, 0, reverse = false), peer2.id))
-    syncController ! MessageFromPeer(BlockHeaders(Seq(targetBlockHeader)), peer2.id)
 
     storagesInstance.storages.appStateStorage.putBestBlockNumber(targetBlockHeader.number)
+    syncController ! MessageFromPeer(BlockHeaders(Seq(targetBlockHeader)), peer2.id)
 
     peerMessageBus.expectMsg(Unsubscribe(MessageClassifier(Set(BlockHeaders.code), PeerSelector.WithId(peer2.id))))
     etcPeerManager.expectMsg(EtcPeerManagerActor.SendMessage(GetBlockHeaders(Left(1), 10, 0, reverse = false), peer2.id))
     peerMessageBus.expectMsg(Subscribe(MessageClassifier(Set(BlockHeaders.code), PeerSelector.WithId(peer2.id))))
 
-    val blockHeadersRequestHandler: ActorRef = peerMessageBus.sender()
-    peerMessageBus.send(syncController, PeerDisconnected(peer1.id))
-    peerMessageBus.send(blockHeadersRequestHandler, PeerDisconnected(peer1.id))
-
     etcPeerManager.expectMsg(EtcPeerManagerActor.SendMessage(GetNodeData(Seq(targetBlockHeader.stateRoot)), peer1.id))
     peerMessageBus.expectMsg(Subscribe(MessageClassifier(Set(NodeData.code), PeerSelector.WithId(peer1.id))))
-    peerMessageBus.expectNoMsg()
+    etcPeerManager.expectNoMsg()
   }
 
   it should "download target block, request state, blocks and finish when downloaded" in new TestSetup() {

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/SyncControllerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/SyncControllerSpec.scala
@@ -74,12 +74,15 @@ class SyncControllerSpec extends FlatSpec with Matchers {
     syncController ! MessageFromPeer(BlockHeaders(Seq(targetBlockHeader)), peer2.id)
 
     peerMessageBus.expectMsg(Unsubscribe(MessageClassifier(Set(BlockHeaders.code), PeerSelector.WithId(peer2.id))))
-    etcPeerManager.expectMsg(EtcPeerManagerActor.SendMessage(GetBlockHeaders(Left(1), 10, 0, reverse = false), peer2.id))
-    peerMessageBus.expectMsg(Subscribe(MessageClassifier(Set(BlockHeaders.code), PeerSelector.WithId(peer2.id))))
 
-    etcPeerManager.expectMsg(EtcPeerManagerActor.SendMessage(GetNodeData(Seq(targetBlockHeader.stateRoot)), peer1.id))
-    peerMessageBus.expectMsg(Subscribe(MessageClassifier(Set(NodeData.code), PeerSelector.WithId(peer1.id))))
+    etcPeerManager.expectMsgAllOf(
+      EtcPeerManagerActor.SendMessage(GetNodeData(Seq(targetBlockHeader.stateRoot)), peer1.id),
+      EtcPeerManagerActor.SendMessage(GetBlockHeaders(Left(1), 10, 0, reverse = false), peer2.id)
+    )
     etcPeerManager.expectNoMsg()
+
+    peerMessageBus.expectMsg(Subscribe(MessageClassifier(Set(BlockHeaders.code), PeerSelector.WithId(peer2.id))))
+    peerMessageBus.expectMsg(Subscribe(MessageClassifier(Set(NodeData.code), PeerSelector.WithId(peer1.id))))
   }
 
   it should "download target block, request state, blocks and finish when downloaded" in new TestSetup() {


### PR DESCRIPTION
this PR is to not blacklist peers which are not responding with mpt nodes, instead we mark them as blockchain only, this PR also changes order in which we schedule fast sync element to get mpt as fast as possible