### PR TITLE
Handle invalid MAC exception on RLPxConnectionHandler

### DIFF
--- a/src/main/scala/io/iohk/ethereum/network/PeerActor.scala
+++ b/src/main/scala/io/iohk/ethereum/network/PeerActor.scala
@@ -2,11 +2,9 @@ package io.iohk.ethereum.network
 
 import java.net.{InetSocketAddress, URI}
 
-import akka.actor.SupervisorStrategy.Stop
+import akka.actor.SupervisorStrategy.Escalate
 import io.iohk.ethereum.network.PeerManagerActor.PeerConfiguration
 import akka.actor._
-import akka.agent.Agent
-import akka.util.ByteString
 import io.iohk.ethereum.network.p2p._
 import io.iohk.ethereum.network.p2p.messages.WireProtocol._
 import io.iohk.ethereum.network.p2p.messages.Versions
@@ -14,12 +12,10 @@ import io.iohk.ethereum.network.rlpx.{AuthHandshaker, RLPxConnectionHandler}
 import io.iohk.ethereum.network.PeerActor.Status._
 import io.iohk.ethereum.network.PeerEventBusActor.PeerEvent.{MessageFromPeer, PeerHandshakeSuccessful}
 import io.iohk.ethereum.network.PeerEventBusActor.Publish
-import io.iohk.ethereum.utils.NodeStatus
 import io.iohk.ethereum.network.handshaker.Handshaker
 import io.iohk.ethereum.network.handshaker.Handshaker.HandshakeComplete.{HandshakeFailure, HandshakeSuccess}
 import io.iohk.ethereum.network.handshaker.Handshaker.{HandshakeResult, NextMessage}
 import io.iohk.ethereum.network.rlpx.RLPxConnectionHandler.RLPxConfiguration
-import org.spongycastle.crypto.AsymmetricCipherKeyPair
 import org.spongycastle.util.encoders.Hex
 
 
@@ -46,7 +42,7 @@ class PeerActor[R <: HandshakeResult](
 
   override val supervisorStrategy: OneForOneStrategy =
     OneForOneStrategy() {
-      case _ => Stop
+      case _ => Escalate
     }
 
   def scheduler: Scheduler = externalSchedulerOpt getOrElse system.scheduler

--- a/src/main/scala/io/iohk/ethereum/network/PeerActor.scala
+++ b/src/main/scala/io/iohk/ethereum/network/PeerActor.scala
@@ -2,6 +2,7 @@ package io.iohk.ethereum.network
 
 import java.net.{InetSocketAddress, URI}
 
+import akka.actor.SupervisorStrategy.Stop
 import io.iohk.ethereum.network.PeerManagerActor.PeerConfiguration
 import akka.actor._
 import akka.agent.Agent
@@ -41,6 +42,11 @@ class PeerActor[R <: HandshakeResult](
 
   import PeerActor._
   import context.{dispatcher, system}
+
+  override val supervisorStrategy: OneForOneStrategy =
+    OneForOneStrategy() {
+      case _ => Stop
+    }
 
   def scheduler: Scheduler = externalSchedulerOpt getOrElse system.scheduler
 

--- a/src/main/scala/io/iohk/ethereum/network/rlpx/RLPxConnectionHandler.scala
+++ b/src/main/scala/io/iohk/ethereum/network/rlpx/RLPxConnectionHandler.scala
@@ -93,7 +93,7 @@ class RLPxConnectionHandler(
               processHandshakeResult(result, remainingData)
 
             case Failure(ex) =>
-              log.warning(s"[Stopping Connection] Init AuthHandshaker message handling failed for peer $peerId due to ${ex.getMessage}")
+              log.debug(s"[Stopping Connection] Init AuthHandshaker message handling failed for peer $peerId due to ${ex.getMessage}")
               context.parent ! ConnectionFailed
               context stop self
           }
@@ -116,7 +116,7 @@ class RLPxConnectionHandler(
           maybePreEIP8Result orElse maybePostEIP8Result match {
             case Success((result, remainingData)) => processHandshakeResult(result, remainingData)
             case Failure(ex) =>
-              log.warning(s"[Stopping Connection] Response AuthHandshaker message handling failed for peer $peerId due to ${ex.getMessage}")
+              log.debug(s"[Stopping Connection] Response AuthHandshaker message handling failed for peer $peerId due to ${ex.getMessage}")
               context.parent ! ConnectionFailed
               context stop self
           }

--- a/src/main/scala/io/iohk/ethereum/network/rlpx/RLPxConnectionHandler.scala
+++ b/src/main/scala/io/iohk/ethereum/network/rlpx/RLPxConnectionHandler.scala
@@ -42,9 +42,11 @@ class RLPxConnectionHandler(
 
   override def receive: Receive = waitingForCommand
 
+  def tcpActor: ActorRef = IO(Tcp)
+
   def waitingForCommand: Receive = {
     case ConnectTo(uri) =>
-      IO(Tcp) ! Connect(new InetSocketAddress(uri.getHost, uri.getPort))
+      tcpActor ! Connect(new InetSocketAddress(uri.getHost, uri.getPort))
       context become waitingForConnectionResult(uri)
 
     case HandleConnection(connection) =>
@@ -74,20 +76,27 @@ class RLPxConnectionHandler(
       handleTimeout orElse handleConnectionClosed orElse {
         case Received(data) =>
           timeout.cancel()
-          Try(handshaker.handleInitialMessage(data.take(InitiatePacketLength))) match {
-            case Success((responsePacket, result)) =>
-              // process pre-eip8 message
-              val remainingData = data.drop(InitiatePacketLength)
+          val maybePreEIP8Result = Try {
+            val (responsePacket, result) = handshaker.handleInitialMessage(data.take(InitiatePacketLength))
+            val remainingData = data.drop(InitiatePacketLength)
+            (responsePacket, result, remainingData)
+          }
+          lazy val maybePostEIP8Result = Try {
+            val encryptedPayloadSize = ByteUtils.bigEndianToShort(data.take(2).toArray)
+            val (packetData, remainingData) = data.splitAt(encryptedPayloadSize + 2)
+            val (responsePacket, result) = handshaker.handleInitialMessageV4(packetData)
+            (responsePacket, result, remainingData)
+          }
+
+          maybePreEIP8Result orElse maybePostEIP8Result match {
+            case Success((responsePacket, result, remainingData)) =>
               connection ! Write(responsePacket)
               processHandshakeResult(result, remainingData)
 
-            case Failure(_) =>
-              // process as eip8 message
-              val encryptedPayloadSize = ByteUtils.bigEndianToShort(data.take(2).toArray)
-              val (packetData, remainingData) = data.splitAt(encryptedPayloadSize + 2)
-              val (responsePacket, result) = handshaker.handleInitialMessageV4(packetData)
-              connection ! Write(responsePacket)
-              processHandshakeResult(result, remainingData)
+            case Failure(ex) =>
+              log.warning(s"[Stopping Connection] Init AuthHandshaker message handling failed for peer $peerId due to ${ex.getMessage}")
+              context.parent ! ConnectionFailed
+              context stop self
           }
       }
 
@@ -95,18 +104,23 @@ class RLPxConnectionHandler(
       handleWriteFailed orElse handleTimeout orElse handleConnectionClosed orElse {
         case Received(data) =>
           timeout.cancel()
-          Try(handshaker.handleResponseMessage(data.take(ResponsePacketLength))) match {
-            case Success(result) =>
-              // process pre-eip8 message
-              val remainingData = data.drop(ResponsePacketLength)
-              processHandshakeResult(result, remainingData)
-
-            case Failure(_) =>
-              // process as eip8 message
-              val size = ByteUtils.bigEndianToShort(data.take(2).toArray)
-              val (packetData, remainingData) = data.splitAt(size + 2)
-              val result = handshaker.handleResponseMessageV4(packetData)
-              processHandshakeResult(result, remainingData)
+          val maybePreEIP8Result = Try {
+            val result = handshaker.handleResponseMessage(data.take(ResponsePacketLength))
+            val remainingData = data.drop(ResponsePacketLength)
+            (result, remainingData)
+          }
+          val maybePostEIP8Result = Try {
+            val size = ByteUtils.bigEndianToShort(data.take(2).toArray)
+            val (packetData, remainingData) = data.splitAt(size + 2)
+            val result = handshaker.handleResponseMessageV4(packetData)
+            (result, remainingData)
+          }
+          maybePreEIP8Result orElse maybePostEIP8Result match {
+            case Success((result, remainingData)) => processHandshakeResult(result, remainingData)
+            case Failure(ex) =>
+              log.warning(s"[Stopping Connection] Response AuthHandshaker message handling failed for peer $peerId due to ${ex.getMessage}")
+              context.parent ! ConnectionFailed
+              context stop self
           }
       }
 

--- a/src/test/scala/io/iohk/ethereum/network/rlpx/RLPxConnectionHandlerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/network/rlpx/RLPxConnectionHandlerSpec.scala
@@ -1,6 +1,8 @@
 package io.iohk.ethereum.network.rlpx
 
-import akka.actor.{ActorSystem, Props}
+import java.net.{InetSocketAddress, URI}
+
+import akka.actor.{ActorRef, ActorSystem, Props}
 import akka.io.Tcp
 import akka.testkit.{TestActorRef, TestProbe}
 import akka.util.ByteString
@@ -20,7 +22,7 @@ class RLPxConnectionHandlerSpec extends FlatSpec with Matchers with MockFactory 
 
   it should "write messages send to TCP connection" in new TestSetup {
 
-    setupRLPxConnection()
+    setupIncomingRLPxConnection()
 
     (mockMessageCodec.encodeMessage _).expects(Ping(): MessageSerializable).returning(ByteString("ping encoded"))
     rlpxConnection ! RLPxConnectionHandler.SendMessage(Ping())
@@ -32,7 +34,7 @@ class RLPxConnectionHandlerSpec extends FlatSpec with Matchers with MockFactory 
 
     (mockMessageCodec.encodeMessage _).expects(Ping(): MessageSerializable).returning(ByteString("ping encoded")).anyNumberOfTimes()
 
-    setupRLPxConnection()
+    setupIncomingRLPxConnection()
 
     //Send first message
     rlpxConnection ! RLPxConnectionHandler.SendMessage(Ping())
@@ -51,7 +53,7 @@ class RLPxConnectionHandlerSpec extends FlatSpec with Matchers with MockFactory 
 
     (mockMessageCodec.encodeMessage _).expects(Ping(): MessageSerializable).returning(ByteString("ping encoded")).anyNumberOfTimes()
 
-    setupRLPxConnection()
+    setupIncomingRLPxConnection()
 
     //Send several messages
     rlpxConnection ! RLPxConnectionHandler.SendMessage(Ping())
@@ -76,9 +78,7 @@ class RLPxConnectionHandlerSpec extends FlatSpec with Matchers with MockFactory 
   it should "close the connection when Ack timeout happens" in new TestSetup {
     (mockMessageCodec.encodeMessage _).expects(Ping(): MessageSerializable).returning(ByteString("ping encoded")).anyNumberOfTimes()
 
-    setupRLPxConnection()
-
-    rlpxConnectionParent watch rlpxConnection
+    setupIncomingRLPxConnection()
 
     rlpxConnection ! RLPxConnectionHandler.SendMessage(Ping())
     connection.expectMsg(Tcp.Write(ByteString("ping encoded"), RLPxConnectionHandler.Ack))
@@ -90,7 +90,7 @@ class RLPxConnectionHandlerSpec extends FlatSpec with Matchers with MockFactory 
   it should "ignore timeout of old messages" in new TestSetup {
     (mockMessageCodec.encodeMessage _).expects(Ping(): MessageSerializable).returning(ByteString("ping encoded")).anyNumberOfTimes()
 
-    setupRLPxConnection()
+    setupIncomingRLPxConnection()
 
     rlpxConnection ! RLPxConnectionHandler.SendMessage(Ping()) //With SEQ number 0
     rlpxConnection ! RLPxConnectionHandler.SendMessage(Ping()) //With SEQ number 1
@@ -111,6 +111,44 @@ class RLPxConnectionHandlerSpec extends FlatSpec with Matchers with MockFactory 
     connection.expectMsg(Tcp.Write(ByteString("ping encoded"), RLPxConnectionHandler.Ack))
   }
 
+  it should "close the connection if the AuthHandshake init message's MAC is invalid" in new TestSetup {
+    //Incomming connection arrives
+    rlpxConnection ! RLPxConnectionHandler.HandleConnection(connection.ref)
+    connection.expectMsgClass(classOf[Tcp.Register])
+
+    //AuthHandshaker throws exception on initial message
+    (mockHandshaker.handleInitialMessage _).expects(*).onCall{_: ByteString => throw new Exception("MAC invalid")}
+    (mockHandshaker.handleInitialMessageV4 _).expects(*).onCall{_: ByteString => throw new Exception("MAC invalid")}
+
+    val data = ByteString((0 until AuthHandshaker.InitiatePacketLength).map(_.toByte).toArray)
+    rlpxConnection ! Tcp.Received(data)
+    rlpxConnectionParent.expectMsg(RLPxConnectionHandler.ConnectionFailed)
+    rlpxConnectionParent.expectTerminated(rlpxConnection)
+  }
+
+  it should "close the connection if the AuthHandshake response message's MAC is invalid" in new TestSetup {
+    //Outgoing connection request arrives
+    rlpxConnection ! RLPxConnectionHandler.ConnectTo(uri)
+    tcpActorProbe.expectMsg(Tcp.Connect(inetAddress))
+
+    //The TCP connection results are handled
+    val initPacket = ByteString("Init packet")
+    (mockHandshaker.initiate _).expects(uri).returning(initPacket -> mockHandshaker)
+
+    tcpActorProbe.reply(Tcp.Connected(inetAddress, inetAddress))
+    tcpActorProbe.expectMsg(Tcp.Register(rlpxConnection))
+    tcpActorProbe.expectMsg(Tcp.Write(initPacket))
+
+    //AuthHandshaker handles the response message (that throws an invalid MAC)
+    (mockHandshaker.handleResponseMessage _).expects(*).onCall{_: ByteString => throw new Exception("MAC invalid")}
+    (mockHandshaker.handleResponseMessageV4 _).expects(*).onCall{_: ByteString => throw new Exception("MAC invalid")}
+
+    val data = ByteString((0 until AuthHandshaker.ResponsePacketLength).map(_.toByte).toArray)
+    rlpxConnection ! Tcp.Received(data)
+    rlpxConnectionParent.expectMsg(RLPxConnectionHandler.ConnectionFailed)
+    rlpxConnectionParent.expectTerminated(rlpxConnection)
+  }
+
   trait TestSetup extends MockFactory with SecureRandomBuilder {
     implicit val system = ActorSystem("RLPxHandlerSpec_System")
 
@@ -124,19 +162,27 @@ class RLPxConnectionHandlerSpec extends FlatSpec with Matchers with MockFactory 
     val connection = TestProbe()
     val mockMessageCodec = mock[MessageCodec]
 
+    val uri = new URI("enode://18a551bee469c2e02de660ab01dede06503c986f6b8520cb5a65ad122df88b17b285e3fef09a40a0d44f99e014f8616cf1ebc2e094f96c6e09e2f390f5d34857@47.90.36.129:30303")
+    val inetAddress = new InetSocketAddress(uri.getHost, uri.getPort)
+
     val rlpxConfiguration = new RLPxConfiguration {
       override val waitForTcpAckTimeout: FiniteDuration = Timeouts.normalTimeout
-      override val waitForHandshakeTimeout: FiniteDuration = Timeouts.normalTimeout
+
+      //unused
+      override val waitForHandshakeTimeout: FiniteDuration = Timeouts.veryLongTimeout
     }
 
+    val tcpActorProbe = TestProbe()
     val rlpxConnectionParent = TestProbe()
     val rlpxConnection = TestActorRef(
-      Props(new RLPxConnectionHandler(
-        mockMessageDecoder, protocolVersion, mockHandshaker, (_, _, _) => mockMessageCodec, rlpxConfiguration)),
+      Props(new RLPxConnectionHandler(mockMessageDecoder, protocolVersion, mockHandshaker, (_, _, _) => mockMessageCodec, rlpxConfiguration) {
+        override def tcpActor: ActorRef = tcpActorProbe.ref
+      }),
       rlpxConnectionParent.ref)
+    rlpxConnectionParent watch rlpxConnection
 
     //Setup for RLPxConnection, after it the RLPxConnectionHandler is in a handshaked state
-    def setupRLPxConnection(): Unit = {
+    def setupIncomingRLPxConnection(): Unit = {
       //Start setting up connection
       rlpxConnection ! RLPxConnectionHandler.HandleConnection(connection.ref)
       connection.expectMsgClass(classOf[Tcp.Register])


### PR DESCRIPTION
## Description
In case incoming connections are enabled (having `server-address.interface="0.0.0.0"`), when a client is restarted with a new node key, many incoming connection attempts were received that caused both an invalid MAC and increasing the number of connected nodes well beyond the limit (ex: `Discovered 0 nodes, connected to 94/45. Trying to connect to 0 more nodes.`).

## Fix
This PR includes a fix to the huge number of connected nodes, which was caused by the [exception restarting the RLPxConnectionHandler](http://doc.akka.io/docs/akka/current/scala/fault-tolerance.html#default-supervisor-strategy), as no handling of this exception was done. This was fixed by closing the connection in case any exception happened during the MAC check.

**Note:** In the depicted scenario the invalid MAC was caused by peers trying to connect to our node using the previous node key in the RLPx handshake, as the MAC incorporates the node key, so it is an expected exception.