### PR TITLE
Missing block headers

### DIFF
--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/FastSync.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/FastSync.scala
@@ -232,6 +232,7 @@ trait FastSync {
         case DbError =>
           blockBodiesQueue = Seq.empty
           receiptsQueue = Seq.empty
+          //todo adjust the formula to minimize redownloaded block headers
           bestBlockHeaderNumber = bestBlockHeaderNumber - 2 * blockHeadersPerRequest
           log.debug("missing block header for known hash")
           self ! ProcessSyncing


### PR DESCRIPTION
This PR handle case when we have requested block bodies by hashes for block headers that are not in our DB, this may happen because of killing client while persisting data