### PR TITLE
[EC-269] Fixed net_version on Morden

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -24,7 +24,7 @@ mantis {
 
   network {
     # Ethereum protocol version
-    protocol-version = "1"
+    protocol-version = 63
 
     server-address {
       # Listening interface for Ethereum protocol connections

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/EthService.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/EthService.scala
@@ -37,8 +37,6 @@ import scala.util.{Failure, Success, Try}
 // scalastyle:off number.of.methods number.of.types
 object EthService {
 
-  val CurrentProtocolVersion = 63
-
   case class ProtocolVersionRequest()
   case class ProtocolVersionResponse(value: String)
 
@@ -180,7 +178,8 @@ class EthService(
     ommersPool: ActorRef,
     filterManager: ActorRef,
     filterConfig: FilterConfig,
-    blockchainConfig: BlockchainConfig)
+    blockchainConfig: BlockchainConfig,
+    protocolVersion: Int)
   extends Logger {
 
   import EthService._
@@ -191,7 +190,7 @@ class EthService(
   val lastActive = new AtomicReference[Option[Date]](None)
 
   def protocolVersion(req: ProtocolVersionRequest): ServiceResponse[ProtocolVersionResponse] =
-    Future.successful(Right(ProtocolVersionResponse(f"0x$CurrentProtocolVersion%x")))
+    Future.successful(Right(ProtocolVersionResponse(f"0x$protocolVersion%x")))
 
   /**
     * eth_blockNumber that returns the number of most recent block.

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/NetService.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/NetService.scala
@@ -36,9 +36,8 @@ object NetService {
 class NetService(nodeStatusHolder: Agent[NodeStatus], peerManager: ActorRef, config: NetServiceConfig) {
   import NetService._
 
-  def version(req: VersionRequest): ServiceResponse[VersionResponse] = {
-    Future.successful(Right(VersionResponse(Config.Network.protocolVersion)))
-  }
+  def version(req: VersionRequest): ServiceResponse[VersionResponse] =
+    Future.successful(Right(VersionResponse(Config.Network.peer.networkId.toString)))
 
   def listening(req: ListeningRequest): ServiceResponse[ListeningResponse] = {
     Future.successful {

--- a/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
@@ -291,8 +291,9 @@ trait EthServiceBuilder {
     FilterManagerBuilder with
     FilterConfigBuilder =>
 
-  lazy val ethService = new EthService(storagesInstance.storages, blockGenerator, storagesInstance.storages.appStateStorage, miningConfig,
-    ledger, keyStore, pendingTransactionsManager, syncController, ommersPool, filterManager, filterConfig, blockchainConfig)
+  lazy val ethService = new EthService(storagesInstance.storages, blockGenerator, storagesInstance.storages.appStateStorage,
+    miningConfig, ledger, keyStore, pendingTransactionsManager, syncController, ommersPool, filterManager, filterConfig,
+    blockchainConfig, Config.Network.protocolVersion)
 }
 
 trait PersonalServiceBuilder {

--- a/src/main/scala/io/iohk/ethereum/utils/Config.scala
+++ b/src/main/scala/io/iohk/ethereum/utils/Config.scala
@@ -38,7 +38,7 @@ object Config {
   object Network {
     private val networkConfig = config.getConfig("network")
 
-    val protocolVersion = networkConfig.getString("protocol-version")
+    val protocolVersion = networkConfig.getInt("protocol-version")
 
     object Server {
       private val serverConfig = networkConfig.getConfig("server-address")

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/EthServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/EthServiceSpec.scala
@@ -52,8 +52,7 @@ class EthServiceSpec extends FlatSpec with Matchers with ScalaFutures with MockF
     val response = ethService.protocolVersion(ProtocolVersionRequest())
     val protocolVersion = response.futureValue.right.get.value
 
-    protocolVersion shouldEqual "0x3f"
-    Integer.parseInt(protocolVersion.drop(2), 16) shouldEqual EthService.CurrentProtocolVersion
+    Integer.parseInt(protocolVersion.drop(2), 16) shouldEqual currentProtocolVersion
   }
 
   it should "answer eth_getBlockTransactionCountByHash with None when the requested block isn't in the blockchain" in new TestSetup {
@@ -787,8 +786,10 @@ class EthServiceSpec extends FlatSpec with Matchers with ScalaFutures with MockF
       override val filterManagerQueryTimeout: FiniteDuration = Timeouts.normalTimeout
     }
 
+    val currentProtocolVersion = 11
+
     val ethService = new EthService(storagesInstance.storages, blockGenerator, appStateStorage, miningConfig, ledger,
-      keyStore, pendingTransactionsManager.ref, syncingController.ref, ommersPool.ref, filterManager.ref, filterConfig, blockchainConfig)
+      keyStore, pendingTransactionsManager.ref, syncingController.ref, ommersPool.ref, filterManager.ref, filterConfig, blockchainConfig, currentProtocolVersion)
 
     val blockToRequest = Block(Fixtures.Blocks.Block3125369.header, Fixtures.Blocks.Block3125369.body)
     val blockToRequestNumber = blockToRequest.header.number

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerSpec.scala
@@ -97,13 +97,15 @@ class JsonRpcControllerSpec extends FlatSpec with Matchers with PropertyChecks w
   }
 
   it should "Handle net_version request" in new TestSetup {
-    (netService.version _).expects(*).returning(Future.successful(Right(VersionResponse("99"))))
+    val netVersion = "99"
+
+    (netService.version _).expects(*).returning(Future.successful(Right(VersionResponse(netVersion))))
 
     val rpcRequest = JsonRpcRequest("2.0", "net_version", None, Some(1))
 
     val response = jsonRpcController.handleRequest(rpcRequest).futureValue
 
-    response.result shouldBe Some(JString("99"))
+    response.result shouldBe Some(JString(netVersion))
   }
 
   it should "eth_protocolVersion" in new TestSetup {
@@ -1313,12 +1315,15 @@ class JsonRpcControllerSpec extends FlatSpec with Matchers with PropertyChecks w
       override val filterManagerQueryTimeout: FiniteDuration = Timeouts.normalTimeout
     }
 
+    val currentProtocolVersion = 63
+
     val appStateStorage = mock[AppStateStorage]
     val web3Service = new Web3Service
     val netService = mock[NetService]
     val personalService = mock[PersonalService]
     val ethService = new EthService(storagesInstance.storages, blockGenerator, appStateStorage, miningConfig, ledger,
-      keyStore, pendingTransactionsManager.ref, syncingController.ref, ommersPool.ref, filterManager.ref, filterConfig, blockchainConfig)
+      keyStore, pendingTransactionsManager.ref, syncingController.ref, ommersPool.ref, filterManager.ref, filterConfig,
+      blockchainConfig, currentProtocolVersion)
     val jsonRpcController = new JsonRpcController(web3Service, netService, ethService, personalService, config)
 
     val blockHeader = BlockHeader(


### PR DESCRIPTION
## Description

When using the JSON RPC method `net_version` on the Morden testnet the value `"1"` was returned, while both the [specification](https://github.com/ethereum/wiki/wiki/JSON-RPC#net_version) and Geth and Parity clients return `"2"`.

## Fix

Fixed `net_version` to use `network-id` configuration instead of `protocol-version` (which never changed from `"1"`).
The value of `protocol-version` was also fixed according to [specification](https://github.com/ethereum/wiki/wiki/Ethereum-Wire-Protocol#ethereum-sub-protocol) and it was added to be used on `eth_protocolVersion`