### PR TITLE
[EC-278] Missing block headers when client is restarted

### DIFF
--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/FastSync.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/FastSync.scala
@@ -313,6 +313,10 @@ trait FastSync {
           bestBlockHeaderNumber = lastHeader.number
         }
       }
+
+      val blockHashes = blockHeadersObtained.map(_.hash)
+      self ! FastSync.EnqueueBlockBodies(blockHashes)
+      self ! FastSync.EnqueueReceipts(blockHashes)
     }
 
     def processSyncing(): Unit = {

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/SyncBlockHeadersRequestHandler.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/SyncBlockHeadersRequestHandler.scala
@@ -28,10 +28,7 @@ class SyncBlockHeadersRequestHandler(
         syncController ! SyncController.BlockHeadersToResolve(peer, headers)
         log.info("Received {} block headers in {} ms", headers.size, timeTakenSoFar())
       } else {
-        val blockHashes = headers.map(_.hash)
         syncController ! SyncController.BlockHeadersReceived(peer, headers)
-        syncController ! FastSync.EnqueueBlockBodies(blockHashes)
-        syncController ! FastSync.EnqueueReceipts(blockHashes)
         log.info("Received {} block headers in {} ms", headers.size, timeTakenSoFar())
       }
     } else {

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/FastSyncBlockHeadersRequestHandlerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/FastSyncBlockHeadersRequestHandlerSpec.scala
@@ -29,10 +29,7 @@ class FastSyncBlockHeadersRequestHandlerSpec extends FlatSpec with Matchers {
 
     peerMessageBus.reply(MessageFromPeer(BlockHeaders(responseHeaders), peer.id))
 
-    parent.expectMsgAllOf(
-      SyncController.BlockHeadersReceived(peer, responseHeaders),
-      FastSync.EnqueueBlockBodies(Seq(responseHeaders.head.hash)),
-      FastSync.EnqueueReceipts(Seq(responseHeaders.head.hash)))
+    parent.expectMsgAllOf(SyncController.BlockHeadersReceived(peer, responseHeaders))
 
     parent.expectMsg(SyncRequestHandler.Done)
 


### PR DESCRIPTION
This PR is to ask for block bodies and receipts only if we are sure that block header was inserted into DB
This also removes block and receipts scheduling from `SyncBlockHeadersRequestHandler` which should be handled by `FastSync`