### PR TITLE
[EC-270] Fixed personal_importRawKey on duplicated import

### DIFF
--- a/src/main/scala/io/iohk/ethereum/jsonrpc/PersonalService.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/PersonalService.scala
@@ -186,5 +186,6 @@ class PersonalService(
     case KeyStore.DecryptionFailed => InvalidPassphrase
     case KeyStore.KeyNotFound => KeyNotFound
     case KeyStore.IOError(msg) => LogicError(msg)
+    case KeyStore.DuplicateKeySaved => LogicError("account already exists")
   }
 }

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/PersonalServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/PersonalServiceSpec.scala
@@ -321,6 +321,14 @@ class PersonalServiceSpec extends FlatSpec with Matchers with MockFactory with S
     txPool.expectMsg(AddOrOverrideTransaction(chainSpecificStx))
   }
 
+  it should "return an error when importing a duplicated key" in new TestSetup {
+    (keyStore.importPrivateKey _).expects(prvKey, passphrase).returning(Left(KeyStore.DuplicateKeySaved))
+
+    val req = ImportRawKeyRequest(prvKey, passphrase)
+    val res = personal.importRawKey(req).futureValue
+    res shouldEqual Left(LogicError("account already exists"))
+  }
+
   trait TestSetup {
     val prvKey = ByteString(Hex.decode("7a44789ed3cd85861c0bbf9693c7e1de1862dd4396c390147ecf1275099c6e6f"))
     val address = Address(Hex.decode("aa6826f00d01fe4085f0c3dd12778e206ce4e2ac"))

--- a/src/test/scala/io/iohk/ethereum/keystore/KeyStoreImplSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/keystore/KeyStoreImplSpec.scala
@@ -30,6 +30,19 @@ class KeyStoreImplSpec extends FlatSpec with Matchers with BeforeAndAfter with S
     listAfterImport.length shouldEqual 2
   }
 
+  it should "fail to import a key twice" in new TestSetup {
+    val resAfterFirstImport = keyStore.importPrivateKey(key1, "aaa")
+    val resAfterDupImport = keyStore.importPrivateKey(key1, "aaa")
+
+    resAfterFirstImport shouldEqual Right(addr1)
+    resAfterDupImport shouldBe Left(KeyStore.DuplicateKeySaved)
+
+    //Only the first import succeeded
+    val listAfterImport = keyStore.listAccounts().right.get
+    listAfterImport.toSet shouldEqual Set(addr1)
+    listAfterImport.length shouldEqual 1
+  }
+
   it should "create new accounts" in new TestSetup {
     val newAddr1 = keyStore.newAccount("aaa").right.get
     val newAddr2 = keyStore.newAccount("bbb").right.get


### PR DESCRIPTION
## Description

When using `personal_importRawKey` to import an already imported account, it succeeds, which causes `personal_listAccounts` to list an account twice. In contrast, Geth returns an error message (`"account already exists"`) when an already imported account is imported again.

## Fix

Check whether an account was already saved to the `KeyStore` before saving a new one.