### PR TITLE
[EC-397 ]Improve logging format

### DIFF
--- a/src/main/scala/io/iohk/ethereum/vm/VM.scala
+++ b/src/main/scala/io/iohk/ethereum/vm/VM.scala
@@ -36,7 +36,7 @@ class VM extends Logger {
       case Some(opCode) =>
         val newState = opCode.execute(state)
         import newState._
-        log.trace(s"$opCode | pc: $pc | depth: ${env.callDepth} | gas: $gas | stack: $stack")
+        log.trace("{} | pc: {} | depth: {} | gas: {} | stack: {}", opCode, Integer.valueOf(pc), Integer.valueOf(env.callDepth), gas, stack)
         if (newState.halted)
           newState
         else

--- a/src/main/scala/io/iohk/ethereum/vm/VM.scala
+++ b/src/main/scala/io/iohk/ethereum/vm/VM.scala
@@ -36,7 +36,9 @@ class VM extends Logger {
       case Some(opCode) =>
         val newState = opCode.execute(state)
         import newState._
-        log.trace("{} | pc: {} | depth: {} | gas: {} | stack: {}", opCode, Integer.valueOf(pc), Integer.valueOf(env.callDepth), gas, stack)
+        if (log.isTraceEnabled) {
+          log.trace(s"$opCode | pc: $pc | depth: ${env.callDepth} | gas: $gas | stack: $stack")
+        }
         if (newState.halted)
           newState
         else


### PR DESCRIPTION
Former format required `String` concatenation and calling `.toString` methods, which were pretty costly for `BigInts` and `Uint256`, even when trace logging turned off (when there was a lot vm action going on it was taking 10% of our cpu time)

Current format incurs only cost of creating `Array[Object]`, `Integer.valueOf` are necessary as primitives cannot be cast to `Object`