### PR TITLE
[EC-466] Pluggable consensus

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,12 @@ val dep = {
     "io.circe" %% "circe-generic-extras" % circeVersion,
     "com.miguno.akka" %% "akka-mock-scheduler" % "0.5.1" % "it,test",
     "commons-io" % "commons-io" % "2.5",
-    "com.typesafe.akka" %% "akka-stream" % akkaVersion
+    "com.typesafe.akka" %% "akka-stream" % akkaVersion,
+
+    // Pluggable Consensus: AtomixRaft
+    "io.atomix" % "atomix" % "2.1.0-beta1",
+    "io.atomix" % "atomix-raft" % "2.1.0-beta1",
+    "io.netty" % "netty-tcnative-boringssl-static" % "2.0.7.Final" classifier "linux-x86_64" // using native epoll
   )
 }
 
@@ -76,7 +81,7 @@ val verifyDeps = Seq(
   "org.consensusresearch" % "scrypto" sha1 "20177c8d44689b7d3d398ab1f142daf42b8a978c",
   "com.chuusai" % "shapeless" sha1 "27e115ffed7917b456e54891de67173f4a68d5f1",
   "org.typelevel" % "macro-compat" sha1 "ed809d26ef4237d7c079ae6cf7ebd0dfa7986adf",
-  "com.google.guava" % "guava" sha1 "6ce200f6b23222af3d8abb6b6459e6c44f4bb0e9",
+  "com.google.guava" % "guava" sha1 "3564ef3803de51fb0530a8377ec6100b33b0d073",
   "org.whispersystems" % "curve25519-java" sha1 "09091eb56d696d0d0d70d00b84e6037dcd3d98b6",
   "com.madgag.spongycastle" % "core" sha1 "9622d6de1407dd3506254fb9b0292eb1206f6991",
   "org.iq80.leveldb" % "leveldb" sha1 "e9b071b63a7b40f7d01ae01e99259a2de72426f6",
@@ -106,7 +111,40 @@ val verifyDeps = Seq(
   "com.lihaoyi" % "fastparse" sha1 "aaf2048f9c6223220eac28c9b6a442f27ba83c55",
   "com.lihaoyi" % "fastparse-utils" sha1 "92da792e8608653317ed6eb456f935fbfb2316bc",
   "com.lihaoyi" % "sourcecode" sha1 "ef9a771975cb0860f2b42778c5cf1f5d76818979",
-  "com.google.protobuf" % "protobuf-java" sha1 "b32aba0cbe737a4ca953f71688725972e3ee927c")
+  "com.google.protobuf" % "protobuf-java" sha1 "b32aba0cbe737a4ca953f71688725972e3ee927c",
+
+  // Pluggable Consensus (AtomixRaft)
+  "io.atomix" % "atomix" sha1 "aa30000cb7d864b4ed52b3d0ade62eee425bf490",
+  "io.atomix" % "atomix-raft" sha1 "e45af08b70220dd010d6f193e3d38147b4be35fe",
+  "io.netty" % "netty-tcnative-boringssl-static" sha1 "ff5f2d6db5aaa1b4df1b381382cd6581844aad9d",
+
+  "io.atomix" % "atomix-primitive" sha1 "73d9bc7c859856832178afd271f1a573e6a7c7e6",
+  "io.atomix" % "atomix-storage" sha1 "136f0b221acbc2680f099b8ff3a34f8cc1592fe7",
+  "io.atomix" % "atomix-primary-backup" sha1 "1c895965e3e67a152ffbccb4283b6cee91b4ea61",
+  "io.atomix" % "atomix-cluster" sha1 "e7bfff8c0466a98cf0bc7b5579983a1b217278f0",
+  "io.atomix" % "atomix-messaging" sha1 "9a1240a24aa5dc3a35c6057af2a1da3069d47a01",
+  "io.atomix" % "atomix-utils" sha1 "2cd36ea1749eb7b5836025933ef8954ba686913f",
+  "io.netty" % "netty-transport" sha1 "4f26f51b86dc1ab19621eb2ac39f1a63682f17f2",
+  "io.netty" % "netty-buffer" sha1 "65abf40a28ce4f52dd763d0b4f740066a87b5c9e",
+  "io.netty" % "netty-common" sha1 "b281916c11d3eeec5e839677ec4f2eb9d7586928",
+  "io.netty" % "netty-resolver" sha1 "07d97be8b3fb195f9d94d9a4afcadef25e08bde2",
+  "io.netty" % "netty-codec" sha1 "ad4d4309c5b011036ca4df6aca190983d75c6b19",
+  "io.netty" % "netty-handler" sha1 "9c784510bc6f81177c4f2c2956144438863cdac4",
+  "io.netty" % "netty-transport-native-epoll" sha1 "58225fd585d628099cff88190dcd4e3589460c01",
+  "io.netty" % "netty-transport-native-unix-common" sha1 "fee46a4e2b4f2f096532ca443f4f63e08b205318",
+  "com.google.code.findbugs" % "jsr305" sha1 "40719ea6961c0cb6afaeb6a921eaa1f6afd4cfdf",
+  "com.google.errorprone" % "error_prone_annotations" sha1 "5f65affce1684999e2f4024983835efc3504012e",
+  "com.google.j2objc" % "j2objc-annotations" sha1 "ed28ded51a8b1c6b112568def5f4b455e6809019",
+  "org.codehaus.mojo" % "animal-sniffer-annotations" sha1 "775b7e22fb10026eed3f86e8dc556dfafe35f2d5",
+  "org.apache.commons" % "commons-lang3" sha1 "6c6c702c89bfff3cd9e80b04d668c5e190d588c6",
+  "org.apache.commons" % "commons-math3" sha1 "e4ba98f1d4b3c80ec46392f25e094a6a2e58fcbf",
+  "com.esotericsoftware" % "kryo" sha1 "5053899c213a6ce50a800d4902c5a9de49fe0098",
+  "com.esotericsoftware" % "reflectasm" sha1 "8b102eed2f12412b254946811111ea48bc03a266",
+  "org.ow2.asm" % "asm" sha1 "0da08b8cce7bbf903602a25a3a163ae252435795",
+  "com.esotericsoftware" % "minlog" sha1 "ff07b5f1b01d2f92bb00a337f9a94873712f0827",
+  "org.objenesis" % "objenesis" sha1 "272bab9a4e5994757044d1fc43ce480c8cb907a4",
+  "org.hamcrest" % "hamcrest-all" sha1 "63a21ebc981131004ad02e0434e799fd7f3a8d5a"
+)
 
 val Integration = config("it") extend Test
 

--- a/src/ets/scala/io/iohk/ethereum/ets/blockchain/BlockchainSuite.scala
+++ b/src/ets/scala/io/iohk/ethereum/ets/blockchain/BlockchainSuite.scala
@@ -66,7 +66,7 @@ class BlockchainSuite extends FreeSpec with Matchers with BeforeAndAfterAll with
     ignoredTests.get(groupName).isDefined && (ignoredTests(groupName).contains(testName) || ignoredTests(groupName).isEmpty)
 
   private def runScenario(scenario: BlockchainScenario, setup: ScenarioSetup): Unit = {
-    import setup._
+    import setup.{log ⇒ _, _}
 
     loadGenesis()
 

--- a/src/ets/scala/io/iohk/ethereum/ets/blockchain/ScenarioSetup.scala
+++ b/src/ets/scala/io/iohk/ethereum/ets/blockchain/ScenarioSetup.scala
@@ -1,15 +1,16 @@
 package io.iohk.ethereum.ets.blockchain
 
 import io.iohk.ethereum.blockchain.sync.EphemBlockchainTestSetup
+import io.iohk.ethereum.consensus.{ConsensusBuilder, ConsensusConfigBuilder}
 import io.iohk.ethereum.domain.Block.BlockDec
 import io.iohk.ethereum.domain.{Account, Address, Block, UInt256}
 import io.iohk.ethereum.ets.common.AccountState
 import io.iohk.ethereum.ledger.Ledger.VMImpl
 import io.iohk.ethereum.ledger._
 import io.iohk.ethereum.network.p2p.messages.PV62.BlockBody
-import io.iohk.ethereum.nodebuilder.{ActorSystemBuilder, BlockchainConfigBuilder, SyncConfigBuilder, ValidatorsBuilder}
+import io.iohk.ethereum.nodebuilder.{ActorSystemBuilder, BlockchainConfigBuilder, ShutdownHookBuilder, SyncConfigBuilder, ValidatorsBuilder}
 import io.iohk.ethereum.utils.BigIntExtensionMethods._
-import io.iohk.ethereum.utils.BlockchainConfig
+import io.iohk.ethereum.utils.{BlockchainConfig, Logger}
 import org.spongycastle.util.encoders.Hex
 
 import scala.util.{Failure, Success, Try}
@@ -19,7 +20,11 @@ abstract class ScenarioSetup(vm: VMImpl, scenario: BlockchainScenario)
   with ValidatorsBuilder
   with SyncConfigBuilder
   with BlockchainConfigBuilder
-  with ActorSystemBuilder {
+  with ActorSystemBuilder
+  with ConsensusBuilder
+  with ConsensusConfigBuilder
+  with ShutdownHookBuilder
+  with Logger {
 
   val emptyWorld = blockchain.getWorldStateProxy(-1, UInt256.Zero, None)
 

--- a/src/it/scala/io/iohk/ethereum/SimulateTransactionTest/SimulateTransactionTest.scala
+++ b/src/it/scala/io/iohk/ethereum/SimulateTransactionTest/SimulateTransactionTest.scala
@@ -2,9 +2,10 @@ package io.iohk.ethereum.ledger
 
 import akka.util.ByteString
 import io.iohk.ethereum.blockchain.sync.EphemBlockchainTestSetup
+import io.iohk.ethereum.consensus.{ConsensusBuilder, ConsensusConfigBuilder}
 import io.iohk.ethereum.crypto.ECDSASignature
 import io.iohk.ethereum.domain._
-import io.iohk.ethereum.nodebuilder.{BlockchainConfigBuilder, SyncConfigBuilder, ValidatorsBuilder}
+import io.iohk.ethereum.nodebuilder.{BlockchainConfigBuilder, ShutdownHookBuilder, SyncConfigBuilder, ValidatorsBuilder}
 import org.scalatest._
 import io.iohk.ethereum.utils._
 import org.spongycastle.util.encoders.Hex
@@ -103,7 +104,11 @@ trait ScenarioSetup
   extends EphemBlockchainTestSetup
   with ValidatorsBuilder
   with SyncConfigBuilder
-  with BlockchainConfigBuilder {
+  with BlockchainConfigBuilder
+  with ConsensusBuilder
+  with ConsensusConfigBuilder
+  with ShutdownHookBuilder
+  with Logger {
 
   override lazy val blockchainConfig = new BlockchainConfig{
     override val eip155BlockNumber: BigInt = 0

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -198,26 +198,49 @@ mantis {
     transaction-timeout = 2.minutes
   }
 
-  mining {
-    # Maximum number of ommers kept in the pool
-    ommers-pool-size = 30
+  consensus {
+    # FIXME this was moved here from the `mining` section
+    active-timeout = 5 seconds
 
+    # New timeout to replace `ommer-pool-query-timeout` for uses outside ethash mining
+    get-transaction-from-pool-timeout = 5.seconds
+
+    # Moved from the `mining` section
+    # Miner's coinbase address
+    coinbase = "0011223344556677889900112233445566778899"
+
+    # Moved from the `mining` section
+    # Extra data to add to mined blocks
+    header-extra-data = "mantis"
+
+    #####################
+    # Moved from the `mining` section because this is needed by BlockGenerator, which we use in other consensus
+    # protocols as well.
+    #####################
     # This determines how many parallel eth_getWork request we can handle, by storing the prepared blocks in a cache,
     # until a corresponding eth_submitWork request is received
     block-cashe-size = 30
 
-    # Miner's coinbase address
-    coinbase = "0011223344556677889900112233445566778899"
+    # See io.iohk.ethereum.consensus.Protocol for the available protocols.
+    # Declaring the protocol here means that a more protocol-specific configuration
+    # is pulled from the corresponding consensus implementation.
+    # For example, in case of ethash, a section named `mining` is used.
+    protocol = ethash
 
-    active-timeout = 5 seconds
+    # If true then the consensus protocol uses this node for mining.
+    # In the case of ethash PoW, this means mining new blocks, as specified by Ethereum.
+    # In the general case, the semantics are due to the specific consensus implementation.
+    mining-enabled = false
+  }
+
+  # This is the section dedicated to Ethash mining.
+  # The consensus protocol is selected by setting `mantis.consensus.protocol = ethash`
+  # but for historical reasons we keep the name `mining` here (instead of `ethash`).
+  mining {
+    # Maximum number of ommers kept in the pool
+    ommers-pool-size = 30
 
     ommer-pool-query-timeout = 5.seconds
-
-    # Extra data to add to mined blocks
-    header-extra-data = "mantis"
-
-    # If true this node will mine new blocks
-    mining-enabled = false
 
     ethash-dir = ${user.home}"/.ethash"
 

--- a/src/main/scala/io/iohk/ethereum/Mantis.scala
+++ b/src/main/scala/io/iohk/ethereum/Mantis.scala
@@ -1,54 +1,10 @@
 package io.iohk.ethereum
 
-import io.iohk.ethereum.blockchain.sync.SyncController
-import io.iohk.ethereum.mining.Miner
-import io.iohk.ethereum.network.discovery.DiscoveryListener
-import io.iohk.ethereum.network.{PeerManagerActor, ServerActor}
-import io.iohk.ethereum.nodebuilder.Node
-import io.iohk.ethereum.utils.Logger
-
-import scala.concurrent.Await
-import scala.util.{Failure, Success, Try}
+import io.iohk.ethereum.nodebuilder.StdNode
 
 object Mantis {
-
   def main(args: Array[String]): Unit = {
-
-    new Node with Logger {
-
-      def tryAndLogFailure(f: () => Any): Unit = Try(f()) match {
-        case Failure(e) => log.warn("Error while shutting down...", e)
-        case Success(_) =>
-      }
-
-      override def shutdown(): Unit = {
-        tryAndLogFailure(() => Await.ready(actorSystem.terminate, shutdownTimeoutDuration))
-        tryAndLogFailure(() => storagesInstance.dataSources.closeAll())
-      }
-
-      genesisDataLoader.loadGenesisData()
-
-      peerManager ! PeerManagerActor.StartConnecting
-      server ! ServerActor.StartServer(networkConfig.Server.listenAddress)
-
-      if (discoveryConfig.discoveryEnabled) {
-        discoveryListener ! DiscoveryListener.Start
-      }
-
-      syncController ! SyncController.Start
-
-      if (miningConfig.miningEnabled) {
-        miner ! Miner.StartMining
-      }
-
-      peerDiscoveryManager // unlazy
-
-      maybeJsonRpcServer match {
-        case Right(jsonRpcServer) if jsonRpcServerConfig.enabled => jsonRpcServer.run()
-        case Left(error) if jsonRpcServerConfig.enabled => log.error(error)
-        case _=> //Nothing
-      }
-    }
-
+    val node = new StdNode
+    node.start()
   }
 }

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/FastSync.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/FastSync.scala
@@ -195,7 +195,7 @@ class FastSync(
               if (syncState.bestBlockHeaderNumber >= syncState.targetBlock.number - X) header.number + 1
               else header.number + K / 2 + Random.nextInt(K))
 
-          validators.blockHeaderValidator.validate(header, blockchain) match {
+          validators.blockHeaderValidator.validate(header, blockchain.getBlockHeaderByHash) match {
             case Right(_) =>
               if (insertHeader(header)) processHeaders(peer, remaining)
               else true

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/RegularSync.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/RegularSync.scala
@@ -128,7 +128,7 @@ class RegularSync(
             case BlockImportedToTop(newBlocks, newTds) =>
               broadcastBlocks(newBlocks, newTds)
               updateTxAndOmmerPools(newBlocks, Nil)
-              log.debug(s"Added new block ${newBlock.header.number} to the top of the chain received from $peerId")
+              log.info(s"Added new block ${newBlock.header.number} to the top of the chain received from $peerId")
 
             case BlockEnqueued =>
               ommersPool ! AddOmmers(newBlock.header)
@@ -216,18 +216,18 @@ class RegularSync(
 
   def handleResponseToRequest: Receive = {
     case ResponseReceived(peer: Peer, BlockHeaders(headers), timeTaken) =>
-      log.info("Received {} block headers in {} ms (branch resolution: {})", headers.size, timeTaken, resolvingBranches)
+      log.debug("Received {} block headers in {} ms from {} (branch resolution: {})", headers.size, timeTaken, peer, resolvingBranches)
       waitingForActor = None
       if (resolvingBranches) handleBlockBranchResolution(peer, headers.reverse)
       else handleBlockHeaders(peer, headers)
 
     case ResponseReceived(peer, BlockBodies(blockBodies), timeTaken) =>
-      log.info("Received {} block bodies in {} ms", blockBodies.size, timeTaken)
+      log.debug("Received {} block bodies in {} ms", blockBodies.size, timeTaken)
       waitingForActor = None
       handleBlockBodies(peer, blockBodies)
 
     case ResponseReceived(peer, NodeData(nodes), timeTaken) if missingStateNodeRetry.isDefined =>
-      log.info("Received {} missing state nodes in {} ms", nodes.size, timeTaken)
+      log.debug("Received {} missing state nodes in {} ms", nodes.size, timeTaken)
       waitingForActor = None
       handleRedownloadedStateNodes(peer, nodes)
 

--- a/src/main/scala/io/iohk/ethereum/consensus/Consensus.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/Consensus.scala
@@ -1,0 +1,41 @@
+package io.iohk.ethereum.consensus
+
+import io.iohk.ethereum.domain.Block
+import io.iohk.ethereum.ledger.BlockExecutionError.ValidationBeforeExecError
+import io.iohk.ethereum.ledger.BlockExecutionSuccess
+import io.iohk.ethereum.nodebuilder.Node
+import io.iohk.ethereum.validators.BlockHeaderValidator
+
+/**
+ * Abstraction for a consensus protocol.
+ *
+ * @see [[io.iohk.ethereum.consensus.Protocol Protocol]]
+ */
+// FIXME Lot's of stuff to do...
+trait Consensus {
+  type Config <: AnyRef /*Product*/
+
+  def protocol: Protocol
+
+  def config: FullConsensusConfig[Config]
+
+  /** Returns `true` if this is the standard Ethereum PoW consensus protocol (`ethash`). */
+  final def isEthash: Boolean = protocol.isEthash
+
+  /**
+   * Starts the consensus protocol on the current `node`.
+   */
+  def startProtocol(node: Node): Unit
+
+  def stopProtocol(): Unit
+
+  /**
+   * Provides the [[io.iohk.ethereum.validators.BlockHeaderValidator BlockHeaderValidator]] that is specific
+   * to this consensus protocol.
+   */
+  // FIXME Probably include the whole of [[io.iohk.ethereum.validators.Validators]].
+  def blockHeaderValidator: BlockHeaderValidator
+
+  // Ledger uses this in importBlock
+  def validateBlockBeforeExecution(block: Block): Either[ValidationBeforeExecError, BlockExecutionSuccess] = ???
+}

--- a/src/main/scala/io/iohk/ethereum/consensus/ConsensusBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/ConsensusBuilder.scala
@@ -1,0 +1,58 @@
+package io.iohk.ethereum.consensus
+
+import io.iohk.ethereum.consensus.atomixraft.AtomixRaftConsensus
+import io.iohk.ethereum.nodebuilder.{BlockchainConfigBuilder, ShutdownHookBuilder}
+import io.iohk.ethereum.utils.{Config, Logger}
+
+/**
+ * A consensus builder is responsible to instantiate the consensus protocol.
+ * This is done dynamically when Mantis boots, based on its configuration.
+ */
+trait ConsensusBuilder {
+  self: BlockchainConfigBuilder with ConsensusConfigBuilder with Logger =>
+
+  private lazy val mantisConfig = Config.config
+
+  private def loadEthashConsensus(): ethash.EthashConsensus = {
+    val miningConfig = ethash.MiningConfig(mantisConfig)
+    val fullConfig = FullConsensusConfig(consensusConfig, miningConfig)
+    val consensus = new ethash.EthashConsensus(blockchainConfig, fullConfig)
+    consensus
+  }
+
+  private def loadDemoConsensus(): demo.DemoConsensus = {
+    val demoConsensusConfig = demo.DemoConsensusConfig(mantisConfig)
+    val fullConfig = FullConsensusConfig(consensusConfig, demoConsensusConfig)
+    val consensus = new demo.DemoConsensus(blockchainConfig, fullConfig)
+    consensus
+  }
+
+  private def loadAtomixRaftConsensus(): atomixraft.AtomixRaftConsensus = {
+    val atomixRaftConfig = atomixraft.AtomixRaftConfig(mantisConfig)
+    val fullConfig = FullConsensusConfig(consensusConfig, atomixRaftConfig)
+    val consensus = new AtomixRaftConsensus(blockchainConfig, fullConfig)
+    consensus
+  }
+
+  private def loadConsensus(): Consensus = {
+    val config = consensusConfig
+    val protocol = config.protocol
+    log.info(s"Configured consensus protocol: ${protocol.name}")
+
+    val consensus =
+      config.protocol match {
+        case Ethash ⇒ loadEthashConsensus()
+        case Demo0 ⇒ loadDemoConsensus()
+        case AtomixRaft ⇒ loadAtomixRaftConsensus()
+      }
+    log.info(s"'${protocol.name}' protocol implemented by ${consensus.getClass.getName}")
+
+    consensus
+  }
+
+  lazy val consensus: Consensus = loadConsensus()
+}
+
+trait ConsensusConfigBuilder { self: ShutdownHookBuilder ⇒
+  lazy val consensusConfig: ConsensusConfig = ConsensusConfig(Config.config)(this)
+}

--- a/src/main/scala/io/iohk/ethereum/consensus/ConsensusConfig.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/ConsensusConfig.scala
@@ -1,0 +1,104 @@
+package io.iohk.ethereum.consensus
+
+import akka.util.ByteString
+import com.typesafe.config.{Config ⇒ TypesafeConfig}
+import io.iohk.ethereum.domain.Address
+import io.iohk.ethereum.nodebuilder.ShutdownHookBuilder
+import io.iohk.ethereum.utils.Logger
+import io.iohk.ethereum.validators.BlockHeaderValidatorImpl
+
+import scala.concurrent.duration.{FiniteDuration, _}
+
+/**
+ * Provides generic consensus configuration. Each consensus protocol implementation
+ * will use its own specific configuration as well.
+ *
+ * @param protocol Designates the consensus protocol.
+ * @param activeTimeout
+ * @param miningEnabled Provides support for generalized "mining". The exact semantics are up to the
+ *                      specific consensus protocol implementation.
+ */
+final case class ConsensusConfig(
+  protocol: Protocol,
+
+  coinbase: Address,
+
+  // NOTE Moved from [[io.iohk.ethereum.consensus.ethash.MiningConfig MiningConfig]]
+  activeTimeout: FiniteDuration,
+
+  // NOTE Moved from [[io.iohk.ethereum.consensus.ethash.MiningConfig MiningConfig]]
+  headerExtraData: ByteString, // only used in BlockGenerator
+
+  // NOTE Moved from [[io.iohk.ethereum.consensus.ethash.MiningConfig MiningConfig]]
+  blockCacheSize: Int, // only used in BlockGenerator
+
+  getTransactionFromPoolTimeout: FiniteDuration,
+
+  miningEnabled: Boolean
+)
+
+object ConsensusConfig extends Logger {
+  object Keys {
+    final val Consensus = "consensus"
+    final val Protocol = "protocol"
+    final val Coinbase = "coinbase"
+    final val ActiveTimeout = "active-timeout"
+    final val HeaderExtraData = "header-extra-data"
+    final val BlockCacheSize = "block-cashe-size"
+    final val MiningEnabled = "mining-enabled"
+    final val GetTransactionFromPoolTimeout = "get-transaction-from-pool-timeout"
+  }
+
+
+  final val AllowedProtocols = Set(
+    Protocol.Names.Ethash,
+    Protocol.Names.Demo0,
+    Protocol.Names.AtomixRaft
+  )
+
+  final val AllowedProtocolsError = (s: String) ⇒ Keys.Consensus +
+    " was '" + s + "'" +
+    " but it should be one of " +
+    AllowedProtocols.map("'" + _ + "'").mkString(",")
+
+  private def readProtocol(consensusConfig: TypesafeConfig): Protocol = {
+    val protocol = consensusConfig.getString(Keys.Protocol)
+
+    // If the consensus protocol is not a known one, then it is a fatal error
+    // and the application must exit.
+    if(!AllowedProtocols(protocol)) {
+      val error = AllowedProtocolsError(protocol)
+      throw new RuntimeException(error)
+    }
+
+    Protocol(protocol)
+  }
+
+
+  def apply(mantisConfig: TypesafeConfig)(shutdownHook: ShutdownHookBuilder): ConsensusConfig = {
+    val config = mantisConfig.getConfig(Keys.Consensus)
+
+    def millis(path: String): FiniteDuration = config.getDuration(path).toMillis.millis
+
+    val protocol = shutdownHook.shutdownOnError(readProtocol(config))
+    val coinbase = Address(config.getString(Keys.Coinbase))
+
+    val activeTimeout = millis(Keys.ActiveTimeout)
+    val headerExtraData = ByteString(config.getString(Keys.HeaderExtraData).getBytes)
+      .take(BlockHeaderValidatorImpl.MaxExtraDataSize)
+    val blockCacheSize = config.getInt(Keys.BlockCacheSize)
+    val miningEnabled = config.getBoolean(Keys.MiningEnabled)
+
+    val getTransactionFromPoolTimeout = millis(Keys.GetTransactionFromPoolTimeout)
+
+    new ConsensusConfig(
+      protocol = protocol,
+      coinbase = coinbase,
+      activeTimeout = activeTimeout,
+      headerExtraData = headerExtraData,
+      blockCacheSize = blockCacheSize,
+      getTransactionFromPoolTimeout = getTransactionFromPoolTimeout,
+      miningEnabled = miningEnabled
+    )
+  }
+}

--- a/src/main/scala/io/iohk/ethereum/consensus/FullConsensusConfig.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/FullConsensusConfig.scala
@@ -1,0 +1,31 @@
+package io.iohk.ethereum.consensus
+
+import io.iohk.ethereum.consensus.ethash.MiningConfig
+
+case class FullConsensusConfig[C <: AnyRef /*Product*/](
+  generic: ConsensusConfig,
+  specific: C
+) {
+  // Sanity check
+  require(
+    generic.protocol.isEthash == ifEthash(_ ⇒ true)(false),
+    "generic.protocol.isEthash == ifEthash(_ ⇒ true)(false)"
+  )
+
+  /**
+   * There are APIs that expect that the standard Ethash consensus is running and so depend
+   * on either its configuration or general PoW semantics.
+   * This is a method that can handle such cases via a respective if/then/else construct:
+   * if we run under [[io.iohk.ethereum.consensus.Ethash Ethash]] the `_if` function is called,
+   * otherwise the `_else` value is computed.
+   */
+  final def ifEthash[A](_if: MiningConfig ⇒ A)(_else: ⇒ A): A =
+    specific match {
+      case mc: ethash.MiningConfig ⇒ _if(mc)
+      case _ ⇒ _else
+    }
+
+  final def isEthash: Boolean = generic.protocol.isEthash
+
+  final def miningEnabled: Boolean = generic.miningEnabled
+}

--- a/src/main/scala/io/iohk/ethereum/consensus/Protocol.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/Protocol.scala
@@ -1,0 +1,61 @@
+package io.iohk.ethereum.consensus
+
+/**
+ * Enumerates the known consensus protocols that Mantis can use.
+ * For the respective implementations, see [[io.iohk.ethereum.consensus.Consensus Consensus]].
+ */
+sealed trait Protocol {
+  /**
+   * We use this `name` to specify the protocol in configuration.
+   *
+   * @see [[io.iohk.ethereum.consensus.Protocol.Names]]
+   */
+  def name: String
+
+  /** Returns `true` if this is the standard Ethereum PoW consensus protocol (`ethash`). */
+  final def isEthash: Boolean =
+    this match {
+      case Ethash ⇒ true
+      case _ ⇒ false
+    }
+}
+
+object Protocol {
+  object Names {
+    // This is the standard Ethereum PoW consensus protocol.
+    final val Ethash = "ethash"
+
+    // This is a dummy consensus protocol for demonstration purposes (pluggable consensus)
+    final val Demo0 = "demo-consensus"
+
+    // Using the Raft implementation from atomix.io
+    final val AtomixRaft = "atomix-raft"
+  }
+
+  def find(name: String): Option[Protocol] =
+    name match {
+      case Names.Ethash ⇒ Some(Ethash)
+      case Names.Demo0 ⇒ Some(Demo0)
+      case Names.AtomixRaft ⇒ Some(AtomixRaft)
+      case _ ⇒ None
+    }
+
+  private[consensus] def apply(name: String): Protocol =
+    find(name) match {
+      case Some(protocol) ⇒ protocol
+      case None ⇒
+        require(requirement = false, "Unknown protocol " + name)
+        throw new Exception()
+    }
+}
+
+sealed abstract class ProtocolImpl private[consensus](val name: String) extends Protocol
+
+/** The standard Ethereum PoW consensus protocol. */
+case object Ethash extends ProtocolImpl(Protocol.Names.Ethash)
+
+/** A dump protocol used internally for demonstration purposes */
+case object Demo0 extends ProtocolImpl(Protocol.Names.Demo0)
+
+/** Raft consensus protocol */
+case object AtomixRaft extends ProtocolImpl(Protocol.Names.AtomixRaft)

--- a/src/main/scala/io/iohk/ethereum/consensus/atomixraft/AtomixRaftConfig.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/atomixraft/AtomixRaftConfig.scala
@@ -1,0 +1,71 @@
+package io.iohk.ethereum.consensus
+package atomixraft
+
+import java.io.File
+
+import com.typesafe.config.{Config ⇒ TypesafeConfig}
+import io.atomix.messaging.impl.NettyMessagingService
+import io.atomix.cluster.{Node ⇒ AtomixNode, NodeId ⇒ AtomixNodeId}
+import io.atomix.messaging.{Endpoint ⇒ AtomixEndpoint}
+import io.iohk.ethereum.domain.Address
+import io.iohk.ethereum.utils.Logger
+
+case class AtomixRaftConfig private(
+  coinbase: Address,
+  localNode: AtomixNode,
+  bootstrapNodes: List[AtomixNode],
+  dataDir: File
+)
+
+object AtomixRaftConfig extends Logger {
+
+  def parseNodeId(parts: Array[String]): AtomixNodeId =
+    parts.length match {
+      case 1 | 3 ⇒ AtomixNodeId.from(parts(0).trim)
+      case 2     ⇒ AtomixNodeId.from(parts(0).trim + "_" + parts(1).trim)
+      case _     ⇒ throw new IllegalArgumentException("parts.length != 1, 2, 3")
+    }
+
+  def parseEndpoint(parts: Array[String]): AtomixEndpoint =
+    parts.length match {
+      case 1 ⇒ AtomixEndpoint.from(parts(0).trim, NettyMessagingService.DEFAULT_PORT)
+      case 2 ⇒ AtomixEndpoint.from(parts(0).trim, parts(1).trim.toInt)
+      case 3 ⇒ AtomixEndpoint.from(parts(1).trim, parts(2).trim.toInt)
+      case _ ⇒ throw new IllegalArgumentException("parts.length != 1, 2, 3")
+    }
+
+  def parseNode(id_host_port: String): AtomixNode = {
+    val parts = id_host_port.split(":")
+    val nodeId = parseNodeId(parts)
+    val endpoint = parseEndpoint(parts)
+
+    AtomixNode.builder
+      .withId(nodeId)
+      .withEndpoint(endpoint)
+      .withType(AtomixNode.Type.DATA)
+      .build
+  }
+
+  def apply(mantisConfig: TypesafeConfig): AtomixRaftConfig = {
+    import scala.collection.JavaConverters._
+
+    val config = mantisConfig.getConfig(Protocol.Names.AtomixRaft)
+    val coinbase = Address(config.getString("coinbase"))
+    val localNode = parseNode(config.getString("local-node"))
+    // In configuration, we can specify all nodes as bootstrap nodes, for convenience
+    val bootstrapNodes_ = config.getStringList("bootstrap-nodes").asScala.map(parseNode).toList
+    // In reality, the API requires all the _other_ nodes, so we just remove ourselves
+    val bootstrapNodes = bootstrapNodes_.filterNot(_.id() == localNode.id())
+    val dataDir = new File(config.getString("data-dir"))
+
+    log.info("***** local-node = " + localNode)
+    log.info("***** bootstrap-nodes = " + bootstrapNodes)
+
+    new AtomixRaftConfig(
+      coinbase = coinbase,
+      localNode = localNode,
+      bootstrapNodes = bootstrapNodes,
+      dataDir = dataDir
+    )
+  }
+}

--- a/src/main/scala/io/iohk/ethereum/consensus/atomixraft/AtomixRaftConsensus.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/atomixraft/AtomixRaftConsensus.scala
@@ -1,0 +1,144 @@
+package io.iohk.ethereum.consensus
+package atomixraft
+
+import io.atomix.cluster._
+import io.atomix.cluster.impl.{DefaultClusterMetadataService, DefaultClusterService}
+import io.atomix.cluster.messaging.impl.DefaultClusterMessagingService
+import io.atomix.core.election.LeaderElectionType
+import io.atomix.messaging.ManagedMessagingService
+import io.atomix.messaging.impl.NettyMessagingService
+import io.atomix.protocols.raft.RaftServer
+import io.atomix.protocols.raft.partition.impl.{RaftNamespaces, RaftServerCommunicator}
+import io.atomix.protocols.raft.protocol.{TransferRequest, TransferResponse}
+import io.atomix.protocols.raft.storage.RaftStorage
+import io.atomix.utils.concurrent.ThreadModel
+import io.atomix.utils.serializer.{KryoNamespace, Serializer}
+import io.iohk.ethereum.consensus.atomixraft.Miner.{IAmTheLeader, Init}
+import io.iohk.ethereum.nodebuilder.Node
+import io.iohk.ethereum.utils.{BlockchainConfig, Logger}
+import io.iohk.ethereum.validators.{BlockHeaderValidator, BlockHeaderValidatorImpl}
+
+class AtomixRaftConsensus(
+  blockchainConfig: BlockchainConfig,
+  val config: FullConsensusConfig[AtomixRaftConfig]
+) extends Consensus with Logger {
+
+  type Config = AtomixRaftConfig
+
+  private[this] final val defaultValidator = new BlockHeaderValidatorImpl(blockchainConfig)
+
+  private[this] final val miner = new MinerRef
+
+  private[this] final val raftServer = new RaftServerRef
+
+  private[this] val raftConfig: AtomixRaftConfig = config.specific
+
+  private[this] def setupMiner(node: Node): Unit = {
+    miner.setOnce {
+      val miner = Miner(node, raftConfig)
+      miner ! Init
+      miner
+    }
+  }
+
+  private[this] def onRaftServerStarted(messagingService: ManagedMessagingService): Unit = {
+    log.info("Raft server started at " + messagingService.endpoint)
+  }
+
+  private[this] def onLeader(): Unit = {
+    miner ! IAmTheLeader
+  }
+
+  private[this] def onClusterEvent(event: ClusterEvent): Unit = {
+    log.info("***** " + event)
+  }
+
+  private[this] def onRoleChange(role: RaftServer.Role): Unit = {
+    log.info("***** Role changed to " + role)
+    if(role == RaftServer.Role.LEADER) {
+      onLeader()
+    }
+  }
+
+  private[this] def addListeners(clusterService: DefaultClusterService, server: RaftServer): Unit = {
+    server.addRoleChangeListener(onRoleChange)
+    clusterService.addListener(onClusterEvent)
+  }
+
+  private[atomixraft] final val RAFT_PROTOCOL_EX = KryoNamespace.builder()
+    .register(RaftNamespaces.RAFT_PROTOCOL)
+    .register(classOf[TransferRequest]) // Nice bug in the lib, this was missing!
+    .register(classOf[TransferResponse]) // Nice bug in the lib, this was missing!
+    .build()
+
+  private[this] def setupRaftServer(node: Node): Unit = {
+    raftServer.setOnce {
+      import raftConfig.{bootstrapNodes, dataDir, localNode}
+
+      import scala.collection.JavaConverters._
+
+      val messagingService = NettyMessagingService.builder.withEndpoint(localNode.endpoint).build
+
+      val metadata = ClusterMetadata.builder.withBootstrapNodes(bootstrapNodes.asJava).build
+      val metadataService = new DefaultClusterMetadataService(metadata, messagingService)
+      val clusterService = new DefaultClusterService(localNode, metadataService, messagingService)
+      val clusterMessagingService = new DefaultClusterMessagingService(clusterService, messagingService)
+
+      val protocol = new RaftServerCommunicator(Serializer.using(RAFT_PROTOCOL_EX), clusterMessagingService)
+      val raftStorage = RaftStorage.builder
+        .withSerializer(Serializer.using(RaftNamespaces.RAFT_STORAGE))
+        .withDirectory(dataDir)
+        .build
+
+      val server = RaftServer.builder(localNode.id)
+        .withThreadModel(ThreadModel.SHARED_THREAD_POOL)
+        .withClusterService(clusterService)
+        .withProtocol(protocol)
+        .withStorage(raftStorage)
+        /*.withElectionTimeout(Duration.ofMillis(3000))
+        .withHeartbeatInterval(Duration.ofMillis(300))*/
+        .addPrimitiveType(LeaderElectionType.instance[Any])
+        .build
+
+      addListeners(clusterService, server)
+
+      val clusterNodeIds = bootstrapNodes.map(_.id())
+      messagingService.start
+        .thenComposeAsync(_ ⇒ metadataService.start)
+        .thenComposeAsync(_ ⇒ clusterService.start)
+        .thenComposeAsync(_ ⇒ clusterMessagingService.start)
+        .thenComposeAsync(_ ⇒ server.bootstrap(clusterNodeIds.asJava))
+        .thenRun(() ⇒ onRaftServerStarted(messagingService))
+
+      server
+    }
+  }
+
+  def isLeader: Option[Boolean] = raftServer.run(_.isLeader) // None means we do not know
+
+  def promoteToLeader(): Unit = raftServer.run(_.promote().join())
+
+  /**
+   * Starts the consensus protocol on the current `node`.
+   */
+  def startProtocol(node: Node): Unit = {
+    setupMiner(node)
+    setupRaftServer(node)
+  }
+
+  def stopProtocol(): Unit = {
+    miner.kill()
+    raftServer.stop()
+  }
+
+  def protocol: Protocol = AtomixRaft
+
+  /**
+   * Provides the [[io.iohk.ethereum.validators.BlockHeaderValidator BlockHeaderValidator]] that is specific
+   * to this consensus protocol.
+   *
+   * The returned validator does whatever Ethereum requires except from PoW-related validation,
+   * since there is no PoW in this consensus protocol.
+   */
+  def blockHeaderValidator: BlockHeaderValidator = defaultValidator
+}

--- a/src/main/scala/io/iohk/ethereum/consensus/atomixraft/Miner.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/atomixraft/Miner.scala
@@ -1,0 +1,162 @@
+package io.iohk.ethereum.consensus
+package atomixraft
+
+import akka.actor.{Actor, ActorLogging, ActorRef, Props}
+import akka.pattern.ask
+import akka.util.Timeout
+import io.iohk.ethereum.blockchain.sync.RegularSync
+import io.iohk.ethereum.consensus.atomixraft.Miner._
+import io.iohk.ethereum.domain.{Block, Blockchain}
+import io.iohk.ethereum.jsonrpc.EthService
+import io.iohk.ethereum.mining.{BlockGenerator, PendingBlock}
+import io.iohk.ethereum.nodebuilder.Node
+import io.iohk.ethereum.transactions.PendingTransactionsManager
+import io.iohk.ethereum.transactions.PendingTransactionsManager.PendingTransactionsResponse
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.concurrent.duration._
+import scala.util.{Failure, Success}
+
+class Miner(
+  blockchain: Blockchain,
+  blockGenerator: BlockGenerator,
+  pendingTransactionsManager: ActorRef,
+  syncController: ActorRef,
+  config: AtomixRaftConfig,
+  ethService: EthService,
+  consensus: AtomixRaftConsensus
+) extends Actor with ActorLogging {
+
+  def receive: Receive = stopped
+
+  private def isLeader: Boolean = consensus.isLeader.getOrElse(false)
+
+  private def scheduleOnce(delay: FiniteDuration, msg: Msg): Unit =
+    context.system.scheduler.scheduleOnce(delay, self, msg)
+
+  private def stopped: Receive = {
+    case Init ⇒
+      log.info("***** Miner initialized")
+
+    case IAmTheLeader ⇒
+      log.info("***** I am the leader, will start mining")
+      context become mining
+      self ! StartMining
+  }
+
+  private def mining: Receive = {
+    case StopMining ⇒ context become stopped
+    case StartMining ⇒ startMining()
+  }
+
+  private def lostLeadership(): Unit = {
+    log.info("***** Ouch, lost leadership")
+    self ! StopMining
+  }
+
+  private def startMining(): Unit = {
+    if(isLeader) {
+      val parentBlock = blockchain.getBestBlock()
+
+      getBlockForMining(parentBlock) onComplete {
+        case Success(PendingBlock(block, _)) ⇒
+          syncTheBlock(block)
+
+        case Failure(ex) ⇒
+          log.error(ex, "Unable to get block for mining")
+          scheduleOnce(10.seconds, StartMining)
+      }
+    }
+    else {
+      lostLeadership()
+    }
+  }
+
+  private def syncTheBlock(block: Block): Unit = {
+    if(isLeader) {
+      log.info("***** Mined block " + block.header.number)
+      syncController ! RegularSync.MinedBlock(block)
+      self ! StartMining
+    }
+    else {
+      lostLeadership()
+    }
+  }
+
+  //noinspection ScalaStyle
+  private def getBlockForMining(parentBlock: Block): Future[PendingBlock] = {
+    Thread.sleep(Miner.ArtificialDelay)
+
+    val ffPendingBlock: Future[Future[PendingBlock]] =
+      for {
+        pendingTxResponse ← getTransactionsFromPool
+      } yield {
+        val pendingTransactions = pendingTxResponse.pendingTransactions.map(_.stx)
+
+        val errorOrPendingBlock = blockGenerator.generateBlockForMining(parentBlock, pendingTransactions, Nil, config.coinbase)
+        errorOrPendingBlock match {
+          case Left(error) ⇒
+            Future.failed(new RuntimeException(s"Error while generating block for mining: $error"))
+
+          case Right(pendingBlock) ⇒
+            Future.successful(pendingBlock)
+        }
+      }
+
+    ffPendingBlock.flatten
+  }
+
+  private def getTransactionsFromPool = {
+    implicit val timeout: Timeout = 2.seconds // FIXME configurable
+
+    (pendingTransactionsManager ? PendingTransactionsManager.GetPendingTransactions).mapTo[PendingTransactionsResponse]
+      .recover { case ex =>
+        log.error(ex, "Failed to get transactions, mining block with empty transactions list")
+        PendingTransactionsResponse(Nil)
+      }
+  }
+}
+
+object Miner {
+  final val ArtificialDelay = 3001 // FIXME Delete
+
+  sealed trait Msg
+  case object Init extends Msg
+  case object IAmTheLeader extends Msg
+  case object StartMining extends Msg
+  case object StopMining extends Msg
+
+  private[atomixraft] def props(
+    blockchain: Blockchain,
+    blockGenerator: BlockGenerator,
+    ommersPool: ActorRef,
+    pendingTransactionsManager: ActorRef,
+    syncController: ActorRef,
+    config: AtomixRaftConfig,
+    ethService: EthService,
+    consensus: AtomixRaftConsensus
+  ): Props =
+    Props(
+      new Miner(
+        blockchain, blockGenerator,
+        pendingTransactionsManager, syncController, config, ethService, consensus)
+    )
+
+  def apply(node: Node, raftConfig: AtomixRaftConfig): ActorRef = {
+    import node._
+
+    val minerProps = props(
+      blockchain,
+      blockGenerator,
+      ommersPool,
+      pendingTransactionsManager,
+      syncController,
+      raftConfig,
+      ethService,
+      consensus.asInstanceOf[AtomixRaftConsensus] // FIXME
+    )
+
+    actorSystem.actorOf(minerProps)
+  }
+}

--- a/src/main/scala/io/iohk/ethereum/consensus/atomixraft/MinerRef.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/atomixraft/MinerRef.scala
@@ -1,0 +1,14 @@
+package io.iohk.ethereum.consensus
+package atomixraft
+
+import akka.actor.{ActorRef, PoisonPill}
+import io.iohk.ethereum.consensus.atomixraft.Miner.Msg
+
+// a new class to avoid "reflective access of structural type member" errors ...
+final class MinerRef extends Ref[ActorRef] {
+  private[this] def send(msg: AnyRef): Unit = run(_ ! msg)
+
+  def !(msg: Msg): Unit = send(msg)
+
+  def kill(): Unit = if(isDefined) send(PoisonPill)
+}

--- a/src/main/scala/io/iohk/ethereum/consensus/atomixraft/MiningConfig.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/atomixraft/MiningConfig.scala
@@ -1,0 +1,5 @@
+package io.iohk.ethereum.consensus.atomixraft
+
+trait MiningConfig {
+
+}

--- a/src/main/scala/io/iohk/ethereum/consensus/atomixraft/RaftServerRef.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/atomixraft/RaftServerRef.scala
@@ -1,0 +1,7 @@
+package io.iohk.ethereum.consensus.atomixraft
+
+import io.atomix.protocols.raft.RaftServer
+
+final class RaftServerRef extends Ref[RaftServer] {
+  def stop(): Unit = run(_.shutdown())
+}

--- a/src/main/scala/io/iohk/ethereum/consensus/atomixraft/Ref.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/atomixraft/Ref.scala
@@ -1,0 +1,15 @@
+package io.iohk.ethereum.consensus.atomixraft
+
+import java.util.concurrent.atomic.AtomicReference
+
+class Ref[T <: AnyRef] {
+  final val ref = new AtomicReference[Option[T]](None)
+
+  // set once (but not necessarily compute once)
+  final def setOnce(t: ⇒T): Boolean = ref.get().isEmpty && ref.compareAndSet(None, Some(t))
+
+  final def isDefined: Boolean = ref.get().isDefined
+  final def isEmpty: Boolean = ref.get().isEmpty
+
+  final def run[U](f: T ⇒ U): Option[U] = ref.get().map(f)
+}

--- a/src/main/scala/io/iohk/ethereum/consensus/atomixraft/atomix-raft-sample.conf
+++ b/src/main/scala/io/iohk/ethereum/consensus/atomixraft/atomix-raft-sample.conf
@@ -1,0 +1,82 @@
+# This is a configuration fragment that shows all the relevant parts to AtomixRaftConsensus
+mantis {
+  network {
+    server-address {
+      # Listening interface for Ethereum protocol connections
+      interface = "999.999.999.999"
+
+      # Listening port for Ethereum protocol connections
+      port = 30309
+    }
+
+    discovery {
+      discovery-enabled = true
+      bootstrap-nodes = [
+        "enode://LONGID@IP:PORT"
+      ]
+    }
+  }
+
+  consensus {
+    # FIXME this was moved here from the `mining` section
+    active-timeout = 5 seconds
+
+    # New timeout to replace `ommer-pool-query-timeout` for uses outside ethash mining
+    get-transaction-from-pool-timeout = 5.seconds
+
+    # Moved from the `mining` section
+    # Miner's coinbase address
+    coinbase = "0011223344556677889900112233445566778899"
+
+    # Moved from the `mining` section
+    # Extra data to add to mined blocks
+    header-extra-data = "mantis"
+
+    #####################
+    # Moved from the `mining` section because this is needed by BlockGenerator, which we use in other consensus
+    # protocols as well.
+    #####################
+    # This determines how many parallel eth_getWork request we can handle, by storing the prepared blocks in a cache,
+    # until a corresponding eth_submitWork request is received
+    block-cashe-size = 30
+
+    # See io.iohk.ethereum.consensus.Protocol for the available protocols.
+    # Declaring the protocol here means that a more protocol-specific configuration
+    # is pulled from the corresponding consensus implementation.
+    # For example, in case of ethash, a section named `mining` is used.
+    protocol = atomix-raft
+
+    # If true then the consensus protocol uses this node for mining.
+    # In the case of ethash PoW, this means mining new blocks, as specified by Ethereum.
+    # In the general case, the semantics are due to the specific consensus implementation.
+    mining-enabled = false
+  }
+
+  atomix-raft {
+    # This is for mining
+    coinbase = "0011223344556677889900112233445566778899"
+
+    # FIXME TBD
+    # cluster-name = ""
+
+    # Represents this node
+    # FIXME Could derive the IP from network.server-address.interface
+    #
+    # ID and PORT are not mandatory.
+    # If PORT is not given, then is assumes the value of
+    # io.atomix.messaging.impl.NettyMessagingService.DEFAULT_PORT, which currently is 5679.
+    # If ID is not given, then it value is IP_PORT.
+    local-node = "ID1:IP:PORT"
+
+    # All the other nodes in the cluster, in the same format as with local-node
+    # FIXME Derive from network.discovery.bootstrap-nodes
+    bootstrap-nodes = [
+      "ID2:IP:PORT",
+      "ID3:IP:PORT",
+      "ID4:IP:PORT"
+    ]
+
+    # Transient data directory
+    data-dir = "atomix-raft-data"
+  }
+}

--- a/src/main/scala/io/iohk/ethereum/consensus/demo/Demo.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/demo/Demo.scala
@@ -1,0 +1,188 @@
+package io.iohk.ethereum.consensus
+package demo
+
+import java.math.BigInteger
+import java.util
+
+import akka.util.ByteString
+import io.iohk.ethereum.crypto.{kec256, kec512}
+import io.iohk.ethereum.utils.ByteUtils._
+import org.spongycastle.util.BigIntegers
+import org.spongycastle.util.encoders.Hex
+import java.lang.Integer.remainderUnsigned
+
+import scala.annotation.tailrec
+
+private[demo] object Demo {
+
+  // Revision number of https://github.com/ethereum/wiki/wiki/Ethash
+  val Revision: Int = 23
+
+  // scalastyle:off magic.number
+
+  // value used in Fowler–Noll–Vo hash function
+  val FNV_PRIME: Int = 0x01000193
+
+  // bytes in word
+  val WORD_BYTES: Int = 4
+
+  // bytes in dataset at genesis
+  val DATASET_BYTES_INIT: Long = BigInt(2).pow(30).toLong
+
+  // dataset growth per epoch
+  val DATASET_BYTES_GROWTH: Long = BigInt(2).pow(23).toLong
+
+  // bytes in cache at genesis
+  val CACHE_BYTES_INIT: Long = BigInt(2).pow(24).toLong
+
+  // cache growth per epoch
+  val CACHE_BYTES_GROWTH: Long = BigInt(2).pow(17).toLong
+
+  // blocks per epoch
+  val EPOCH_LENGTH: Int = 30000
+
+  // width of mix
+  val MIX_BYTES: Int = 128
+
+  // hash length in bytes
+  val HASH_BYTES: Int = 64
+
+  // number of parents of each dataset element
+  val DATASET_PARENTS: Int = 256
+
+  // number of rounds in cache production
+  val CACHE_ROUNDS: Int = 3
+
+  // number of accesses in hashimoto loop
+  val ACCESSES: Int = 64
+
+  // scalastyle:on magic.number
+
+  def seed(epoch: Long): ByteString = {
+    (BigInt(0) until epoch)
+      .foldLeft(ByteString(Hex.decode("00" * 32))) { case (b, _) => kec256(b) }
+  }
+
+  def epoch(blockNumber: Long): Long = blockNumber / EPOCH_LENGTH
+
+  def cacheSize(epoch: Long): Long = {
+    val sz = (CACHE_BYTES_INIT + CACHE_BYTES_GROWTH * epoch) - HASH_BYTES
+    highestPrimeBelow(sz, HASH_BYTES)
+  }
+
+  def dagSize(epoch: Long): Long = {
+    val sz = DATASET_BYTES_INIT + DATASET_BYTES_GROWTH * epoch - MIX_BYTES
+    highestPrimeBelow(sz, MIX_BYTES)
+  }
+
+  @tailrec
+  private def highestPrimeBelow(n: Long, len: Long): Long = {
+    if (isPrime(n / len)) n
+    else highestPrimeBelow(n - 2 * len, len)
+  }
+
+  private def isPrime(n: BigInt): Boolean = {
+    @tailrec
+    def isPrime(n: BigInt, i: BigInt): Boolean =
+      (n % i != 0) && ((i * i > n) || isPrime(n, i + 2))
+
+    if (n == 2 || n == 3) true
+    else if (n < 2 || n % 2 == 0) false
+    else isPrime(n, 3)
+  }
+
+  def makeCache(epoch: Long): Array[Int] = {
+    /* watch out, arrays are mutable here */
+
+    val n = (cacheSize(epoch) / HASH_BYTES).toInt
+    val s = seed(epoch).toArray[Byte]
+
+    val bytes = new Array[Array[Byte]](n)
+    bytes(0) = kec512(s)
+
+    (1 until n).foreach { i =>
+      bytes(i) = kec512(bytes(i - 1))
+    }
+
+    (0 until CACHE_ROUNDS).foreach { _ =>
+      (0 until n).foreach { i =>
+        val v = remainderUnsigned(getIntFromWord(bytes(i)), n)
+        bytes(i) = kec512(xor(bytes((i - 1 + n) % n), bytes(v)))
+      }
+    }
+
+    val res = new Array[Int](bytes.length * bytes(0).length / 4)
+    bytes.indices.foreach { i =>
+      val ints = bytesToInts(bytes(i))
+      System.arraycopy(ints, 0, res, i * ints.length, ints.length)
+    }
+    res
+  }
+
+  private def compressMix(mixToCompress: Array[Int], compressedMix: Array[Int]): Unit = {
+    var l = 0
+    while (l < mixToCompress.length) {
+      val fnv1 = fnv(mixToCompress(l), mixToCompress(l + 1))
+      val fnv2 = fnv(fnv1, mixToCompress(l + 2))
+      val fnv3 = fnv(fnv2, mixToCompress(l + 3))
+      compressedMix(l >> 2) = fnv3
+      l = l + 4
+    }
+    ()
+  }
+
+  def calcDatasetItem(cache: Array[Int], index: Int): Array[Int] = {
+    /* watch out, arrays are mutable here */
+
+    val r = HASH_BYTES / WORD_BYTES
+    val n = cache.length / r
+    val initialMix = util.Arrays.copyOfRange(cache, index % n * r, (index % n + 1) * r)
+
+    initialMix(0) = index ^ initialMix(0)
+    val mix = bytesToInts(kec512(intsToBytes(initialMix)))
+
+    mixArray(mix, cache, index, r, n)
+
+    bytesToInts(kec512(intsToBytes(mix)))
+  }
+
+  private def mixArray(mix: Array[Int], cache: Array[Int],  index: Int, r: Int, n: Int): Unit = {
+    var j = 0
+    while (j < DATASET_PARENTS) {
+      val cacheIdx = remainderUnsigned(fnv(index ^ j, mix(j % r)), n)
+      val off = cacheIdx * r
+
+      var k = 0
+      while (k < mix.length) {
+        mix(k) = fnv(mix(k), cache(off + k))
+        k = k + 1
+      }
+      j = j + 1
+    }
+  }
+
+  private def fnv(v1: Int, v2: Int): Int = {
+    (v1 * FNV_PRIME) ^ v2
+  }
+
+  private[demo] def checkDifficulty(blockDifficulty: Long, proofOfWork: ProofOfWork): Boolean = {
+    @tailrec
+    def compare(a1: Array[Byte], a2: Array[Byte]): Int = {
+      if (a1.length > a2.length) 1
+      else if (a1.length < a2.length) -1
+      else {
+        if (a1.length == 0 && a2.length == 0) 0
+        else if ((a1.head & 0xFF) > (a2.head & 0xFF)) 1
+        else if ((a1.head & 0xFF) < (a2.head & 0xFF)) -1
+        else compare(a1.tail, a2.tail)
+      }
+    }
+
+    val headerDifficultyAsByteArray: Array[Byte] =
+      BigIntegers.asUnsignedByteArray(32, BigInteger.ONE.shiftLeft(256).divide(BigInteger.valueOf(blockDifficulty)))
+
+    compare(headerDifficultyAsByteArray, proofOfWork.difficultyBoundary.toArray[Byte]) >= 0
+  }
+
+  case class ProofOfWork(mixHash: ByteString, difficultyBoundary: ByteString)
+}

--- a/src/main/scala/io/iohk/ethereum/consensus/demo/DemoConsensus.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/demo/DemoConsensus.scala
@@ -1,0 +1,46 @@
+package io.iohk.ethereum.consensus
+package demo
+import io.iohk.ethereum.nodebuilder.Node
+import io.iohk.ethereum.utils.{BlockchainConfig, Logger}
+import io.iohk.ethereum.validators.{BlockHeaderValidator, BlockHeaderValidatorImpl}
+
+/**
+ * Ridiculously simple (non-)consensus.
+ * A node with the stake declares to be the leader.
+ * All other nodes know about it via hard-coded configuration.
+ */
+class DemoConsensus(
+  blockchainConfig: BlockchainConfig,
+  val config: FullConsensusConfig[DemoConsensusConfig]
+) extends Consensus with Logger {
+
+  private[this] val defaultValidator = new BlockHeaderValidatorImpl(blockchainConfig)
+
+  type Config = DemoConsensusConfig
+
+  /**
+   * Starts the consensus protocol on the current `node`.
+   */
+  def startProtocol(node: Node): Unit = {
+    if(config.miningEnabled) {
+      startMiningProcess(node)
+    }
+    log.info(s"Howdy, started consensus protocol $this")
+  }
+
+  def stopProtocol(): Unit = {}
+
+  private[this] def startMiningProcess(node: Node): Unit = {
+    val minerBuilder = new DemoConsensusMinerBuilder(node, config.specific)
+    val miner = minerBuilder.miner
+    miner ! DemoConsensusMiner.StartMining
+  }
+
+  def protocol: Protocol = Demo0
+
+  /**
+   * Provides the [[io.iohk.ethereum.validators.BlockHeaderValidator BlockHeaderValidator]] that is specific
+   * to this consensus protocol.
+   */
+  def blockHeaderValidator: BlockHeaderValidator = defaultValidator
+}

--- a/src/main/scala/io/iohk/ethereum/consensus/demo/DemoConsensusConfig.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/demo/DemoConsensusConfig.scala
@@ -1,0 +1,38 @@
+package io.iohk.ethereum.consensus
+package demo
+
+
+import akka.util.ByteString
+import com.typesafe.config.{Config ⇒ TypesafeConfig}
+import io.iohk.ethereum.domain.Address
+import io.iohk.ethereum.validators.BlockHeaderValidatorImpl
+
+import scala.concurrent.duration.{FiniteDuration, _}
+
+case class DemoConsensusConfig(
+  IAmTheLeader: Boolean,
+  ommersPoolSize: Int, // NOTE was only used to instantiate OmmersPool
+  blockCacheSize: Int, // NOTE only used in BlockGenerator
+  coinbase: Address,
+  ommerPoolQueryTimeout: FiniteDuration,
+  headerExtraData: ByteString, // only used in BlockGenerator
+  ethashDir: String,
+  mineRounds: Int
+)
+
+object DemoConsensusConfig {
+  def apply(etcClientConfig: TypesafeConfig): DemoConsensusConfig = {
+    val config = etcClientConfig.getConfig("demo-consensus")
+
+    DemoConsensusConfig(
+      IAmTheLeader = config.getBoolean("I-am-the-leader"),
+      ommersPoolSize = config.getInt("ommers-pool-size"),
+      blockCacheSize = config.getInt("block-cashe-size"),
+      coinbase = Address(config.getString("coinbase")),
+      ommerPoolQueryTimeout = config.getDuration("ommer-pool-query-timeout").toMillis.millis,
+      headerExtraData = ByteString(config.getString("header-extra-data").getBytes).take(BlockHeaderValidatorImpl.MaxExtraDataSize),
+      ethashDir = config.getString("ethash-dir"),
+      mineRounds = config.getInt("mine-rounds")
+    )
+  }
+}

--- a/src/main/scala/io/iohk/ethereum/consensus/demo/DemoConsensusMiner.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/demo/DemoConsensusMiner.scala
@@ -1,0 +1,167 @@
+package io.iohk.ethereum.consensus
+package demo
+
+import akka.actor.{Actor, ActorLogging, ActorRef, Props}
+import akka.util.{ByteString, Timeout}
+import io.iohk.ethereum.blockchain.sync.RegularSync
+import io.iohk.ethereum.consensus.demo.Demo.ProofOfWork
+import io.iohk.ethereum.domain.{Block, Blockchain}
+import io.iohk.ethereum.jsonrpc.EthService
+import io.iohk.ethereum.mining.{BlockGenerator, PendingBlock}
+import io.iohk.ethereum.transactions.PendingTransactionsManager
+import io.iohk.ethereum.transactions.PendingTransactionsManager.PendingTransactionsResponse
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.concurrent.duration._
+import scala.util.{Failure, Success}
+
+class DemoConsensusMiner(
+  blockchain: Blockchain,
+  blockGenerator: BlockGenerator,
+  ommersPool: ActorRef,
+  pendingTransactionsManager: ActorRef,
+  syncController: ActorRef,
+  demoConsensusConfig: DemoConsensusConfig,
+  ethService: EthService
+) extends Actor with ActorLogging {
+
+  import DemoConsensusMiner._
+  import akka.pattern.ask
+
+  var currentEpoch: Option[Long] = None
+  var currentEpochDagSize: Option[Long] = None
+  var currentEpochDag: Option[Array[Array[Int]]] = None
+
+  private[this] val IAmTheLeader = demoConsensusConfig.IAmTheLeader
+
+  def receive: Receive = stopped
+
+  def stopped: Receive = {
+    case StartMining =>
+      context become started
+      self ! ProcessMining
+    case ProcessMining => // nothing
+  }
+
+  def started: Receive = {
+    case StopMining => context become stopped
+    case ProcessMining => processMining()
+    case UpdateAndSyncTheBlock(block) => updateAndSyncTheBlock(block)
+  }
+
+  private def syncTheBlock(block: Block): Unit = {
+    syncController ! RegularSync.MinedBlock(block)
+    self ! ProcessMining
+  }
+
+  private def updateAndSyncTheBlock(block: Block): Unit = {
+    val header = block.header
+    val blockTime = header.unixTimestamp
+    val now = blockGenerator.blockTimestampProvider.getEpochSecond
+
+    require(now > blockTime)
+
+    val newHeader = header.copy(unixTimestamp = now)
+    val newBlock = block.copy(header = newHeader)
+
+    log.info("***** Syncing the block")
+    syncTheBlock(newBlock)
+  }
+
+  private def processMining(): Unit = {
+    if(IAmTheLeader) {
+      log.info("***** I am the leader, going to mine a block ...")
+      val initialTime = blockGenerator.blockTimestampProvider.getEpochSecond
+      val parentBlock = blockchain.getBestBlock()
+
+      getBlockForMining(parentBlock) onComplete {
+        case Success(PendingBlock(block, _)) =>
+          val blockTime = block.header.unixTimestamp
+          // Just to make sure we pass the relevant validation
+          // FIXME This needs to be generalized (move all relevant validation to the consensus implementation)
+          if(blockTime > initialTime) {
+            syncTheBlock(block)
+          }
+          else {
+            val delay = 5.seconds
+            log.warning(s"***** Block mined too soon, inserting delay of ~ $delay")
+            context.system.scheduler.scheduleOnce(delay, self, UpdateAndSyncTheBlock(block))
+          }
+
+        case Failure(ex) =>
+          log.error(ex, "Unable to get block for mining")
+          context.system.scheduler.scheduleOnce(10.seconds, self, ProcessMining)
+      }
+    }
+    else {
+      // Hoping to become the leader ...
+      log.info("***** I am not the leader, hoping to become one in the future ...")
+      context.system.scheduler.scheduleOnce(5.seconds, self, ProcessMining)
+    }
+  }
+
+  private def getBlockForMining(parentBlock: Block): Future[PendingBlock] = {
+    val ffPendingBlock: Future[Future[PendingBlock]] =
+      for {
+        pendingTxResponse ← getTransactionsFromPool
+      } yield {
+        val pendingTransactions = pendingTxResponse.pendingTransactions.map(_.stx)
+
+        val errorOrPendingBlock = blockGenerator.generateBlockForMining(parentBlock, pendingTransactions, Nil, demoConsensusConfig.coinbase)
+        errorOrPendingBlock match {
+          case Left(error) ⇒
+            Future.failed(new RuntimeException(s"Error while generating block for mining: $error"))
+
+          case Right(pendingBlock) ⇒
+            Future.successful(pendingBlock)
+        }
+      }
+
+    ffPendingBlock.flatten
+  }
+
+  private def getTransactionsFromPool = {
+    // FIXME Rename this since we do not use ommers?
+    implicit val timeout = Timeout(demoConsensusConfig.ommerPoolQueryTimeout)
+
+    (pendingTransactionsManager ? PendingTransactionsManager.GetPendingTransactions).mapTo[PendingTransactionsResponse]
+      .recover { case ex =>
+        log.error(ex, "Failed to get transactions, mining block with empty transactions list")
+        PendingTransactionsResponse(Nil)
+      }
+  }
+}
+
+object DemoConsensusMiner {
+  def props(blockchain: Blockchain,
+    blockGenerator: BlockGenerator,
+    ommersPool: ActorRef,
+    pendingTransactionsManager: ActorRef,
+    syncController: ActorRef,
+    miningConfig: DemoConsensusConfig,
+    ethService: EthService
+  ): Props =
+    Props(new DemoConsensusMiner(blockchain, blockGenerator, ommersPool,
+      pendingTransactionsManager, syncController, miningConfig, ethService))
+
+  case object StartMining
+  case object StopMining
+
+  private case object ProcessMining
+  private case class UpdateAndSyncTheBlock(block: Block) // FIXME this is just to ensure header validation succeeds
+
+  // scalastyle:off magic.number
+  val MaxNonce: BigInt = BigInt(2).pow(64) - 1
+
+  val DagFilePrefix: ByteString = ByteString(Array(0xfe, 0xca, 0xdd, 0xba, 0xad, 0xde, 0xe1, 0xfe).map(_.toByte))
+
+  sealed trait MiningResult {
+    def triedHashes: Int
+  }
+
+  case class MiningSuccessful(triedHashes: Int, pow: ProofOfWork, nonce: ByteString) extends MiningResult
+  case class MiningUnsuccessful(triedHashes: Int) extends MiningResult
+
+}
+

--- a/src/main/scala/io/iohk/ethereum/consensus/demo/DemoConsensusMinerBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/demo/DemoConsensusMinerBuilder.scala
@@ -1,0 +1,19 @@
+package io.iohk.ethereum.consensus
+package demo
+
+import akka.actor.ActorRef
+import io.iohk.ethereum.nodebuilder._
+
+class DemoConsensusMinerBuilder(node: Node, demoConsensusConfig: DemoConsensusConfig) {
+  import node._
+
+  lazy val miner: ActorRef = actorSystem.actorOf(DemoConsensusMiner.props(
+    blockchain,
+    blockGenerator,
+    ommersPool,
+    pendingTransactionsManager,
+    syncController,
+    demoConsensusConfig,
+    ethService
+  ))
+}

--- a/src/main/scala/io/iohk/ethereum/consensus/ethash/Ethash.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/ethash/Ethash.scala
@@ -1,4 +1,5 @@
 package io.iohk.ethereum.consensus
+package ethash
 
 import java.math.BigInteger
 import java.util
@@ -212,7 +213,7 @@ object Ethash {
     (v1 * FNV_PRIME) ^ v2
   }
 
-  def checkDifficulty(blockDifficulty: Long, proofOfWork: ProofOfWork): Boolean = {
+  private[ethash] def checkDifficulty(blockDifficulty: Long, proofOfWork: ProofOfWork): Boolean = {
     @tailrec
     def compare(a1: Array[Byte], a2: Array[Byte]): Int = {
       if (a1.length > a2.length) 1

--- a/src/main/scala/io/iohk/ethereum/consensus/ethash/EthashConsensus.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/ethash/EthashConsensus.scala
@@ -1,0 +1,64 @@
+package io.iohk.ethereum
+package consensus
+package ethash
+
+import java.util.concurrent.atomic.AtomicReference
+
+import akka.actor.ActorRef
+import io.iohk.ethereum.consensus.ethash.Miner.MinerMsg
+import io.iohk.ethereum.nodebuilder.Node
+import io.iohk.ethereum.utils.BlockchainConfig
+import io.iohk.ethereum.validators.BlockHeaderValidator
+
+/**
+ * Implements standard Ethereum consensus (ethash PoW).
+ */
+class EthashConsensus(
+  blockchainConfig: BlockchainConfig,
+  val config: FullConsensusConfig[MiningConfig]
+) extends Consensus {
+
+  type Config = MiningConfig
+
+  private[this] val ethashValidator = new ethash.validators.EthashBlockHeaderValidator(blockchainConfig)
+
+  private[this] val atomicMiner = new AtomicReference[Option[ActorRef]](None)
+  private[this] def sendMiner(msg: MinerMsg): Unit =
+    atomicMiner.get().foreach(_ ! msg)
+
+  private[this] def startMiningProcess(node: Node): Unit = {
+    atomicMiner.get() match {
+      case None ⇒
+        val minerBuilder = new MinerBuilder(node, config.specific)
+        val miner = minerBuilder.miner
+        atomicMiner.set(Some(miner))
+
+        sendMiner(Miner.StartMining)
+
+      case _ ⇒
+    }
+  }
+
+  private[this] def stopMiningProcess(): Unit = {
+    sendMiner(Miner.StopMining)
+  }
+
+  def blockHeaderValidator: BlockHeaderValidator = ethashValidator
+
+  /**
+   * Starts the consensus protocol on the current `node`.
+   */
+  def startProtocol(node: Node): Unit = {
+    if(config.miningEnabled) {
+      startMiningProcess(node)
+    }
+  }
+
+  def stopProtocol(): Unit = {
+    if(config.miningEnabled) {
+      stopMiningProcess()
+    }
+  }
+
+  def protocol: Protocol = consensus.Ethash
+}

--- a/src/main/scala/io/iohk/ethereum/consensus/ethash/Miner.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/ethash/Miner.scala
@@ -1,20 +1,21 @@
-package io.iohk.ethereum.mining
+package io.iohk.ethereum.consensus
+package ethash
 
 import java.io.{File, FileInputStream, FileOutputStream}
 
 import akka.actor.{Actor, ActorLogging, ActorRef, Props}
 import akka.util.{ByteString, Timeout}
 import io.iohk.ethereum.blockchain.sync.RegularSync
-import io.iohk.ethereum.consensus.Ethash
-import io.iohk.ethereum.consensus.Ethash.ProofOfWork
+import io.iohk.ethereum.consensus.ethash.Ethash.ProofOfWork
 import io.iohk.ethereum.crypto
 import io.iohk.ethereum.domain.{Block, BlockHeader, Blockchain}
 import io.iohk.ethereum.jsonrpc.EthService
 import io.iohk.ethereum.jsonrpc.EthService.SubmitHashRateRequest
+import io.iohk.ethereum.mining.{BlockGenerator, PendingBlock}
 import io.iohk.ethereum.ommers.OmmersPool
 import io.iohk.ethereum.transactions.PendingTransactionsManager
 import io.iohk.ethereum.transactions.PendingTransactionsManager.PendingTransactionsResponse
-import io.iohk.ethereum.utils.{ByteUtils, MiningConfig}
+import io.iohk.ethereum.utils.ByteUtils
 import org.spongycastle.util.encoders.Hex
 
 import scala.concurrent.Future
@@ -24,14 +25,14 @@ import scala.util.{Failure, Random, Success, Try}
 import io.iohk.ethereum.utils.BigIntExtensionMethods._
 
 class Miner(
-    blockchain: Blockchain,
-    blockGenerator: BlockGenerator,
-    ommersPool: ActorRef,
-    pendingTransactionsManager: ActorRef,
-    syncController: ActorRef,
-    miningConfig: MiningConfig,
-    ethService: EthService)
-  extends Actor with ActorLogging {
+  blockchain: Blockchain,
+  blockGenerator: BlockGenerator,
+  ommersPool: ActorRef,
+  pendingTransactionsManager: ActorRef,
+  syncController: ActorRef,
+  config: FullConsensusConfig[MiningConfig],
+  ethService: EthService
+) extends Actor with ActorLogging {
 
   import Miner._
   import akka.pattern.ask
@@ -39,6 +40,9 @@ class Miner(
   var currentEpoch: Option[Long] = None
   var currentEpochDagSize: Option[Long] = None
   var currentEpochDag: Option[Array[Array[Int]]] = None
+
+  private[this] val consensusConfig = config.generic
+  private[this] val miningConfig = config.specific
 
   override def receive: Receive = stopped
 
@@ -75,7 +79,7 @@ class Miner(
         currentEpoch = Some(epoch)
         currentEpochDag = Some(dag)
         currentEpochDagSize = Some(dagSize)
-      (dag, dagSize)
+        (dag, dagSize)
     }
 
     getBlockForMining(parentBlock) onComplete {
@@ -164,13 +168,13 @@ class Miner(
       val pow = Ethash.hashimoto(headerHash, nonceBytes.toArray[Byte], dagSize, dag.apply)
       (Ethash.checkDifficulty(difficulty, pow), pow, nonceBytes, n)
     }
-    .collectFirst { case (true, pow, nonceBytes, n) => MiningSuccessful(n + 1, pow, nonceBytes) }
-    .getOrElse(MiningUnsuccessful(numRounds))
+      .collectFirst { case (true, pow, nonceBytes, n) => MiningSuccessful(n + 1, pow, nonceBytes) }
+      .getOrElse(MiningUnsuccessful(numRounds))
   }
 
   private def getBlockForMining(parentBlock: Block): Future[PendingBlock] = {
     getOmmersFromPool(parentBlock.header.number + 1).zip(getTransactionsFromPool).flatMap { case (ommers, pendingTxs) =>
-      blockGenerator.generateBlockForMining(parentBlock, pendingTxs.pendingTransactions.map(_.stx), ommers.headers, miningConfig.coinbase) match {
+      blockGenerator.generateBlockForMining(parentBlock, pendingTxs.pendingTransactions.map(_.stx), ommers.headers, consensusConfig.coinbase) match {
         case Right(pb) => Future.successful(pb)
         case Left(err) => Future.failed(new RuntimeException(s"Error while generating block for mining: $err"))
       }
@@ -188,7 +192,7 @@ class Miner(
   }
 
   private def getTransactionsFromPool = {
-    implicit val timeout = Timeout(miningConfig.ommerPoolQueryTimeout)
+    implicit val timeout = Timeout(consensusConfig.getTransactionFromPoolTimeout)
 
     (pendingTransactionsManager ? PendingTransactionsManager.GetPendingTransactions).mapTo[PendingTransactionsResponse]
       .recover { case ex =>
@@ -200,17 +204,19 @@ class Miner(
 
 object Miner {
   def props(blockchain: Blockchain,
-            blockGenerator: BlockGenerator,
-            ommersPool: ActorRef,
-            pendingTransactionsManager: ActorRef,
-            syncController: ActorRef,
-            miningConfig: MiningConfig,
-            ethService: EthService): Props =
+    blockGenerator: BlockGenerator,
+    ommersPool: ActorRef,
+    pendingTransactionsManager: ActorRef,
+    syncController: ActorRef,
+    config: FullConsensusConfig[MiningConfig],
+    ethService: EthService
+  ): Props =
     Props(new Miner(blockchain, blockGenerator, ommersPool,
-      pendingTransactionsManager, syncController, miningConfig, ethService))
+      pendingTransactionsManager, syncController, config, ethService))
 
-  case object StartMining
-  case object StopMining
+  sealed trait MinerMsg
+  case object StartMining extends MinerMsg
+  case object StopMining extends MinerMsg
 
   private case object ProcessMining
 
@@ -226,3 +232,4 @@ object Miner {
   case class MiningUnsuccessful(triedHashes: Int) extends MiningResult
 
 }
+

--- a/src/main/scala/io/iohk/ethereum/consensus/ethash/MinerBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/ethash/MinerBuilder.scala
@@ -1,0 +1,24 @@
+package io.iohk.ethereum.consensus.ethash
+
+import akka.actor.ActorRef
+import io.iohk.ethereum.consensus.FullConsensusConfig
+import io.iohk.ethereum.nodebuilder._
+
+class MinerBuilder(
+  node: Node,
+  miningConfig: MiningConfig
+) {
+  import node._
+
+  private[this] val config = FullConsensusConfig(consensusConfig, miningConfig)
+
+  lazy val miner: ActorRef = actorSystem.actorOf(Miner.props(
+    blockchain,
+    blockGenerator,
+    ommersPool,
+    pendingTransactionsManager,
+    syncController,
+    config,
+    ethService
+  ))
+}

--- a/src/main/scala/io/iohk/ethereum/consensus/ethash/MiningConfig.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/ethash/MiningConfig.scala
@@ -1,0 +1,27 @@
+package io.iohk.ethereum
+package consensus
+package ethash
+
+import com.typesafe.config.{Config ⇒ TypesafeConfig}
+
+import scala.concurrent.duration.{FiniteDuration, _}
+
+final case class MiningConfig(
+  ommersPoolSize: Int, // NOTE was only used to instantiate OmmersPool
+  ommerPoolQueryTimeout: FiniteDuration,
+  ethashDir: String,
+  mineRounds: Int
+)
+
+object MiningConfig {
+  def apply(mantisConfig: TypesafeConfig): MiningConfig = {
+    val miningConfig = mantisConfig.getConfig("mining")
+
+    new MiningConfig(
+      ommersPoolSize = miningConfig.getInt("ommers-pool-size"),
+      ommerPoolQueryTimeout = miningConfig.getDuration("ommer-pool-query-timeout").toMillis.millis,
+      ethashDir = miningConfig.getString("ethash-dir"),
+      mineRounds = miningConfig.getInt("mine-rounds")
+    )
+  }
+}

--- a/src/main/scala/io/iohk/ethereum/consensus/ethash/validators/EthashBlockHeaderValidator.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/ethash/validators/EthashBlockHeaderValidator.scala
@@ -1,0 +1,101 @@
+package io.iohk.ethereum.consensus.ethash
+package validators
+
+import akka.util.ByteString
+import io.iohk.ethereum.crypto
+import io.iohk.ethereum.domain.BlockHeader
+import io.iohk.ethereum.utils.BlockchainConfig
+import io.iohk.ethereum.validators.BlockHeaderError.{HeaderParentNotFoundError, HeaderPoWError}
+import io.iohk.ethereum.validators.BlockHeaderValidatorImpl.PowCacheData
+import io.iohk.ethereum.validators.{BlockHeaderError, BlockHeaderValid, BlockHeaderValidator, BlockHeaderValidatorImpl}
+
+// NOTE Copied parts from [[io.iohk.ethereum.validators.BlockHeaderValidatorImpl]]
+class EthashBlockHeaderValidator(blockchainConfig: BlockchainConfig) extends BlockHeaderValidator {
+  import EthashBlockHeaderValidator._
+
+  // NOTE This is code from before PoW decoupling
+  // we need concurrent map since validators can be used from multiple places
+  val powCaches: java.util.Map[Long, PowCacheData] = new java.util.concurrent.ConcurrentHashMap[Long, PowCacheData]()
+
+  private[this] val defaultValidator = new BlockHeaderValidatorImpl(blockchainConfig)
+
+
+  /** This method allows validate a BlockHeader (stated on
+   * section 4.4.4 of http://paper.gavwood.com/).
+   *
+   * @param blockHeader  BlockHeader to validate.
+   * @param parentHeader BlockHeader of the parent of the block to validate.
+   */
+  def validate(blockHeader: BlockHeader, parentHeader: BlockHeader): Either[BlockHeaderError, BlockHeaderValid] = {
+    for {
+      _ ← defaultValidator.validate(blockHeader, parentHeader)
+      _ ← validatePoW(blockHeader)
+    } yield BlockHeaderValid
+  }
+
+  /** This method allows validate a BlockHeader (stated on
+   * section 4.4.4 of http://paper.gavwood.com/).
+   *
+   * @param blockHeader BlockHeader to validate.
+   * @param getBlockHeaderByHash function to obtain the parent header.
+   */
+  def validate(blockHeader: BlockHeader, getBlockHeaderByHash: ByteString => Option[BlockHeader]): Either[BlockHeaderError, BlockHeaderValid] = {
+    for {
+      blockHeaderParent <- getBlockHeaderByHash(blockHeader.parentHash).map(Right(_)).getOrElse(Left(HeaderParentNotFoundError))
+      _ <- validate(blockHeader, blockHeaderParent)
+    } yield BlockHeaderValid
+  }
+
+  /**
+   * Validates [[io.iohk.ethereum.domain.BlockHeader.nonce]] and [[io.iohk.ethereum.domain.BlockHeader.mixHash]] are correct
+   * based on validations stated in section 4.4.4 of http://paper.gavwood.com/
+   *
+   * @param blockHeader BlockHeader to validate.
+   * @return BlockHeader if valid, an [[io.iohk.ethereum.validators.BlockHeaderError.HeaderPoWError]] otherwise
+   */
+  private def validatePoW(blockHeader: BlockHeader): Either[BlockHeaderError, BlockHeaderValid] = {
+    import Ethash._
+    import scala.collection.JavaConverters._
+
+    def getPowCacheData(epoch: Long): PowCacheData = {
+      if (epoch == 0) EthashBlockHeaderValidator.epoch0PowCache else
+        Option(powCaches.get(epoch)) match {
+          case Some(pcd) => pcd
+          case None =>
+            val data = new PowCacheData(
+              cache = Ethash.makeCache(epoch),
+              dagSize = Ethash.dagSize(epoch))
+
+            val keys = powCaches.keySet().asScala
+            val keysToRemove = keys.toSeq.sorted.take(keys.size - MaxPowCaches + 1)
+            keysToRemove.foreach(powCaches.remove)
+
+            powCaches.put(epoch, data)
+
+            data
+        }
+    }
+
+    val powCacheData = getPowCacheData(epoch(blockHeader.number.toLong))
+
+    val proofOfWork = hashimotoLight(crypto.kec256(BlockHeader.getEncodedWithoutNonce(blockHeader)),
+      blockHeader.nonce.toArray[Byte], powCacheData.dagSize, powCacheData.cache)
+
+    if (proofOfWork.mixHash == blockHeader.mixHash && checkDifficulty(blockHeader.difficulty.toLong, proofOfWork)) Right(BlockHeaderValid)
+    else Left(HeaderPoWError)
+  }
+}
+
+object EthashBlockHeaderValidator {
+  val MaxPowCaches: Int = 2 // maximum number of epochs for which PoW cache is stored in memory
+
+  // NOTE The below FIXME is from before PoW decoupling.
+
+  // FIXME [EC-331]: this is used to speed up ETS Blockchain tests. All blocks in those tests have low numbers (1, 2, 3 ...)
+  // so keeping the cache for epoch 0 avoids recalculating it for each individual test. The difference in test runtime
+  // can be dramatic - full suite: 26 hours vs 21 minutes on same machine
+  // It might be desirable to find a better solution for this - one that doesn't keep this cache unnecessarily
+  lazy val epoch0PowCache = new PowCacheData(
+    cache = Ethash.makeCache(0),
+    dagSize = Ethash.dagSize(0))
+}

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/EthService.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/EthService.scala
@@ -1,35 +1,35 @@
 package io.iohk.ethereum.jsonrpc
 
 import java.time.Duration
-import java.util.function.UnaryOperator
 import java.util.Date
 import java.util.concurrent.atomic.AtomicReference
+import java.util.function.UnaryOperator
 
-import akka.pattern.ask
-import akka.util.Timeout
-import io.iohk.ethereum.domain.{BlockHeader, SignedTransaction, UInt256, _}
 import akka.actor.ActorRef
-import io.iohk.ethereum.db.storage.AppStateStorage
-import akka.util.ByteString
+import akka.pattern.ask
+import akka.util.{ByteString, Timeout}
 import io.iohk.ethereum.blockchain.sync.RegularSync
+import io.iohk.ethereum.consensus.{ConsensusConfig, FullConsensusConfig}
 import io.iohk.ethereum.crypto._
+import io.iohk.ethereum.db.storage.AppStateStorage
 import io.iohk.ethereum.db.storage.TransactionMappingStorage.TransactionLocation
+import io.iohk.ethereum.domain.{BlockHeader, SignedTransaction, UInt256, _}
 import io.iohk.ethereum.jsonrpc.FilterManager.{FilterChanges, FilterLogs, LogFilterLogs, TxLog}
 import io.iohk.ethereum.keystore.KeyStore
 import io.iohk.ethereum.ledger.{InMemoryWorldStateProxy, Ledger}
 import io.iohk.ethereum.mining.BlockGenerator
-import io.iohk.ethereum.utils._
-import io.iohk.ethereum.transactions.PendingTransactionsManager
-import io.iohk.ethereum.transactions.PendingTransactionsManager.PendingTransactionsResponse
 import io.iohk.ethereum.ommers.OmmersPool
 import io.iohk.ethereum.rlp
-import io.iohk.ethereum.rlp.RLPList
 import io.iohk.ethereum.rlp.RLPImplicitConversions._
+import io.iohk.ethereum.rlp.RLPList
 import io.iohk.ethereum.rlp.UInt256RLPImplicits._
+import io.iohk.ethereum.transactions.PendingTransactionsManager
+import io.iohk.ethereum.transactions.PendingTransactionsManager.PendingTransactionsResponse
+import io.iohk.ethereum.utils._
 import org.spongycastle.util.encoders.Hex
 
-import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
 import scala.util.{Failure, Success, Try}
 
 // scalastyle:off number.of.methods number.of.types
@@ -171,7 +171,7 @@ class EthService(
     blockchain: Blockchain,
     blockGenerator: BlockGenerator,
     appStateStorage: AppStateStorage,
-    miningConfig: MiningConfig,
+    fullConsensusConfig: FullConsensusConfig[_],
     ledger: Ledger,
     keyStore: KeyStore,
     pendingTransactionsManager: ActorRef,
@@ -187,6 +187,13 @@ class EthService(
 
   val hashRate: AtomicReference[Map[ByteString, (BigInt, Date)]] = new AtomicReference[Map[ByteString, (BigInt, Date)]](Map())
   val lastActive = new AtomicReference[Option[Date]](None)
+
+  private[this] def consensusConfig: ConsensusConfig = fullConsensusConfig.generic
+
+  private[this] def ifEthash[Req, Res](req: Req)(f: Req ⇒ Res): ServiceResponse[Res] = {
+    @inline def F[A](x: A) = Future.successful(x)
+    fullConsensusConfig.ifEthash[ServiceResponse[Res]](_ ⇒ F(Right(f(req))))(F(Left(JsonRpcErrors.ConsensusIsNotEthash)))
+  }
 
   def protocolVersion(req: ProtocolVersionRequest): ServiceResponse[ProtocolVersionResponse] =
     Future.successful(Right(ProtocolVersionResponse(f"0x$protocolVersion%x")))
@@ -371,17 +378,18 @@ class EthService(
     Right(UncleByBlockNumberAndIndexResponse(uncleBlockResponseOpt))
   }
 
-  def submitHashRate(req: SubmitHashRateRequest): ServiceResponse[SubmitHashRateResponse] = {
-    reportActive()
-    hashRate.updateAndGet(new UnaryOperator[Map[ByteString, (BigInt, Date)]] {
-      override def apply(t: Map[ByteString, (BigInt, Date)]): Map[ByteString, (BigInt, Date)] = {
-        val now = new Date
-        removeObsoleteHashrates(now, t + (req.id -> (req.hashRate, now)))
-      }
-    })
+  def submitHashRate(req: SubmitHashRateRequest): ServiceResponse[SubmitHashRateResponse] =
+    ifEthash(req) { req ⇒
+      reportActive()
+      hashRate.updateAndGet(new UnaryOperator[Map[ByteString, (BigInt, Date)]] {
+        override def apply(t: Map[ByteString, (BigInt, Date)]): Map[ByteString, (BigInt, Date)] = {
+          val now = new Date
+          removeObsoleteHashrates(now, t + (req.id -> (req.hashRate, now)))
+        }
+      })
 
-    Future.successful(Right(SubmitHashRateResponse(true)))
-  }
+      SubmitHashRateResponse(true)
+    }
 
   def getGetGasPrice(req: GetGasPriceRequest): ServiceResponse[GetGasPriceResponse] = {
     val blockDifference = 30
@@ -401,75 +409,79 @@ class EthService(
     }
   }
 
-  def getMining(req: GetMiningRequest): ServiceResponse[GetMiningResponse] = {
-    val isMining = lastActive.updateAndGet(new UnaryOperator[Option[Date]] {
-      override def apply(e: Option[Date]): Option[Date] = {
-        e.filter { time => Duration.between(time.toInstant, (new Date).toInstant).toMillis < miningConfig.activeTimeout.toMillis }
-      }
-    }).isDefined
-    Future.successful(Right(GetMiningResponse(isMining)))
-  }
+  def getMining(req: GetMiningRequest): ServiceResponse[GetMiningResponse] =
+    ifEthash(req) { req ⇒
+      val isMining = lastActive.updateAndGet(new UnaryOperator[Option[Date]] {
+        override def apply(e: Option[Date]): Option[Date] = {
+          e.filter {
+            time => Duration.between(time.toInstant, (new Date).toInstant).toMillis < consensusConfig.activeTimeout.toMillis
+          }
+        }
+      }).isDefined
+
+      GetMiningResponse(isMining)
+    }
 
   private def reportActive() = {
     val now = new Date()
-    lastActive.updateAndGet(new UnaryOperator[Option[Date]] {
-      override def apply(e: Option[Date]): Option[Date] = {
-        Some(now)
-      }
-    })
+    lastActive.updateAndGet(_ ⇒ Some(now))
   }
 
-  def getHashRate(req: GetHashRateRequest): ServiceResponse[GetHashRateResponse] = {
-    val hashRates: Map[ByteString, (BigInt, Date)] = hashRate.updateAndGet(new UnaryOperator[Map[ByteString, (BigInt, Date)]] {
-      override def apply(t: Map[ByteString, (BigInt, Date)]): Map[ByteString, (BigInt, Date)] = {
-        removeObsoleteHashrates(new Date, t)
-      }
-    })
+  def getHashRate(req: GetHashRateRequest): ServiceResponse[GetHashRateResponse] =
+    ifEthash(req) { req ⇒
+      val hashRates: Map[ByteString, (BigInt, Date)] = hashRate.updateAndGet(new UnaryOperator[Map[ByteString, (BigInt, Date)]] {
+        override def apply(t: Map[ByteString, (BigInt, Date)]): Map[ByteString, (BigInt, Date)] = {
+          removeObsoleteHashrates(new Date, t)
+        }
+      })
 
-    //sum all reported hashRates
-    Future.successful(Right(GetHashRateResponse(hashRates.mapValues { case (hr, _) => hr }.values.sum)))
-  }
+      //sum all reported hashRates
+      GetHashRateResponse(hashRates.mapValues { case (hr, _) => hr }.values.sum)
+    }
 
+  // NOTE This is called from places that guarantee we are running Ethash consensus.
   private def removeObsoleteHashrates(now: Date, rates: Map[ByteString, (BigInt, Date)]):Map[ByteString, (BigInt, Date)]={
     rates.filter { case (_, (_, reported)) =>
-      Duration.between(reported.toInstant, now.toInstant).toMillis < miningConfig.activeTimeout.toMillis
+      Duration.between(reported.toInstant, now.toInstant).toMillis < consensusConfig.activeTimeout.toMillis
     }
   }
 
-  def getWork(req: GetWorkRequest): ServiceResponse[GetWorkResponse] = {
-    reportActive()
-    import io.iohk.ethereum.consensus.Ethash.{seed, epoch}
+  def getWork(req: GetWorkRequest): ServiceResponse[GetWorkResponse] =
+    fullConsensusConfig.ifEthash(_ ⇒ {
+      reportActive()
+      import io.iohk.ethereum.consensus.ethash.Ethash.{seed, epoch}
 
-    val bestBlock = blockchain.getBestBlock()
+      val bestBlock = blockchain.getBestBlock()
+      getOmmersFromPool(bestBlock.header.number + 1).zip(getTransactionsFromPool).map {
+        case (ommers, pendingTxs) =>
+          blockGenerator.generateBlockForMining(bestBlock, pendingTxs.pendingTransactions.map(_.stx), ommers.headers, consensusConfig.coinbase) match {
+            case Right(pb) =>
+              Right(GetWorkResponse(
+                powHeaderHash = ByteString(kec256(BlockHeader.getEncodedWithoutNonce(pb.block.header))),
+                dagSeed = seed(epoch(pb.block.header.number.toLong)),
+                target = ByteString((BigInt(2).pow(256) / pb.block.header.difficulty).toByteArray)
+              ))
+            case Left(err) =>
+              log.error(s"unable to prepare block because of $err")
+              Left(JsonRpcErrors.InternalError)
+          }
+      }
+    })(Future.successful(Left(JsonRpcErrors.ConsensusIsNotEthash)))
 
-    getOmmersFromPool(bestBlock.header.number + 1).zip(getTransactionsFromPool).map {
-      case (ommers, pendingTxs) =>
-        blockGenerator.generateBlockForMining(bestBlock, pendingTxs.pendingTransactions.map(_.stx), ommers.headers, miningConfig.coinbase) match {
-          case Right(pb) =>
-            Right(GetWorkResponse(
-              powHeaderHash = ByteString(kec256(BlockHeader.getEncodedWithoutNonce(pb.block.header))),
-              dagSeed = seed(epoch(pb.block.header.number.toLong)),
-              target = ByteString((BigInt(2).pow(256) / pb.block.header.difficulty).toByteArray)
-            ))
-          case Left(err) =>
-            log.error(s"unable to prepare block because of $err")
-            Left(JsonRpcErrors.InternalError)
+  private def getOmmersFromPool(blockNumber: BigInt): Future[OmmersPool.Ommers] =
+    fullConsensusConfig.ifEthash(miningConfig ⇒ {
+      implicit val timeout = Timeout(miningConfig.ommerPoolQueryTimeout)
+
+      (ommersPool ? OmmersPool.GetOmmers(blockNumber)).mapTo[OmmersPool.Ommers]
+        .recover { case ex =>
+          log.error("failed to get ommer, mining block with empty ommers list", ex)
+          OmmersPool.Ommers(Nil)
         }
-      }
-  }
+    })(Future.successful(OmmersPool.Ommers(Nil))) // NOTE If not Ethash consensus, ommers do not make sense, so => Nil
 
-  private def getOmmersFromPool(blockNumber: BigInt) = {
-    implicit val timeout = Timeout(miningConfig.ommerPoolQueryTimeout)
-
-    (ommersPool ? OmmersPool.GetOmmers(blockNumber)).mapTo[OmmersPool.Ommers]
-      .recover { case ex =>
-        log.error("failed to get ommer, mining block with empty ommers list", ex)
-        OmmersPool.Ommers(Nil)
-      }
-  }
-
-  private def getTransactionsFromPool = {
-    implicit val timeout = Timeout(miningConfig.ommerPoolQueryTimeout)
+  // TODO This seems to be re-implemented elsewhere, probably move to a better place? Also generalize the error message.
+  private def getTransactionsFromPool: Future[PendingTransactionsResponse] = {
+    implicit val timeout = Timeout(consensusConfig.getTransactionFromPoolTimeout)
 
     (pendingTransactionsManager ? PendingTransactionsManager.GetPendingTransactions).mapTo[PendingTransactionsResponse]
       .recover { case ex =>
@@ -479,8 +491,9 @@ class EthService(
   }
 
   def getCoinbase(req: GetCoinbaseRequest): ServiceResponse[GetCoinbaseResponse] =
-    Future.successful(Right(GetCoinbaseResponse(miningConfig.coinbase)))
+    Future.successful(Right(GetCoinbaseResponse(consensusConfig.coinbase)))
 
+  // FIXME only valid for Ethash consensus?
   def submitWork(req: SubmitWorkRequest): ServiceResponse[SubmitWorkResponse] = {
     reportActive()
     Future {

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/JsonRpcError.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/JsonRpcError.scala
@@ -14,4 +14,8 @@ object JsonRpcErrors {
   val InternalError = JsonRpcError(-32603, "Internal JSON-RPC error", None)
   def LogicError(msg: String) = JsonRpcError(-32000, msg, None)
   val AccountLocked = LogicError("account is locked or unknown")
+
+  // Using the recommendation from https://github.com/ethereum/wiki/wiki/JSON-RPC-Error-Codes-Improvement-Proposal
+  // Error Code "2", "Action not allowed" could be a candidate here
+  final val ConsensusIsNotEthash = JsonRpcError(200, "The consensus algorithm is not Ethash", None)
 }

--- a/src/main/scala/io/iohk/ethereum/ledger/Ledger.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/Ledger.scala
@@ -25,6 +25,7 @@ trait Ledger {
 
   def simulateTransaction(stx: SignedTransaction, blockHeader: BlockHeader, world: Option[InMemoryWorldStateProxy]): TxResult
 
+  // FIXME check if needs to change for pluggable consensus
   def importBlock(block: Block): BlockImportResult
 
   def resolveBranch(headers: Seq[BlockHeader]): BranchResolutionResult
@@ -545,6 +546,7 @@ class LedgerImpl(
     TxResult(world2, executionGasToPayToMiner, resultWithErrorHandling.logs, result.returnData, result.error)
   }
 
+  // FIXME move to consensus
   private def validateBlockBeforeExecution(block: Block): Either[ValidationBeforeExecError, BlockExecutionSuccess] = {
     val result = for {
       _ <- validators.blockHeaderValidator.validate(block.header, getHeaderFromChainOrQueue _)
@@ -555,6 +557,7 @@ class LedgerImpl(
     result.left.map(ValidationBeforeExecError)
   }
 
+  // FIXME move to consensus
   /**
     * This function validates that the various results from execution are consistent with the block. This includes:
     *   - Validating the resulting stateRootHash

--- a/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
@@ -5,8 +5,10 @@ import java.time.Clock
 
 import akka.actor.{ActorRef, ActorSystem}
 import akka.agent.Agent
+import akka.util.ByteString
 import io.iohk.ethereum.blockchain.data.GenesisDataLoader
 import io.iohk.ethereum.blockchain.sync.{BlockchainHostActor, SyncController}
+import io.iohk.ethereum.consensus.{ConsensusBuilder, ConsensusConfigBuilder}
 import io.iohk.ethereum.db.components.Storages.PruningModeComponent
 import io.iohk.ethereum.db.components.{SharedLevelDBDataSources, Storages}
 import io.iohk.ethereum.db.storage.AppStateStorage
@@ -20,7 +22,7 @@ import io.iohk.ethereum.jsonrpc._
 import io.iohk.ethereum.jsonrpc.server.JsonRpcServer
 import io.iohk.ethereum.keystore.{KeyStore, KeyStoreImpl}
 import io.iohk.ethereum.ledger.Ledger.VMImpl
-import io.iohk.ethereum.mining.{BlockGenerator, Miner}
+import io.iohk.ethereum.mining.BlockGenerator
 import io.iohk.ethereum.network.PeerManagerActor.PeerConfiguration
 import io.iohk.ethereum.network.EtcPeerManagerActor.PeerInfo
 import io.iohk.ethereum.utils._
@@ -35,6 +37,8 @@ import io.iohk.ethereum.transactions.PendingTransactionsManager
 import io.iohk.ethereum.validators._
 import io.iohk.ethereum.ommers.OmmersPool
 import io.iohk.ethereum.utils.Config.SyncConfig
+
+import scala.util.{Failure, Success, Try}
 
 // scalastyle:off number.of.types
 trait BlockchainConfigBuilder {
@@ -51,10 +55,6 @@ trait SyncConfigBuilder {
 
 trait TxPoolConfigBuilder {
   lazy val txPoolConfig = TxPoolConfig(Config.config)
-}
-
-trait MiningConfigBuilder {
-  lazy val miningConfig = MiningConfig(Config.config)
 }
 
 trait FilterConfigBuilder {
@@ -277,12 +277,14 @@ trait FilterManagerBuilder {
 
 trait BlockGeneratorBuilder {
   self: BlockchainConfigBuilder with
+    ConsensusConfigBuilder with
     ValidatorsBuilder with
     LedgerBuilder with
-    MiningConfigBuilder with
     BlockchainBuilder =>
 
-  lazy val blockGenerator = new BlockGenerator(blockchain, blockchainConfig, miningConfig, ledger, validators)
+  lazy val headerExtraData: ByteString = consensusConfig.headerExtraData
+  lazy val blockCacheSize: Int = consensusConfig.blockCacheSize
+  lazy val blockGenerator = new BlockGenerator(blockchain, blockchainConfig, headerExtraData, blockCacheSize, ledger, validators)
 }
 
 trait EthServiceBuilder {
@@ -296,12 +298,13 @@ trait EthServiceBuilder {
     KeyStoreBuilder with
     SyncControllerBuilder with
     OmmersPoolBuilder with
-    MiningConfigBuilder with
+    ConsensusBuilder with
+    ConsensusConfigBuilder with
     FilterManagerBuilder with
     FilterConfigBuilder =>
 
   lazy val ethService = new EthService(blockchain, blockGenerator, storagesInstance.storages.appStateStorage,
-    miningConfig, ledger, keyStore, pendingTransactionsManager, syncController, ommersPool, filterManager, filterConfig,
+    consensus.config, ledger, keyStore, pendingTransactionsManager, syncController, ommersPool, filterManager, filterConfig,
     blockchainConfig, Config.Network.protocolVersion)
 }
 
@@ -340,17 +343,18 @@ trait JSONRpcHttpServerBuilder {
 trait OmmersPoolBuilder {
   self: ActorSystemBuilder with
     BlockchainBuilder with
-    MiningConfigBuilder =>
+    ConsensusConfigBuilder =>
 
-  lazy val ommersPool: ActorRef = actorSystem.actorOf(OmmersPool.props(blockchain, miningConfig))
+  lazy val ommersPoolSize: Int = 30 // FIXME For this we need MiningConfig, which means Ethash consensus
+  lazy val ommersPool: ActorRef = actorSystem.actorOf(OmmersPool.props(blockchain, ommersPoolSize))
 }
 
 trait ValidatorsBuilder {
-  self: BlockchainConfigBuilder =>
+  self: BlockchainConfigBuilder with ConsensusBuilder =>
 
   lazy val validators = new Validators {
     val blockValidator: BlockValidator = BlockValidator
-    val blockHeaderValidator: BlockHeaderValidator = new BlockHeaderValidatorImpl(blockchainConfig)
+    val blockHeaderValidator: BlockHeaderValidator = consensus.blockHeaderValidator
     val ommersValidator: OmmersValidator = new OmmersValidatorImpl(blockchainConfig, blockHeaderValidator)
     val signedTransactionValidator: SignedTransactionValidator = new SignedTransactionValidatorImpl(blockchainConfig)
   }
@@ -408,9 +412,8 @@ trait SyncControllerBuilder {
 
 }
 
-trait ShutdownHookBuilder {
-
-  def shutdown(): Unit
+trait ShutdownHookBuilder { self: Logger ⇒
+  def shutdown(): Unit = {/* No default behaviour during shutdown. */}
 
   lazy val shutdownTimeoutDuration = Config.shutdownTimeout
 
@@ -419,7 +422,19 @@ trait ShutdownHookBuilder {
       shutdown()
     }
   })
+
+  def shutdownOnError[A](f: ⇒ A): A = {
+    Try(f) match {
+      case Success(v) ⇒ v
+      case Failure(t) ⇒
+        log.error(t.getMessage, t)
+        shutdown()
+        throw t
+    }
+  }
 }
+
+object ShutdownHookBuilder extends ShutdownHookBuilder with Logger
 
 trait GenesisDataLoaderBuilder {
   self: BlockchainBuilder
@@ -434,26 +449,12 @@ trait SecureRandomBuilder {
     Config.secureRandomAlgo.map(SecureRandom.getInstance).getOrElse(new SecureRandom())
 }
 
-trait MinerBuilder {
-  self: ActorSystemBuilder
-    with BlockchainBuilder
-    with OmmersPoolBuilder
-    with PendingTransactionsManagerBuilder
-    with BlockGeneratorBuilder
-    with SyncControllerBuilder
-    with MiningConfigBuilder
-    with EthServiceBuilder =>
-
-  lazy val miner: ActorRef = actorSystem.actorOf(Miner.props(
-    blockchain,
-    blockGenerator,
-    ommersPool,
-    pendingTransactionsManager,
-    syncController,
-    miningConfig,
-    ethService))
-}
-
+/**
+ * Provides the basic functionality of a Node.
+ * The consensus algorithm is loaded dynamically based on configuration.
+ *
+ * @see [[io.iohk.ethereum.consensus.Consensus]]
+ */
 trait Node extends NodeKeyBuilder
   with ActorSystemBuilder
   with StorageBuilder
@@ -475,13 +476,13 @@ trait Node extends NodeKeyBuilder
   with JSONRpcControllerBuilder
   with JSONRpcHttpServerBuilder
   with ShutdownHookBuilder
+  with Logger
   with GenesisDataLoaderBuilder
   with BlockchainConfigBuilder
   with VmConfigBuilder
   with PeerEventBusBuilder
   with PendingTransactionsManagerBuilder
   with OmmersPoolBuilder
-  with MiningConfigBuilder
   with EtcPeerManagerActorBuilder
   with BlockchainHostBuilder
   with FilterManagerBuilder
@@ -495,5 +496,6 @@ trait Node extends NodeKeyBuilder
   with DiscoveryListenerBuilder
   with KnownNodesManagerBuilder
   with SyncConfigBuilder
-  with MinerBuilder
   with VmBuilder
+  with ConsensusBuilder
+  with ConsensusConfigBuilder

--- a/src/main/scala/io/iohk/ethereum/nodebuilder/StdNode.scala
+++ b/src/main/scala/io/iohk/ethereum/nodebuilder/StdNode.scala
@@ -1,0 +1,72 @@
+package io.iohk.ethereum.nodebuilder
+
+import io.iohk.ethereum.blockchain.sync.SyncController
+import io.iohk.ethereum.network.{PeerManagerActor, ServerActor}
+import io.iohk.ethereum.network.discovery.DiscoveryListener
+
+import scala.concurrent.Await
+import scala.util.{Failure, Success, Try}
+
+/**
+ * A standard node is everything Ethereum prescribes except the consensus algorithm,
+ * which is plugged in dynamically.
+ *
+ * The design is historically related to the initial cake-pattern-based
+ * [[io.iohk.ethereum.nodebuilder.Node Node]].
+ *
+ * @see [[io.iohk.ethereum.nodebuilder.Node Node]]
+ */
+class StdNode extends Node {
+  private[this] def loadGenesisData(): Unit = genesisDataLoader.loadGenesisData()
+
+  private[this] def startPeerManager(): Unit = peerManager ! PeerManagerActor.StartConnecting
+
+  private[this] def startServer(): Unit = server ! ServerActor.StartServer(networkConfig.Server.listenAddress)
+
+  private[this] def startDiscoveryListener(): Unit =
+    if (discoveryConfig.discoveryEnabled) {
+      discoveryListener ! DiscoveryListener.Start
+    }
+
+  private[this] def startSyncController(): Unit = syncController ! SyncController.Start
+
+  private[this] def startConsensus(): Unit = consensus.startProtocol(this)
+
+  private[this] def startDiscoveryManager(): Unit = peerDiscoveryManager // unlazy
+
+  private[this] def startJsonRpcServer(): Unit =
+    maybeJsonRpcServer match {
+      case Right(jsonRpcServer) if jsonRpcServerConfig.enabled => jsonRpcServer.run()
+      case Left(error) if jsonRpcServerConfig.enabled => log.error(error)
+      case _=> //Nothing
+    }
+
+  def start(): Unit = {
+    loadGenesisData()
+
+    startPeerManager()
+
+    startServer()
+
+    startDiscoveryListener()
+
+    startSyncController()
+
+    startConsensus()
+
+    startDiscoveryManager()
+
+    startJsonRpcServer()
+  }
+
+  override def shutdown(): Unit = {
+    def tryAndLogFailure(f: () => Any): Unit = Try(f()) match {
+      case Failure(e) => log.warn("Error while shutting down...", e)
+      case Success(_) =>
+    }
+
+    tryAndLogFailure(() => consensus.stopProtocol())
+    tryAndLogFailure(() => Await.ready(actorSystem.terminate, shutdownTimeoutDuration))
+    tryAndLogFailure(() => storagesInstance.dataSources.closeAll())
+  }
+}

--- a/src/main/scala/io/iohk/ethereum/ommers/OmmersPool.scala
+++ b/src/main/scala/io/iohk/ethereum/ommers/OmmersPool.scala
@@ -3,9 +3,8 @@ package io.iohk.ethereum.ommers
 import akka.actor.{Actor, Props}
 import io.iohk.ethereum.domain.{BlockHeader, Blockchain}
 import io.iohk.ethereum.ommers.OmmersPool.{AddOmmers, GetOmmers, RemoveOmmers}
-import io.iohk.ethereum.utils.MiningConfig
 
-class OmmersPool(blockchain: Blockchain, miningConfig: MiningConfig) extends Actor {
+class OmmersPool(blockchain: Blockchain, ommersPoolSize: Int) extends Actor {
 
   var ommersPool: Seq[BlockHeader] = Nil
 
@@ -14,7 +13,7 @@ class OmmersPool(blockchain: Blockchain, miningConfig: MiningConfig) extends Act
 
   override def receive: Receive = {
     case AddOmmers(ommers) =>
-      ommersPool = (ommers ++ ommersPool).take(miningConfig.ommersPoolSize).distinct
+      ommersPool = (ommers ++ ommersPool).take(ommersPoolSize).distinct
 
     case RemoveOmmers(ommers) =>
       val toDelete = ommers.map(_.hash).toSet
@@ -32,7 +31,7 @@ class OmmersPool(blockchain: Blockchain, miningConfig: MiningConfig) extends Act
 }
 
 object OmmersPool {
-  def props(blockchain: Blockchain, miningConfig: MiningConfig): Props = Props(new OmmersPool(blockchain, miningConfig))
+  def props(blockchain: Blockchain, ommersPoolSize: Int): Props = Props(new OmmersPool(blockchain, ommersPoolSize))
 
   case class AddOmmers(ommers: List[BlockHeader])
 

--- a/src/main/scala/io/iohk/ethereum/utils/Config.scala
+++ b/src/main/scala/io/iohk/ethereum/utils/Config.scala
@@ -14,7 +14,6 @@ import io.iohk.ethereum.network.PeerManagerActor.{FastSyncHostConfiguration, Pee
 import io.iohk.ethereum.network.rlpx.RLPxConnectionHandler.RLPxConfiguration
 import io.iohk.ethereum.utils.NumericUtils._
 import io.iohk.ethereum.utils.VmConfig.VmMode
-import io.iohk.ethereum.validators.BlockHeaderValidatorImpl
 import org.spongycastle.util.encoders.Hex
 
 import scala.collection.JavaConverters._
@@ -247,39 +246,6 @@ object TxPoolConfig {
       val txPoolSize: Int = txPoolConfig.getInt("tx-pool-size")
       val pendingTxManagerQueryTimeout: FiniteDuration = txPoolConfig.getDuration("pending-tx-manager-query-timeout").toMillis.millis
       val transactionTimeout: FiniteDuration = txPoolConfig.getDuration("transaction-timeout").toMillis.millis
-    }
-  }
-}
-
-trait MiningConfig {
-  val ommersPoolSize: Int
-  val blockCacheSize: Int
-  val coinbase: Address
-  val activeTimeout: FiniteDuration
-  val ommerPoolQueryTimeout: FiniteDuration
-  val headerExtraData: ByteString
-  val miningEnabled: Boolean
-  val ethashDir: String
-  val mineRounds: Int
-}
-
-object MiningConfig {
-  def apply(etcClientConfig: TypesafeConfig): MiningConfig = {
-    val miningConfig = etcClientConfig.getConfig("mining")
-
-    new MiningConfig {
-      val coinbase: Address = Address(miningConfig.getString("coinbase"))
-      val blockCacheSize: Int = miningConfig.getInt("block-cashe-size")
-      val ommersPoolSize: Int = miningConfig.getInt("ommers-pool-size")
-      val activeTimeout: FiniteDuration = miningConfig.getDuration("active-timeout").toMillis.millis
-      val ommerPoolQueryTimeout: FiniteDuration = miningConfig.getDuration("ommer-pool-query-timeout").toMillis.millis
-      override val headerExtraData: ByteString =
-        ByteString(miningConfig
-          .getString("header-extra-data").getBytes)
-          .take(BlockHeaderValidatorImpl.MaxExtraDataSize)
-      override val miningEnabled = miningConfig.getBoolean("mining-enabled")
-      override val ethashDir = miningConfig.getString("ethash-dir")
-      override val mineRounds = miningConfig.getInt("mine-rounds")
     }
   }
 }

--- a/src/main/scala/io/iohk/ethereum/validators/BlockHeaderValidator.scala
+++ b/src/main/scala/io/iohk/ethereum/validators/BlockHeaderValidator.scala
@@ -1,16 +1,17 @@
 package io.iohk.ethereum.validators
 
 import akka.util.ByteString
-import io.iohk.ethereum.consensus.Ethash
-import io.iohk.ethereum.crypto
-import io.iohk.ethereum.domain.{BlockHeader, Blockchain, DifficultyCalculator}
+import io.iohk.ethereum.domain.{BlockHeader, DifficultyCalculator}
 import io.iohk.ethereum.utils.{BlockchainConfig, DaoForkConfig}
 
+/**
+ * Validates a [[io.iohk.ethereum.domain.BlockHeader BlockHeader]].
+ */
 trait BlockHeaderValidator {
-  def validate(blockHeader: BlockHeader, getBlockHeaderByHash: ByteString => Option[BlockHeader]): Either[BlockHeaderError, BlockHeaderValid]
-
-  def validate(blockHeader: BlockHeader, blockchain: Blockchain): Either[BlockHeaderError, BlockHeaderValid] =
-    validate(blockHeader, blockchain.getBlockHeaderByHash _)
+  def validate(
+    blockHeader: BlockHeader,
+    getBlockHeaderByHash: ByteString => Option[BlockHeader]
+  ): Either[BlockHeaderError, BlockHeaderValid]
 }
 
 object BlockHeaderValidatorImpl {
@@ -18,26 +19,19 @@ object BlockHeaderValidatorImpl {
   val GasLimitBoundDivisor: Int = 1024
   val MinGasLimit: BigInt = 5000 //Although the paper states this value is 125000, on the different clients 5000 is used
   val MaxGasLimit = Long.MaxValue // max gasLimit is equal 2^63-1 according to EIP106
-  val MaxPowCaches: Int = 2 // maximum number of epochs for which PoW cache is stored in memory
 
   class PowCacheData(val cache: Array[Int], val dagSize: Long)
 
-  // FIXME [EC-331]: this is used to speed up ETS Blockchain tests. All blocks in those tests have low numbers (1, 2, 3 ...)
-  // so keeping the cache for epoch 0 avoids recalculating it for each individual test. The difference in test runtime
-  // can be dramatic - full suite: 26 hours vs 21 minutes on same machine
-  // It might be desirable to find a better solution for this - one that doesn't keep this cache unnecessarily
-  lazy val epoch0PowCache = new PowCacheData(
-    cache = Ethash.makeCache(0),
-    dagSize = Ethash.dagSize(0))
 }
 
+// FIXME Decouple PoW validation
 class BlockHeaderValidatorImpl(blockchainConfig: BlockchainConfig) extends BlockHeaderValidator {
 
-  import BlockHeaderValidatorImpl._
   import BlockHeaderError._
+  import BlockHeaderValidatorImpl._
 
   // we need concurrent map since validators can be used from multiple places
-  val powCaches: java.util.Map[Long, PowCacheData] = new java.util.concurrent.ConcurrentHashMap[Long, PowCacheData]()
+  val powCaches: java.util.concurrent.ConcurrentMap[Long, PowCacheData] = new java.util.concurrent.ConcurrentHashMap[Long, PowCacheData]()
 
   val difficulty = new DifficultyCalculator(blockchainConfig)
 
@@ -55,7 +49,6 @@ class BlockHeaderValidatorImpl(blockchainConfig: BlockchainConfig) extends Block
       _ <- validateGasUsed(blockHeader)
       _ <- validateGasLimit(blockHeader, parentHeader)
       _ <- validateNumber(blockHeader, parentHeader)
-      _ <- validatePoW(blockHeader)
     } yield BlockHeaderValid
   }
 
@@ -169,45 +162,6 @@ class BlockHeaderValidatorImpl(blockchainConfig: BlockchainConfig) extends Block
   private def validateNumber(blockHeader: BlockHeader, parentHeader: BlockHeader): Either[BlockHeaderError, BlockHeaderValid] =
     if(blockHeader.number == parentHeader.number + 1) Right(BlockHeaderValid)
     else Left(HeaderNumberError)
-
-  /**
-    * Validates [[io.iohk.ethereum.domain.BlockHeader.nonce]] and [[io.iohk.ethereum.domain.BlockHeader.mixHash]] are correct
-    * based on validations stated in section 4.4.4 of http://paper.gavwood.com/
-    *
-    * @param blockHeader BlockHeader to validate.
-    * @return BlockHeader if valid, an [[HeaderPoWError]] otherwise
-    */
-  private def validatePoW(blockHeader: BlockHeader): Either[BlockHeaderError, BlockHeaderValid] = {
-    import Ethash._
-    import scala.collection.JavaConverters._
-
-    def getPowCacheData(epoch: Long): PowCacheData = {
-      if (epoch == 0) BlockHeaderValidatorImpl.epoch0PowCache else
-      Option(powCaches.get(epoch)) match {
-        case Some(pcd) => pcd
-        case None =>
-          val data = new PowCacheData(
-            cache = Ethash.makeCache(epoch),
-            dagSize = Ethash.dagSize(epoch))
-
-          val keys = powCaches.keySet().asScala
-          val keysToRemove = keys.toSeq.sorted.take(keys.size - MaxPowCaches + 1)
-          keysToRemove.foreach(powCaches.remove)
-
-          powCaches.put(epoch, data)
-
-          data
-      }
-    }
-
-    val powCacheData = getPowCacheData(epoch(blockHeader.number.toLong))
-
-    val proofOfWork = hashimotoLight(crypto.kec256(BlockHeader.getEncodedWithoutNonce(blockHeader)),
-      blockHeader.nonce.toArray[Byte], powCacheData.dagSize, powCacheData.cache)
-
-    if (proofOfWork.mixHash == blockHeader.mixHash && checkDifficulty(blockHeader.difficulty.toLong, proofOfWork)) Right(BlockHeaderValid)
-    else Left(HeaderPoWError)
-  }
 }
 
 sealed trait BlockHeaderError

--- a/src/main/scala/io/iohk/ethereum/validators/Validators.scala
+++ b/src/main/scala/io/iohk/ethereum/validators/Validators.scala
@@ -1,5 +1,6 @@
 package io.iohk.ethereum.validators
 
+// FIXME Consider moving to [[io.iohk.ethereum.consensus.Consensus]]
 trait Validators {
 
   val blockValidator: BlockValidator

--- a/src/snappy/scala/io/iohk/ethereum/snappy/Prerequisites.scala
+++ b/src/snappy/scala/io/iohk/ethereum/snappy/Prerequisites.scala
@@ -1,15 +1,17 @@
 package io.iohk.ethereum.snappy
 
 import io.iohk.ethereum.blockchain.data.GenesisDataLoader
+import io.iohk.ethereum.consensus.{ConsensusBuilder, ConsensusConfigBuilder}
 import io.iohk.ethereum.db.components.Storages.PruningModeComponent
 import io.iohk.ethereum.db.components.{SharedLevelDBDataSources, Storages}
 import io.iohk.ethereum.db.dataSource.{LevelDBDataSource, LevelDbConfig}
 import io.iohk.ethereum.db.storage.pruning.ArchivePruning
 import io.iohk.ethereum.domain.BlockchainImpl
 import io.iohk.ethereum.ledger.{Ledger, LedgerImpl}
-import io.iohk.ethereum.nodebuilder.{BlockchainConfigBuilder, SyncConfigBuilder, ValidatorsBuilder}
+import io.iohk.ethereum.nodebuilder.{BlockchainConfigBuilder, ShutdownHookBuilder, SyncConfigBuilder, ValidatorsBuilder}
 import io.iohk.ethereum.snappy.Config.{DualDB, SingleDB}
 import io.iohk.ethereum.snappy.Prerequisites._
+import io.iohk.ethereum.utils.Logger
 
 
 object Prerequisites {
@@ -49,6 +51,7 @@ class Prerequisites(config: Config) {
   val targetBlockchain = targetStorages.map(ts => BlockchainImpl(ts.storages))
 
   private val components = new ValidatorsBuilder with BlockchainConfigBuilder with SyncConfigBuilder
+    with ConsensusBuilder with ConsensusConfigBuilder with ShutdownHookBuilder with Logger
 
   private val vm = new Ledger.VMImpl
 

--- a/src/test/scala/io/iohk/ethereum/consensus/ConsensusConfigs.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/ConsensusConfigs.scala
@@ -1,0 +1,33 @@
+package io.iohk.ethereum.consensus
+
+import akka.util.ByteString
+import io.iohk.ethereum.Timeouts
+import io.iohk.ethereum.consensus.ethash.MiningConfig
+import io.iohk.ethereum.domain.Address
+
+/** Provides utility values used throughout tests */
+object ConsensusConfigs {
+  final val blockCacheSize = 30
+  final val coinbaseAddressNum = 42
+  final val coinbase = Address(coinbaseAddressNum)
+
+  //noinspection ScalaStyle
+  final val miningConfig = new MiningConfig(
+    ommersPoolSize = 30,
+    ommerPoolQueryTimeout = Timeouts.normalTimeout,
+    ethashDir = "~/.ethash",
+    mineRounds = 100000
+  )
+
+  final val consensusConfig: ConsensusConfig = new ConsensusConfig(
+    protocol = Ethash,
+    coinbase = coinbase,
+    activeTimeout = Timeouts.shortTimeout,
+    headerExtraData = ByteString.empty,
+    blockCacheSize = blockCacheSize,
+    getTransactionFromPoolTimeout = miningConfig.ommerPoolQueryTimeout,
+    miningEnabled = false
+  )
+
+  final val fullConsensusConfig = FullConsensusConfig(consensusConfig, miningConfig)
+}

--- a/src/test/scala/io/iohk/ethereum/consensus/EthashSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/EthashSpec.scala
@@ -9,7 +9,7 @@ import org.spongycastle.util.encoders.Hex
 
 class EthashSpec extends FlatSpec with Matchers with PropertyChecks {
 
-  import Ethash._
+  import io.iohk.ethereum.consensus.ethash.Ethash._
 
   "Ethash" should "generate correct hash" in {
     forAll(Arbitrary.arbitrary[Long].filter(_ < 15000000)) { blockNumber =>

--- a/src/test/scala/io/iohk/ethereum/ommers/OmmersPoolSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/ommers/OmmersPoolSpec.scala
@@ -2,16 +2,12 @@ package io.iohk.ethereum.ommers
 
 import akka.actor.ActorSystem
 import akka.testkit.TestProbe
-import akka.util.ByteString
 import io.iohk.ethereum.Fixtures.Blocks.Block3125369
 import io.iohk.ethereum.Timeouts
-import io.iohk.ethereum.domain.{Address, BlockchainImpl}
+import io.iohk.ethereum.domain.BlockchainImpl
 import io.iohk.ethereum.ommers.OmmersPool.{AddOmmers, GetOmmers, RemoveOmmers}
-import io.iohk.ethereum.utils.MiningConfig
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FlatSpec, Matchers}
-
-import scala.concurrent.duration._
 
 class OmmersPoolSpec extends FlatSpec with Matchers with MockFactory {
 
@@ -55,21 +51,10 @@ class OmmersPoolSpec extends FlatSpec with Matchers with MockFactory {
   trait TestSetup extends MockFactory {
     implicit val system = ActorSystem("OmmersPoolSpec_System")
 
-    val miningConfig = new MiningConfig {
-      override val ommersPoolSize: Int = 3
-      override val coinbase: Address = Address(2)
-      override val ommerPoolQueryTimeout: FiniteDuration = Timeouts.normalTimeout
-      override val blockCacheSize: Int = 4
-      override val activeTimeout: FiniteDuration = Timeouts.normalTimeout
-      override val headerExtraData: ByteString = ByteString.empty
-      override val miningEnabled: Boolean = false
-      override val ethashDir: String = "~/.ethash"
-      override val mineRounds: Int = 100000
-    }
-
+    val ommersPoolSize: Int = 3
     val testProbe = TestProbe()
 
     val blockchain = mock[BlockchainImpl]
-    val ommersPool = system.actorOf(OmmersPool.props(blockchain, miningConfig))
+    val ommersPool = system.actorOf(OmmersPool.props(blockchain, ommersPoolSize))
   }
 }

--- a/src/test/scala/io/iohk/ethereum/validators/BlockHeaderValidatorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/validators/BlockHeaderValidatorSpec.scala
@@ -3,6 +3,7 @@ package io.iohk.ethereum.validators
 import akka.util.ByteString
 import io.iohk.ethereum.{Fixtures, ObjectGenerators}
 import io.iohk.ethereum.blockchain.sync.EphemBlockchainTestSetup
+import io.iohk.ethereum.consensus.ethash.validators.EthashBlockHeaderValidator
 import io.iohk.ethereum.domain.{UInt256, _}
 import io.iohk.ethereum.utils.{BlockchainConfig, DaoForkConfig, MonetaryPolicyConfig}
 import io.iohk.ethereum.validators.BlockHeaderError._
@@ -22,7 +23,7 @@ class BlockHeaderValidatorSpec extends FlatSpec with Matchers with PropertyCheck
 
   val blockchainConfig = createBlockchainConfig()
 
-  val blockHeaderValidator = new BlockHeaderValidatorImpl(blockchainConfig)
+  val blockHeaderValidator = new EthashBlockHeaderValidator(blockchainConfig)
   val difficultyCalculator = new DifficultyCalculator(blockchainConfig)
 
   "BlockHeaderValidator" should "validate correctly formed BlockHeaders" in {
@@ -148,14 +149,14 @@ class BlockHeaderValidatorSpec extends FlatSpec with Matchers with PropertyCheck
 
   it should "validate correctly a block whose parent is in storage" in new EphemBlockchainTestSetup {
     blockchain.save(validBlockParent)
-    blockHeaderValidator.validate(validBlockHeader, blockchain) match {
+    blockHeaderValidator.validate(validBlockHeader, blockchain.getBlockHeaderByHash _) match {
       case Right(_)  => succeed
       case _ => fail
     }
   }
 
   it should "return a failure if the parent's header is not in storage" in new EphemBlockchainTestSetup {
-    blockHeaderValidator.validate(validBlockHeader, blockchain) match {
+    blockHeaderValidator.validate(validBlockHeader, blockchain.getBlockHeaderByHash _) match {
       case Left(HeaderParentNotFoundError) => succeed
       case _ => fail
     }


### PR DESCRIPTION
This PR includes the initial design for pluggable consensus and everything that has been demonstrated in demo0, demo1 milestones. 

A subsequent PR will include the updated pluggable consensus design.

All workstreams have been squashed to one commit. For the historical development, please have a look at one of 
* [`consensus_as_a_service_EC466_historical`](https://github.com/input-output-hk/mantis/tree/feature/consensus_as_a_service_EC466_historical) in the main repo.
* [`consensus_as_a_service_EC466_historical`](https://github.com/loverdos/mantis-fork/tree/feature/consensus_as_a_service_EC466_historical) in my fork.

