### PR TITLE
Use an exact amount of heap memory with SBT

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,8 @@
 version: 2
 jobs:
   build:
+    environment:
+      - SBT: "sbt -v -mem 1024"
     docker:
       - image: rtkaczyk/mantis-circleci:v4
     steps:
@@ -17,24 +19,24 @@ jobs:
 
       - run:
           name: scalastyle
-          command: sbt -v -mem 1024 scalastyle test:scalastyle
+          command: $SBT scalastyle test:scalastyle
 
       - run:
           name: unit tests
-          command: sbt -v -mem 1024 coverage test
+          command: $SBT coverage test
 
       - run:
           name: EVM tests
           # coverage ???
-          command: sbt -v -mem 1024 coverage evm:test
+          command: $SBT coverage evm:test
 
       - run:
           name: integration tests
-          command: sbt -v -mem 1024 coverageOff it:test
+          command: $SBT coverageOff it:test
 
       - run:
           name: coverage report
-          command: sbt -v -mem 1024 coverageReport coverageAggregate coveralls
+          command: $SBT coverageReport coverageAggregate coveralls
 
       - store_artifacts:
           path: target/scala-2.12/coverage-report
@@ -53,7 +55,7 @@ jobs:
           name: additional compilation & dist
           # this step builds parts of the codebase which are not tested in CI
           # so as to prevent compilation regression
-          command: sbt -v -mem 1024 benchmark:compile snappy:compile dist
+          command: $SBT benchmark:compile snappy:compile dist
 
       - save_cache:
           key: mantis-{{ checksum "build.sbt" }}-{{ checksum "project/build.properties" }}-{{ checksum "project/plugins.sbt" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,24 +17,24 @@ jobs:
 
       - run:
           name: scalastyle
-          command: sbt scalastyle test:scalastyle
+          command: sbt -v -mem 1024 scalastyle test:scalastyle
 
       - run:
           name: unit tests
-          command: sbt coverage test
+          command: sbt -v -mem 1024 coverage test
 
       - run:
           name: EVM tests
           # coverage ???
-          command: sbt coverage evm:test
+          command: sbt -v -mem 1024 coverage evm:test
 
       - run:
           name: integration tests
-          command: sbt coverageOff it:test
+          command: sbt -v -mem 1024 coverageOff it:test
 
       - run:
           name: coverage report
-          command: sbt coverageReport coverageAggregate coveralls
+          command: sbt -v -mem 1024 coverageReport coverageAggregate coveralls
 
       - store_artifacts:
           path: target/scala-2.12/coverage-report
@@ -53,7 +53,7 @@ jobs:
           name: additional compilation & dist
           # this step builds parts of the codebase which are not tested in CI
           # so as to prevent compilation regression
-          command: sbt benchmark:compile snappy:compile dist
+          command: sbt -v -mem 1024 benchmark:compile snappy:compile dist
 
       - save_cache:
           key: mantis-{{ checksum "build.sbt" }}-{{ checksum "project/build.properties" }}-{{ checksum "project/plugins.sbt" }}

--- a/test-ets.sh
+++ b/test-ets.sh
@@ -16,12 +16,13 @@ if [ -z $SKIP_ETS_TESTS ]; then
     git submodule init;
     git submodule update;
     if [ "$CIRCLE_BRANCH" == "master" -o -n "$RUN_FULL_ETS" ]; then
+        export JAVA_OPTS="-Xmx3g -Xss16m -XX:MaxMetaspaceSize=512m"
         echo "running full ETS"
-        sbt "ets:testOnly * -- -Dexg=vmPerf*";
+        sbt -v "ets:testOnly * -- -Dexg=vmPerf*";
     else
         echo "running a subset of ETS"
-        sbt "ets:testOnly *VMSuite -- -Dexg=vmPerf*" &&
-        sbt "ets:testOnly *BlockchainSuite -- -Ding=bcForkStress*,bcMulti*,bcState*,bcTotalDiff*,bcValidBlock*,Transition*";
+        sbt -v "ets:testOnly *VMSuite -- -Dexg=vmPerf*" &&
+        sbt -v "ets:testOnly *BlockchainSuite -- -Ding=bcForkStress*,bcMulti*,bcState*,bcTotalDiff*,bcValidBlock*,Transition*";
     fi
 else
     echo "SKIP_ETS_TESTS variable is set - skipping the tests";


### PR DESCRIPTION
We also have SBT print the exact process arguments by using the `-v` parameter.

These are mostly for when running under CircleCI. We have noticed random OOM errors during compilation (= compiler crashes) due to not having enough memory under CircleCI. This PR ensures that we specify exactly our requirements.

The amount of heap memory chosen, `1024`, has never failed me locally and seems reasonable, so it was the first candidate.