### PR TITLE
Fix overflow possibility

### DIFF
--- a/src/main/scala/io/iohk/ethereum/domain/UInt256.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/UInt256.scala
@@ -161,7 +161,13 @@ class UInt256 private (private val n: BigInt) extends Ordered[UInt256] {
     }
   }
 
-
+  def fillingAdd(that: UInt256): UInt256 = {
+    val result = this.n + that.n
+    if (result > MaxValue)
+      MaxValue
+    else
+      new UInt256(result)
+  }
 
   //standard methods
   override def equals(that: Any): Boolean = {

--- a/src/main/scala/io/iohk/ethereum/vm/OpCode.scala
+++ b/src/main/scala/io/iohk/ethereum/vm/OpCode.scala
@@ -422,7 +422,7 @@ case object RETURNDATASIZE extends ConstOp(0x3d)(_.returnData.size)
 case object RETURNDATACOPY extends OpCode(0x3e, 3, 0, _.G_verylow) {
   protected def exec[W <: WorldStateProxy[W, S], S <: Storage[S]](state: ProgramState[W, S]): ProgramState[W, S] = {
     val (Seq(memOffset, dataOffset, size), stack1) = state.stack.pop(3)
-    if(dataOffset + size > state.returnData.size){
+    if (dataOffset.fillingAdd(size) > state.returnData.size){
       state.withStack(stack1).withError(ReturnDataOverflow)
     } else {
       val data = OpCode.sliceBytes(state.returnData, dataOffset, size)

--- a/src/test/scala/io/iohk/ethereum/domain/UInt256Spec.scala
+++ b/src/test/scala/io/iohk/ethereum/domain/UInt256Spec.scala
@@ -201,6 +201,25 @@ class UInt256Spec extends FunSuite with PropertyChecks {
     }
   }
 
+  test("fillingAdd") {
+    val testData = Table[UInt256, UInt256, UInt256](
+      ("value", "extension", "result"),
+      (-9, 10, UInt256.MaxValue),
+      (42, 3, 45),
+      (-1, 1, UInt256.MaxValue),
+      (1, -1, UInt256.MaxValue),
+      (-10, 10, UInt256.MaxValue),
+      (10, -10, UInt256.MaxValue),
+      (UInt256.MaxValue - 10, 20, UInt256.MaxValue),
+      (0, UInt256.MaxValue - 1, UInt256.MaxValue - 1),
+      (UInt256.MaxValue, 1, UInt256.MaxValue)
+    )
+
+    forAll(testData) { (uint, extension, result) =>
+      assert(uint.fillingAdd(extension) == result)
+    }
+  }
+
   test("slt") {
     forAll(bigIntGen, bigIntGen) {(n1: BigInt, n2: BigInt) =>
       assert((UInt256(n1) slt UInt256(n2)) == (toSignedBigInt(n1) < toSignedBigInt(n2)))


### PR DESCRIPTION
In case when `dataOffset` is equals for example `-1 mod (2 ^ 256)` and size is equal to `1`, `(dataOffset + size) mod (2 ^ 256) ` will be qual to `0` and there will be possibility to read byte from empty byte array.