### PR TITLE
Fix/proper address collsion handling

### DIFF
--- a/src/main/scala/io/iohk/ethereum/vm/VM.scala
+++ b/src/main/scala/io/iohk/ethereum/vm/VM.scala
@@ -68,10 +68,14 @@ class VM[W <: WorldStateProxy[W, S], S <: Storage[S]] extends Logger {
       require(context.doTransfer, "contract creation will alwyas transfer funds")
 
       val newAddress = context.world.createAddress(context.callerAddr)
-      val world1 = context.world.initialiseAccount(newAddress).transfer(context.callerAddr, newAddress, context.endowment)
 
       // EIP-684
+      // Need to check for conflicts before initialising account (initialisation set account codehash and storage root
+      // to empty values.
       val conflict = context.world.nonEmptyCodeOrNonceAccount(newAddress)
+
+      val world1 = context.world.initialiseAccount(newAddress).transfer(context.callerAddr, newAddress, context.endowment)
+
       val code = if (conflict) ByteString(INVALID.code) else context.inputData
 
       val env = ExecEnv(context, code, newAddress).copy(inputData = ByteString.empty)

--- a/src/test/scala/io/iohk/ethereum/ledger/InMemoryWorldStateProxySpec.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/InMemoryWorldStateProxySpec.scala
@@ -259,7 +259,7 @@ class InMemoryWorldStateProxySpec extends FlatSpec with Matchers {
     changedReadState.getAccount(address1) shouldEqual Some(changedAccount)
   }
 
-  it should "get changed accsad" in new TestSetup {
+  it should "properly handle address collision during initialisation" in new TestSetup {
     val alreadyExistingAddress = Address("0x6295ee1b4f6dd65047762f924ecd367c17eabf8f")
     val accountBalance = 100
 


### PR DESCRIPTION
According to https://ethereum.github.io/yellowpaper/paper.pdf Eq.`79` freshly created account should have codehash equal to emptyCodeHash, storage root equals to emptyStorageRoot. It holds even when there is address collision and create overwrites existing account.

It fixes last failing byzantium ets test.