### PR TITLE
validation by header only

### DIFF
--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/FastSync.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/FastSync.scala
@@ -255,7 +255,7 @@ class FastSync(
       val shouldValidate = header.number >= syncState.nextBlockToFullyValidate
 
       if (shouldValidate) {
-        validators.blockHeaderValidator.validate(header, blockchain.getBlockByHash) match {
+        validators.blockHeaderValidator.validate(header, blockchain.getBlockHeaderByHash) match {
           case Right(_) =>
             updateValidationState(header)
             Right(header)

--- a/src/main/scala/io/iohk/ethereum/consensus/blocks/BlockGeneratorSkeleton.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/blocks/BlockGeneratorSkeleton.scala
@@ -61,7 +61,7 @@ abstract class BlockGeneratorSkeleton(
         transactionsRoot = ByteString.empty,
         receiptsRoot = ByteString.empty,
         logsBloom = ByteString.empty,
-        difficulty = difficulty.calculateDifficulty(blockNumber, blockTimestamp, parent),
+        difficulty = difficulty.calculateDifficulty(blockNumber, blockTimestamp, parent.header),
         number = blockNumber,
         gasLimit = calculateGasLimit(parent.header.gasLimit),
         gasUsed = 0,

--- a/src/main/scala/io/iohk/ethereum/consensus/difficulty/ConstantDifficulty.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/difficulty/ConstantDifficulty.scala
@@ -1,8 +1,8 @@
 package io.iohk.ethereum.consensus.difficulty
 
-import io.iohk.ethereum.domain.Block
+import io.iohk.ethereum.domain.BlockHeader
 
 class ConstantDifficulty(c: BigInt) extends DifficultyCalculator {
-  final def calculateDifficulty(blockNumber: BigInt, blockTimestamp: Long, parent: Block): BigInt = c
+  final def calculateDifficulty(blockNumber: BigInt, blockTimestamp: Long, parent: BlockHeader): BigInt = c
 }
 

--- a/src/main/scala/io/iohk/ethereum/consensus/difficulty/DifficultyCalculator.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/difficulty/DifficultyCalculator.scala
@@ -1,7 +1,7 @@
 package io.iohk.ethereum.consensus.difficulty
 
-import io.iohk.ethereum.domain.Block
+import io.iohk.ethereum.domain.BlockHeader
 
 trait DifficultyCalculator {
-  def calculateDifficulty(blockNumber: BigInt, blockTimestamp: Long, parent: Block): BigInt
+  def calculateDifficulty(blockNumber: BigInt, blockTimestamp: Long, parent: BlockHeader): BigInt
 }

--- a/src/main/scala/io/iohk/ethereum/consensus/ethash/validators/EthashValidators.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/ethash/validators/EthashValidators.scala
@@ -14,14 +14,14 @@ trait EthashValidators extends Validators {
 
   def validateBlockBeforeExecution(
     block: Block,
-    getBlockByHash: GetBlockByHash,
+    getBlockHeaderByHash: GetBlockHeaderByHash,
     getNBlocksBack: GetNBlocksBack
   ): Either[BlockExecutionError.ValidationBeforeExecError, BlockExecutionSuccess] = {
 
     EthashValidators.validateBlockBeforeExecution(
       self = this,
       block = block,
-      getBlockByHash = getBlockByHash,
+      getBlockHeaderByHash = getBlockHeaderByHash,
       getNBlocksBack = getNBlocksBack
     )
   }
@@ -58,7 +58,7 @@ object EthashValidators {
   def validateBlockBeforeExecution(
     self: EthashValidators,
     block: Block,
-    getBlockByHash: GetBlockByHash,
+    getBlockHeaderByHash: GetBlockHeaderByHash,
     getNBlocksBack: GetNBlocksBack
   ): Either[BlockExecutionError.ValidationBeforeExecError, BlockExecutionSuccess] = {
 
@@ -66,10 +66,10 @@ object EthashValidators {
     val body = block.body
 
     val result = for {
-      _ <- self.blockHeaderValidator.validate(header, getBlockByHash)
+      _ <- self.blockHeaderValidator.validate(header, getBlockHeaderByHash)
       _ <- self.blockValidator.validateHeaderAndBody(header, body)
       _ <- self.ommersValidator.validate(header.parentHash, header.number, body.uncleNodesList,
-        getBlockByHash, getNBlocksBack)
+        getBlockHeaderByHash, getNBlocksBack)
     } yield BlockExecutionSuccess
 
     result.left.map(ValidationBeforeExecError)

--- a/src/main/scala/io/iohk/ethereum/consensus/ethash/validators/OmmersValidator.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/ethash/validators/OmmersValidator.scala
@@ -1,9 +1,9 @@
 package io.iohk.ethereum.consensus.ethash.validators
 
 import akka.util.ByteString
-import io.iohk.ethereum.consensus.ethash.validators.OmmersValidator.{ OmmersError, OmmersValid }
-import io.iohk.ethereum.consensus.{ GetBlockByHash, GetNBlocksBack }
-import io.iohk.ethereum.domain.{ Block, BlockHeader, Blockchain }
+import io.iohk.ethereum.consensus.ethash.validators.OmmersValidator.{OmmersError, OmmersValid}
+import io.iohk.ethereum.consensus.{GetBlockHeaderByHash, GetNBlocksBack}
+import io.iohk.ethereum.domain.{Block, BlockHeader, Blockchain}
 
 trait OmmersValidator {
 
@@ -11,7 +11,7 @@ trait OmmersValidator {
     parentHash: ByteString,
     blockNumber: BigInt,
     ommers: Seq[BlockHeader],
-    getBlockByHash: GetBlockByHash,
+    getBlockByHash: GetBlockHeaderByHash,
     getNBlocksBack: GetNBlocksBack
   ): Either[OmmersError, OmmersValid]
 
@@ -22,11 +22,11 @@ trait OmmersValidator {
     blockchain: Blockchain
   ): Either[OmmersError, OmmersValid] = {
 
-    val getBlockByHash: GetBlockByHash = blockchain.getBlockByHash
+    val getBlockHeaderByHash: ByteString => Option[BlockHeader] = blockchain.getBlockHeaderByHash
     val getNBlocksBack: (ByteString, Int) => List[Block] =
       (_, n) => ((blockNumber - n) until blockNumber).toList.flatMap(blockchain.getBlockByNumber)
 
-    validate(parentHash, blockNumber, ommers, getBlockByHash, getNBlocksBack)
+    validate(parentHash, blockNumber, ommers, getBlockHeaderByHash, getNBlocksBack)
   }
 
 }

--- a/src/main/scala/io/iohk/ethereum/consensus/ethash/validators/StdOmmersValidator.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/ethash/validators/StdOmmersValidator.scala
@@ -4,7 +4,7 @@ import akka.util.ByteString
 import io.iohk.ethereum.consensus.ethash.validators.OmmersValidator.OmmersError._
 import io.iohk.ethereum.consensus.ethash.validators.OmmersValidator.{OmmersError, OmmersValid}
 import io.iohk.ethereum.consensus.validators.BlockHeaderValidator
-import io.iohk.ethereum.consensus.{GetBlockByHash, GetNBlocksBack}
+import io.iohk.ethereum.consensus.{GetBlockHeaderByHash, GetNBlocksBack}
 import io.iohk.ethereum.domain.BlockHeader
 import io.iohk.ethereum.utils.BlockchainConfig
 
@@ -36,7 +36,7 @@ class StdOmmersValidator(blockchainConfig: BlockchainConfig, blockHeaderValidato
     parentHash: ByteString,
     blockNumber: BigInt,
     ommers: Seq[BlockHeader],
-    getBlockHeaderByHash: GetBlockByHash,
+    getBlockHeaderByHash: GetBlockHeaderByHash,
     getNBlocksBack: GetNBlocksBack): Either[OmmersError, OmmersValid] = {
 
     if (ommers.isEmpty)
@@ -71,12 +71,12 @@ class StdOmmersValidator(blockchainConfig: BlockchainConfig, blockHeaderValidato
    * based on validations stated in section 11.1 of the YP
    *
    * @param ommers         The list of ommers to validate
-   * @param getBlockByHash     function to obtain ommers' parents
+   * @param getBlockHeaderByHash     function to obtain ommers' parents
    * @return ommers if valid, an [[io.iohk.ethereum.consensus.ethash.validators.OmmersValidator.OmmersError.OmmersNotValidError OmmersNotValidError]]
    *         otherwise
    */
-  private def validateOmmersHeaders(ommers: Seq[BlockHeader], getBlockByHash: GetBlockByHash): Either[OmmersError, OmmersValid] = {
-    if (ommers.forall(blockHeaderValidator.validate(_, getBlockByHash).isRight)) Right(OmmersValid)
+  private def validateOmmersHeaders(ommers: Seq[BlockHeader], getBlockHeaderByHash: GetBlockHeaderByHash): Either[OmmersError, OmmersValid] = {
+    if (ommers.forall(blockHeaderValidator.validate(_, getBlockHeaderByHash).isRight)) Right(OmmersValid)
     else Left(OmmersNotValidError)
   }
 

--- a/src/main/scala/io/iohk/ethereum/consensus/package.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/package.scala
@@ -4,7 +4,7 @@ import akka.util.ByteString
 import io.iohk.ethereum.consensus.blocks.BlockGenerator
 import io.iohk.ethereum.consensus.ethash.EthashConsensus
 import io.iohk.ethereum.consensus.validators.Validators
-import io.iohk.ethereum.domain.Block
+import io.iohk.ethereum.domain.{Block, BlockHeader}
 
 import scala.reflect.ClassTag
 
@@ -13,7 +13,7 @@ import scala.reflect.ClassTag
  * Different consensus protocols are implemented in sub-packages.
  */
 package object consensus {
-  final type GetBlockByHash = ByteString ⇒ Option[Block]
+  final type GetBlockHeaderByHash = ByteString ⇒ Option[BlockHeader]
   final type GetNBlocksBack = (ByteString, Int) ⇒ Seq[Block]
 
   def wrongConsensusArgument[T <: Consensus : ClassTag](consensus: Consensus): Nothing = {

--- a/src/main/scala/io/iohk/ethereum/consensus/validators/BlockHeaderValidator.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/validators/BlockHeaderValidator.scala
@@ -9,7 +9,7 @@ import io.iohk.ethereum.domain.BlockHeader
 trait BlockHeaderValidator {
   def validate(
     blockHeader: BlockHeader,
-    getBlockHeaderByHash: GetBlockByHash
+    getBlockHeaderByHash: GetBlockHeaderByHash
   ): Either[BlockHeaderError, BlockHeaderValid]
 }
 

--- a/src/main/scala/io/iohk/ethereum/consensus/validators/BlockHeaderValidatorSkeleton.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/validators/BlockHeaderValidatorSkeleton.scala
@@ -1,10 +1,10 @@
 package io.iohk.ethereum.consensus.validators
 
-import io.iohk.ethereum.consensus.GetBlockByHash
+import io.iohk.ethereum.consensus.GetBlockHeaderByHash
 import io.iohk.ethereum.consensus.difficulty.DifficultyCalculator
 import io.iohk.ethereum.consensus.validators.BlockHeaderError._
-import io.iohk.ethereum.domain.{ Block, BlockHeader }
-import io.iohk.ethereum.utils.{ BlockchainConfig, DaoForkConfig }
+import io.iohk.ethereum.domain.BlockHeader
+import io.iohk.ethereum.utils.{BlockchainConfig, DaoForkConfig}
 
 /**
  * A block header validator that does everything Ethereum prescribes except from:
@@ -36,16 +36,15 @@ abstract class BlockHeaderValidatorSkeleton(blockchainConfig: BlockchainConfig) 
    * section 4.4.4 of http://paper.gavwood.com/).
    *
    * @param blockHeader BlockHeader to validate.
-   * @param parent Block of the parent of the block to validate.
+   * @param parentHeader BlockHeader of the parent of the block to validate.
    */
-  def validate(blockHeader: BlockHeader, parent: Block): Either[BlockHeaderError, BlockHeaderValid] = {
+  def validate(blockHeader: BlockHeader, parentHeader: BlockHeader): Either[BlockHeaderError, BlockHeaderValid] = {
     for {
       // NOTE how we include everything except PoW (which is deferred to `validateEvenMore`),
       //      and that difficulty validation is in effect abstract (due to `difficulty`).
       _ <- validateExtraData(blockHeader)
-      parentHeader = parent.header
       _ <- validateTimestamp(blockHeader, parentHeader)
-      _ <- validateDifficulty(blockHeader, parent)
+      _ <- validateDifficulty(blockHeader, parentHeader)
       _ <- validateGasUsed(blockHeader)
       _ <- validateGasLimit(blockHeader, parentHeader)
       _ <- validateNumber(blockHeader, parentHeader)
@@ -57,11 +56,11 @@ abstract class BlockHeaderValidatorSkeleton(blockchainConfig: BlockchainConfig) 
    * section 4.4.4 of http://paper.gavwood.com/).
    *
    * @param blockHeader BlockHeader to validate.
-   * @param getBlockByHash function to obtain the parent.
+   * @param getBlockHeaderByHash function to obtain the parent.
    */
-  def validate(blockHeader: BlockHeader, getBlockByHash: GetBlockByHash): Either[BlockHeaderError, BlockHeaderValid] = {
+  def validate(blockHeader: BlockHeader, getBlockHeaderByHash: GetBlockHeaderByHash): Either[BlockHeaderError, BlockHeaderValid] = {
     for {
-      blockHeaderParent <- getBlockByHash(blockHeader.parentHash).map(Right(_)).getOrElse(Left(HeaderParentNotFoundError))
+      blockHeaderParent <- getBlockHeaderByHash(blockHeader.parentHash).map(Right(_)).getOrElse(Left(HeaderParentNotFoundError))
       _ <- validate(blockHeader, blockHeaderParent)
     } yield BlockHeaderValid
   }
@@ -113,7 +112,7 @@ abstract class BlockHeaderValidatorSkeleton(blockchainConfig: BlockchainConfig) 
    * @param parent Block of the parent of the block to validate.
    * @return BlockHeader if valid, an [[HeaderDifficultyError]] otherwise
    */
-  private def validateDifficulty(blockHeader: BlockHeader, parent: Block): Either[BlockHeaderError, BlockHeaderValid] =
+  private def validateDifficulty(blockHeader: BlockHeader, parent: BlockHeader): Either[BlockHeaderError, BlockHeaderValid] =
     if (difficulty.calculateDifficulty(blockHeader.number, blockHeader.unixTimestamp, parent) == blockHeader.difficulty) Right(BlockHeaderValid)
     else Left(HeaderDifficultyError)
 

--- a/src/main/scala/io/iohk/ethereum/consensus/validators/Validators.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/validators/Validators.scala
@@ -1,10 +1,10 @@
 package io.iohk.ethereum.consensus.validators
 
 import akka.util.ByteString
-import io.iohk.ethereum.consensus.{ GetBlockByHash, GetNBlocksBack }
-import io.iohk.ethereum.domain.{ Block, Receipt }
+import io.iohk.ethereum.consensus.{GetBlockHeaderByHash, GetNBlocksBack}
+import io.iohk.ethereum.domain.{Block, Receipt}
 import io.iohk.ethereum.ledger.BlockExecutionError.ValidationBeforeExecError
-import io.iohk.ethereum.ledger.{ BlockExecutionError, BlockExecutionSuccess }
+import io.iohk.ethereum.ledger.{BlockExecutionError, BlockExecutionSuccess}
 
 trait Validators {
   def blockValidator: BlockValidator
@@ -14,7 +14,7 @@ trait Validators {
   // Note Ledger uses this in importBlock
   def validateBlockBeforeExecution(
     block: Block,
-    getBlockByHash: GetBlockByHash,
+    getBlockHeaderByHash: GetBlockHeaderByHash,
     getNBlocksBack: GetNBlocksBack
   ): Either[ValidationBeforeExecError, BlockExecutionSuccess]
 

--- a/src/main/scala/io/iohk/ethereum/consensus/validators/std/StdValidators.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/validators/std/StdValidators.scala
@@ -2,10 +2,10 @@ package io.iohk.ethereum.consensus.validators.std
 
 import akka.util.ByteString
 import io.iohk.ethereum.consensus.validators._
-import io.iohk.ethereum.consensus.{ GetBlockByHash, GetNBlocksBack }
-import io.iohk.ethereum.domain.{ Block, Receipt }
-import io.iohk.ethereum.ledger.BlockExecutionError.{ ValidationAfterExecError, ValidationBeforeExecError }
-import io.iohk.ethereum.ledger.{ BlockExecutionError, BlockExecutionSuccess }
+import io.iohk.ethereum.consensus.{GetBlockHeaderByHash, GetNBlocksBack}
+import io.iohk.ethereum.domain.{Block, Receipt}
+import io.iohk.ethereum.ledger.BlockExecutionError.{ValidationAfterExecError, ValidationBeforeExecError}
+import io.iohk.ethereum.ledger.{BlockExecutionError, BlockExecutionSuccess}
 import org.bouncycastle.util.encoders.Hex
 
 /**
@@ -23,14 +23,14 @@ final class StdValidators(
 
   def validateBlockBeforeExecution(
     block: Block,
-    getBlockByHash: GetBlockByHash,
+    getBlockHeaderByHash: GetBlockHeaderByHash,
     getNBlocksBack: GetNBlocksBack
   ): Either[ValidationBeforeExecError, BlockExecutionSuccess] = {
 
     StdValidators.validateBlockBeforeExecution(
       self = this,
       block = block,
-      getBlockByHash = getBlockByHash,
+      getBlockHeaderByHash = getBlockHeaderByHash,
       getNBlocksBack = getNBlocksBack
     )
   }
@@ -56,7 +56,7 @@ object StdValidators {
   def validateBlockBeforeExecution(
     self: Validators,
     block: Block,
-    getBlockByHash: GetBlockByHash,
+    getBlockHeaderByHash: GetBlockHeaderByHash,
     getNBlocksBack: GetNBlocksBack
   ): Either[ValidationBeforeExecError, BlockExecutionSuccess] = {
 
@@ -64,7 +64,7 @@ object StdValidators {
     val body = block.body
 
     val result = for {
-      _ <- self.blockHeaderValidator.validate(header, getBlockByHash)
+      _ <- self.blockHeaderValidator.validate(header, getBlockHeaderByHash)
       _ <- self.blockValidator.validateHeaderAndBody(header, body)
     } yield BlockExecutionSuccess
 

--- a/src/main/scala/io/iohk/ethereum/domain/BlockHeader.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/BlockHeader.scala
@@ -57,6 +57,8 @@ case class BlockHeader(
 
 object BlockHeader {
 
+  val emptyOmmerHash = ByteString(Hex.decode("1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"))
+
   def getEncodedWithoutNonce(blockHeader: BlockHeader): Array[Byte] = {
     val rlpEncoded = blockHeader.toRLPEncodable match {
       case rlpList: RLPList => RLPList(rlpList.items.dropRight(2): _*)

--- a/src/main/scala/io/iohk/ethereum/ledger/Ledger.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/Ledger.scala
@@ -516,7 +516,7 @@ class LedgerImpl(
   private def validateBlockBeforeExecution(block: Block): Either[ValidationBeforeExecError, BlockExecutionSuccess] = {
     consensus.validators.validateBlockBeforeExecution(
       block = block,
-      getBlockByHash = getBlockFromChainOrQueue,
+      getBlockHeaderByHash = getBlockHeaderFromChainOrQueue,
       getNBlocksBack = getNBlocksBackFromChainOrQueue
     )
   }
@@ -587,8 +587,8 @@ class LedgerImpl(
   private[ledger] def deleteEmptyTouchedAccounts(world: InMemoryWorldStateProxy): InMemoryWorldStateProxy =
     _blockPreparator.deleteEmptyTouchedAccounts(world)
 
-  private def getBlockFromChainOrQueue(hash: ByteString): Option[Block] = {
-    blockchain.getBlockByHash(hash).orElse(blockQueue.getBlockByHash(hash))
+  private def getBlockHeaderFromChainOrQueue(hash: ByteString): Option[BlockHeader] = {
+    blockchain.getBlockHeaderByHash(hash).orElse(blockQueue.getBlockByHash(hash).map(_.header))
   }
 
   private def getNBlocksBackFromChainOrQueue(hash: ByteString, n: Int): List[Block] = {

--- a/src/main/scala/io/iohk/ethereum/testmode/TestmodeConsensus.scala
+++ b/src/main/scala/io/iohk/ethereum/testmode/TestmodeConsensus.scala
@@ -29,7 +29,7 @@ class TestmodeConsensus(
   class TestValidators extends Validators {
     override def blockHeaderValidator: BlockHeaderValidator = (_, _) => Right(BlockHeaderValid)
     override def signedTransactionValidator: SignedTransactionValidator = new StdSignedTransactionValidator(blockchainConfig)
-    override def validateBlockBeforeExecution(block: Block, getBlockByHash: GetBlockByHash, getNBlocksBack: GetNBlocksBack)
+    override def validateBlockBeforeExecution(block: Block, getBlockHeaderByHash: GetBlockHeaderByHash, getNBlocksBack: GetNBlocksBack)
     : Either[BlockExecutionError.ValidationBeforeExecError, BlockExecutionSuccess] = Right(BlockExecutionSuccess)
     override def validateBlockAfterExecution(block: Block, stateRootHash: ByteString,receipts: Seq[Receipt], gasUsed: BigInt)
     : Either[BlockExecutionError, BlockExecutionSuccess] = Right(BlockExecutionSuccess)

--- a/src/test/scala/io/iohk/ethereum/Mocks.scala
+++ b/src/test/scala/io/iohk/ethereum/Mocks.scala
@@ -7,7 +7,7 @@ import io.iohk.ethereum.consensus.ethash.validators.{EthashValidators, OmmersVal
 import io.iohk.ethereum.consensus.validators.BlockHeaderError.HeaderNumberError
 import io.iohk.ethereum.consensus.validators._
 import io.iohk.ethereum.consensus.validators.std.StdBlockValidator.{BlockTransactionsHashError, BlockValid}
-import io.iohk.ethereum.consensus.{Consensus, GetBlockByHash, GetNBlocksBack}
+import io.iohk.ethereum.consensus.{Consensus, GetBlockHeaderByHash, GetNBlocksBack}
 import io.iohk.ethereum.domain._
 import io.iohk.ethereum.ledger.BlockExecutionError.{StateBeforeFailure, TxsExecutionError}
 import io.iohk.ethereum.ledger.Ledger.BlockPreparationResult
@@ -85,10 +85,10 @@ object Mocks {
       override def validateHeaderAndBody(blockHeader: BlockHeader, blockBody: BlockBody) = Right(BlockValid)
     }
 
-    override val blockHeaderValidator: BlockHeaderValidator = (_: BlockHeader, _: GetBlockByHash) => Right(BlockHeaderValid)
+    override val blockHeaderValidator: BlockHeaderValidator = (_: BlockHeader, _: GetBlockHeaderByHash) => Right(BlockHeaderValid)
 
     override val ommersValidator: OmmersValidator =
-      (_: ByteString, _: BigInt, _: Seq[BlockHeader], _: GetBlockByHash, _: GetNBlocksBack) => Right(OmmersValid)
+      (_: ByteString, _: BigInt, _: Seq[BlockHeader], _: GetBlockHeaderByHash, _: GetNBlocksBack) => Right(OmmersValid)
 
     override val signedTransactionValidator: SignedTransactionValidator =
       (_: SignedTransaction, _: Account, _: BlockHeader, _: UInt256, _: BigInt) => Right(SignedTransactionValid)
@@ -100,10 +100,10 @@ object Mocks {
     override val signedTransactionValidator: SignedTransactionValidator =
       (_: SignedTransaction, _: Account, _: BlockHeader, _: UInt256, _: BigInt) => Left(SignedTransactionError.TransactionSignatureError)
 
-    override val blockHeaderValidator: BlockHeaderValidator = (_: BlockHeader, _: GetBlockByHash) => Left(HeaderNumberError)
+    override val blockHeaderValidator: BlockHeaderValidator = (_: BlockHeader, _: GetBlockHeaderByHash) => Left(HeaderNumberError)
 
     override val ommersValidator: OmmersValidator =
-      (_: ByteString, _: BigInt, _: Seq[BlockHeader], _: GetBlockByHash, _: GetNBlocksBack) => Left(OmmersNotValidError)
+      (_: ByteString, _: BigInt, _: Seq[BlockHeader], _: GetBlockHeaderByHash, _: GetNBlocksBack) => Left(OmmersNotValidError)
 
     override val blockValidator: BlockValidator = new BlockValidator {
       override def validateHeaderAndBody(blockHeader: BlockHeader, blockBody: BlockBody) = Left(BlockTransactionsHashError)

--- a/src/test/scala/io/iohk/ethereum/consensus/BlockGeneratorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/BlockGeneratorSpec.scala
@@ -34,7 +34,7 @@ class BlockGeneratorSpec extends FlatSpec with Matchers with PropertyChecks with
 
     val fullBlock: Either[BlockPreparationError, Block] = result.right
       .map(pb => pb.block.copy(header = pb.block.header.copy(nonce = minedNonce, mixHash = minedMixHash, unixTimestamp = miningTimestamp)))
-    fullBlock.right.foreach(b => validators.blockHeaderValidator.validate(b.header, blockchain.getBlockByHash) shouldBe Right(BlockHeaderValid))
+    fullBlock.right.foreach(b => validators.blockHeaderValidator.validate(b.header, blockchain.getBlockHeaderByHash) shouldBe Right(BlockHeaderValid))
     fullBlock.right.foreach(b => ledger.executeBlock(b) shouldBe a[Right[_, Seq[Receipt]]])
     fullBlock.right.foreach(b => b.header.extraData shouldBe headerExtraData)
   }
@@ -51,7 +51,7 @@ class BlockGeneratorSpec extends FlatSpec with Matchers with PropertyChecks with
 
     val fullBlock: Either[BlockPreparationError, Block] = result.right
       .map(pb => pb.block.copy(header = pb.block.header.copy(nonce = minedNonce, mixHash = minedMixHash, unixTimestamp = miningTimestamp)))
-    fullBlock.right.foreach(b => validators.blockHeaderValidator.validate(b.header, blockchain.getBlockByHash) shouldBe Right(BlockHeaderValid))
+    fullBlock.right.foreach(b => validators.blockHeaderValidator.validate(b.header, blockchain.getBlockHeaderByHash) shouldBe Right(BlockHeaderValid))
     fullBlock.right.foreach(b => ledger.executeBlock(b) shouldBe a[Right[_, Seq[Receipt]]])
     fullBlock.right.foreach(b => b.header.extraData shouldBe headerExtraData)
   }
@@ -103,7 +103,7 @@ class BlockGeneratorSpec extends FlatSpec with Matchers with PropertyChecks with
 
     val fullBlock: Either[BlockPreparationError, Block] = result.right
       .map(pb => pb.block.copy(header = pb.block.header.copy(nonce = minedNonce, mixHash = minedMixHash, unixTimestamp = miningTimestamp)))
-    fullBlock.right.foreach(b => validators.blockHeaderValidator.validate(b.header, blockchain.getBlockByHash) shouldBe Right(BlockHeaderValid))
+    fullBlock.right.foreach(b => validators.blockHeaderValidator.validate(b.header, blockchain.getBlockHeaderByHash) shouldBe Right(BlockHeaderValid))
     fullBlock.right.foreach(b => ledger.executeBlock(b) shouldBe a[Right[_, Seq[Receipt]]])
     fullBlock.right.foreach(b => b.body.transactionList shouldBe Seq(signedTransaction))
     fullBlock.right.foreach(b => b.header.extraData shouldBe headerExtraData)
@@ -128,7 +128,7 @@ class BlockGeneratorSpec extends FlatSpec with Matchers with PropertyChecks with
 
     val fullBlock: Either[BlockPreparationError, Block] = result.right
       .map(pb => pb.block.copy(header = pb.block.header.copy(nonce = minedNonce, mixHash = minedMixHash, unixTimestamp = miningTimestamp)))
-    fullBlock.right.foreach(b => validators.blockHeaderValidator.validate(b.header, blockchain.getBlockByHash) shouldBe Right(BlockHeaderValid))
+    fullBlock.right.foreach(b => validators.blockHeaderValidator.validate(b.header, blockchain.getBlockHeaderByHash) shouldBe Right(BlockHeaderValid))
     fullBlock.right.foreach(b => ledger.executeBlock(b) shouldBe a[Right[_, Seq[Receipt]]])
     fullBlock.right.foreach(b => b.body.transactionList shouldBe Seq(signedTransaction))
     fullBlock.right.foreach(b => b.header.extraData shouldBe headerExtraData)
@@ -173,7 +173,7 @@ class BlockGeneratorSpec extends FlatSpec with Matchers with PropertyChecks with
 
     val fullBlock: Either[BlockPreparationError, Block] = result.right
       .map(pb => pb.block.copy(header = pb.block.header.copy(nonce = minedNonce, mixHash = minedMixHash, unixTimestamp = miningTimestamp)))
-    fullBlock.right.foreach(b => validators.blockHeaderValidator.validate(b.header, blockchain.getBlockByHash) shouldBe Right(BlockHeaderValid))
+    fullBlock.right.foreach(b => validators.blockHeaderValidator.validate(b.header, blockchain.getBlockHeaderByHash) shouldBe Right(BlockHeaderValid))
     fullBlock.right.foreach(b => ledger.executeBlock(b) shouldBe a[Right[_, Seq[Receipt]]])
     fullBlock.right.foreach(b => b.body.transactionList shouldBe Seq(generalTx))
     fullBlock.right.foreach(b => b.header.extraData shouldBe headerExtraData)
@@ -193,7 +193,7 @@ class BlockGeneratorSpec extends FlatSpec with Matchers with PropertyChecks with
 
     val fullBlock: Either[BlockPreparationError, Block] = result.right
       .map(pb => pb.block.copy(header = pb.block.header.copy(nonce = minedNonce, mixHash = minedMixHash, unixTimestamp = miningTimestamp)))
-    fullBlock.right.foreach(b => validators.blockHeaderValidator.validate(b.header, blockchain.getBlockByHash) shouldBe Right(BlockHeaderValid))
+    fullBlock.right.foreach(b => validators.blockHeaderValidator.validate(b.header, blockchain.getBlockHeaderByHash) shouldBe Right(BlockHeaderValid))
     fullBlock.right.foreach(b => ledger.executeBlock(b) shouldBe a[Right[_, Seq[Receipt]]])
     fullBlock.right.foreach(b => b.body.transactionList shouldBe Seq(signedTransaction, generalTx))
     fullBlock.right.foreach(b => b.header.extraData shouldBe headerExtraData)
@@ -213,7 +213,7 @@ class BlockGeneratorSpec extends FlatSpec with Matchers with PropertyChecks with
 
     val fullBlock: Either[BlockPreparationError, Block] = result.right
       .map(pb => pb.block.copy(header = pb.block.header.copy(nonce = minedNonce, mixHash = minedMixHash, unixTimestamp = miningTimestamp)))
-    fullBlock.right.foreach(b => validators.blockHeaderValidator.validate(b.header, blockchain.getBlockByHash) shouldBe Right(BlockHeaderValid))
+    fullBlock.right.foreach(b => validators.blockHeaderValidator.validate(b.header, blockchain.getBlockHeaderByHash) shouldBe Right(BlockHeaderValid))
     fullBlock.right.foreach(b => ledger.executeBlock(b) shouldBe a[Right[_, Seq[Receipt]]])
     fullBlock.right.foreach(b => b.body.transactionList shouldBe Seq(signedTransaction, nextTransaction))
     fullBlock.right.foreach(b => b.header.extraData shouldBe headerExtraData)
@@ -245,7 +245,7 @@ class BlockGeneratorSpec extends FlatSpec with Matchers with PropertyChecks with
 
     val fullBlock: Either[BlockPreparationError, Block] = result.right
       .map(pb => pb.block.copy(header = pb.block.header.copy(nonce = minedNonce, mixHash = minedMixHash, unixTimestamp = miningTimestamp)))
-    fullBlock.right.foreach(b => validators.blockHeaderValidator.validate(b.header, blockchain.getBlockByHash) shouldBe Right(BlockHeaderValid))
+    fullBlock.right.foreach(b => validators.blockHeaderValidator.validate(b.header, blockchain.getBlockHeaderByHash) shouldBe Right(BlockHeaderValid))
     fullBlock.right.foreach(b => ledger.executeBlock(b) shouldBe a[Right[_, Seq[Receipt]]])
     fullBlock.right.foreach(b => b.body.transactionList shouldBe Seq(signedTransaction, nextTransaction))
     fullBlock.right.foreach(b => b.header.extraData shouldBe headerExtraData)
@@ -268,7 +268,7 @@ class BlockGeneratorSpec extends FlatSpec with Matchers with PropertyChecks with
 
     val fullBlock: Either[BlockPreparationError, Block] = result.right
       .map(pb => pb.block.copy(header = pb.block.header.copy(nonce = minedNonce, mixHash = minedMixHash, unixTimestamp = miningTimestamp)))
-    fullBlock.right.foreach(b => validators.blockHeaderValidator.validate(b.header, blockchain.getBlockByHash) shouldBe Right(BlockHeaderValid))
+    fullBlock.right.foreach(b => validators.blockHeaderValidator.validate(b.header, blockchain.getBlockHeaderByHash) shouldBe Right(BlockHeaderValid))
     fullBlock.right.foreach(b => ledger.executeBlock(b) shouldBe a[Right[_, Seq[Receipt]]])
     fullBlock.right.foreach(b => b.body.transactionList shouldBe Seq(signedTransaction))
     fullBlock.right.foreach(b => b.header.extraData shouldBe headerExtraData)

--- a/src/test/scala/io/iohk/ethereum/consensus/atomixraft/difficulty/DifficultySpec.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/atomixraft/difficulty/DifficultySpec.scala
@@ -57,8 +57,8 @@ class DifficultySpec extends FlatSpec with Matchers with PropertyChecks {
     val blockNumber: BigInt = parentHeader.number + 1
     val blockTimestamp: Long = parentHeader.unixTimestamp + 6
 
-    val difficulty = calculator.calculateDifficulty(blockNumber, blockTimestamp, parentBlock)
-    val result = blockHeaderValidator.validate(blockHeader, parentBlock)
+    val difficulty = calculator.calculateDifficulty(blockNumber, blockTimestamp, parentBlock.header)
+    val result = blockHeaderValidator.validate(blockHeader, parentBlock.header)
 
     result shouldBe Right(BlockHeaderValid)
     difficulty shouldBe 1

--- a/src/test/scala/io/iohk/ethereum/consensus/ethash/EthashMinerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/ethash/EthashMinerSpec.scala
@@ -57,7 +57,7 @@ class EthashMinerSpec extends FlatSpec with Matchers {
 
     block.body.transactionList shouldBe Seq(txToMine)
     block.header.nonce.length shouldBe 8
-    blockHeaderValidator.validate(block.header, parent) shouldBe Right(BlockHeaderValid)
+    blockHeaderValidator.validate(block.header, parent.header) shouldBe Right(BlockHeaderValid)
   }
 
   trait TestSetup extends ScenarioSetup with MockFactory {
@@ -124,7 +124,7 @@ class EthashMinerSpec extends FlatSpec with Matchers {
         transactionsRoot = blockHeader.transactionsRoot,
         receiptsRoot = blockHeader.receiptsRoot,
         logsBloom = blockHeader.logsBloom,
-        difficulty = difficultyCalc.calculateDifficulty(1, blockForMiningTimestamp, parent),
+        difficulty = difficultyCalc.calculateDifficulty(1, blockForMiningTimestamp, parent.header),
         number = BigInt(1),
         gasLimit = calculateGasLimit(blockHeader.gasLimit),
         gasUsed = BigInt(0),

--- a/src/test/scala/io/iohk/ethereum/ledger/BlockImportSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/BlockImportSpec.scala
@@ -151,7 +151,7 @@ class BlockImportSpec extends FlatSpec with Matchers with MockFactory {
 
     val newBlock = getBlock()
 
-    (validators.blockHeaderValidator.validate(_: BlockHeader, _: GetBlockByHash))
+    (validators.blockHeaderValidator.validate(_: BlockHeader, _: GetBlockHeaderByHash))
       .expects(newBlock.header, *).returning(Left(HeaderParentNotFoundError))
 
     ledgerWithMockedValidators.importBlock(newBlock) shouldEqual UnknownParent
@@ -168,7 +168,7 @@ class BlockImportSpec extends FlatSpec with Matchers with MockFactory {
 
     val newBlock = getBlock()
 
-    (validators.blockHeaderValidator.validate(_: BlockHeader, _: GetBlockByHash))
+    (validators.blockHeaderValidator.validate(_: BlockHeader, _: GetBlockHeaderByHash))
       .expects(newBlock.header, *).returning(Left(HeaderDifficultyError))
 
     ledgerWithMockedValidators.importBlock(newBlock) shouldEqual BlockImportFailed(HeaderDifficultyError.toString)
@@ -394,7 +394,7 @@ class BlockImportSpec extends FlatSpec with Matchers with MockFactory {
 
     object FailHeaderValidation extends Mocks.MockValidatorsAlwaysSucceed {
        override val blockHeaderValidator: BlockHeaderValidator =
-         (_: BlockHeader, _: GetBlockByHash) => Left(HeaderParentNotFoundError)
+         (_: BlockHeader, _: GetBlockHeaderByHash) => Left(HeaderParentNotFoundError)
     }
 
     lazy val failLedger = new TestLedgerImpl(FailHeaderValidation)
@@ -456,7 +456,7 @@ class BlockImportSpec extends FlatSpec with Matchers with MockFactory {
         (parentHash: ByteString,
          blockNumber: BigInt,
          ommers: Seq[BlockHeader],
-         getBlockHeaderByHash: GetBlockByHash,
+         getBlockHeaderByHash: GetBlockHeaderByHash,
          getNBlocksBack: GetNBlocksBack) =>
           new StdOmmersValidator(blockchainConfig, blockHeaderValidator).validate(parentHash, blockNumber, ommers, getBlockHeaderByHash, getNBlocksBack)
     }


### PR DESCRIPTION
Improvement to changes introducing https://github.com/ethereum/EIPs/blob/master/EIPS/eip-100.md
To depends only on parent header for difficulty calculator, it is better to chcek if:
`parentHeader.ommerHash == Hash(emptyOmmmerlist)`