### PR TITLE
Use rocks db native column families

### DIFF
--- a/src/it/scala/io/iohk/ethereum/db/DataSourceIntegrationTestBehavior.scala
+++ b/src/it/scala/io/iohk/ethereum/db/DataSourceIntegrationTestBehavior.scala
@@ -19,7 +19,7 @@ trait DataSourceIntegrationTestBehavior
   val KeySize: Int = KeySizeWithoutPrefix + 1
   //Hash size + prefix
   val KeyNumberLimit: Int = 40
-  val OtherNamespace: IndexedSeq[Byte] = IndexedSeq[Byte]('e'.toByte)
+  val OtherNamespace: IndexedSeq[Byte] = IndexedSeq[Byte]('r'.toByte)
 
   val MaxIncreaseInLength = 10
 
@@ -153,7 +153,7 @@ trait DataSourceIntegrationTestBehavior
     }
 
     it should "be able to handle inserts to multiple namespaces with the same key" in {
-      val OtherNamespace2: IndexedSeq[Byte] = IndexedSeq[Byte]('o'.toByte)
+      val OtherNamespace2: IndexedSeq[Byte] = IndexedSeq[Byte]('h'.toByte)
       forAll(seqByteStringOfNItemsGen(KeySizeWithoutPrefix)) { unFilteredKeyList: Seq[ByteString] =>
         withDir { path =>
           val keyList = unFilteredKeyList.take(KeyNumberLimit)
@@ -179,7 +179,7 @@ trait DataSourceIntegrationTestBehavior
     }
 
     it should "be able to handle removals from multiple namespaces with the same key" in {
-      val OtherNamespace2: IndexedSeq[Byte] = IndexedSeq[Byte]('o'.toByte)
+      val OtherNamespace2: IndexedSeq[Byte] = IndexedSeq[Byte]('h'.toByte)
       forAll(seqByteStringOfNItemsGen(KeySizeWithoutPrefix)) { unFilteredKeyList: Seq[ByteString] =>
         withDir { path =>
           val keyList = unFilteredKeyList.take(KeyNumberLimit)

--- a/src/it/scala/io/iohk/ethereum/db/RocksDbDataSourceIntegrationSuite.scala
+++ b/src/it/scala/io/iohk/ethereum/db/RocksDbDataSourceIntegrationSuite.scala
@@ -1,6 +1,7 @@
 package io.iohk.ethereum.db
 
-import io.iohk.ethereum.db.dataSource.{ RocksDbConfig, RocksDbDataSource }
+import io.iohk.ethereum.db.dataSource.{RocksDbConfig, RocksDbDataSource}
+import io.iohk.ethereum.db.storage.Namespaces
 import org.scalatest.FlatSpec
 
 class RocksDbDataSourceIntegrationSuite extends FlatSpec with DataSourceIntegrationTestBehavior {
@@ -15,7 +16,7 @@ class RocksDbDataSourceIntegrationSuite extends FlatSpec with DataSourceIntegrat
     override val levelCompaction: Boolean = true
     override val blockSize: Long = 16384
     override val blockCacheSize: Long = 33554432
-  })
+  }, Namespaces.nsSeq)
 
   it should behave like dataSource(createDataSource)
 }

--- a/src/main/scala/io/iohk/ethereum/db/components/SharedRocksDbDataSources.scala
+++ b/src/main/scala/io/iohk/ethereum/db/components/SharedRocksDbDataSources.scala
@@ -1,11 +1,12 @@
 package io.iohk.ethereum.db.components
 
-import io.iohk.ethereum.db.dataSource.{ DataSource, RocksDbDataSource }
+import io.iohk.ethereum.db.dataSource.{DataSource, RocksDbDataSource}
+import io.iohk.ethereum.db.storage.Namespaces
 import io.iohk.ethereum.utils.Config
 
 trait SharedRocksDbDataSources extends DataSourcesComponent {
 
-  lazy val dataSource = RocksDbDataSource(Config.Db.RocksDb)
+  lazy val dataSource = RocksDbDataSource(Config.Db.RocksDb, Namespaces.nsSeq)
 
   lazy val dataSources = new DataSources {
 

--- a/src/main/scala/io/iohk/ethereum/db/dataSource/DataSource.scala
+++ b/src/main/scala/io/iohk/ethereum/db/dataSource/DataSource.scala
@@ -1,10 +1,7 @@
 package io.iohk.ethereum.db.dataSource
 
 trait DataSource {
-
-  type Key = IndexedSeq[Byte]
-  type Value = IndexedSeq[Byte]
-  type Namespace = IndexedSeq[Byte]
+  import DataSource._
 
   /**
     * This function obtains the associated value to a key. It requires the (key-value) pair to be in the DataSource
@@ -73,4 +70,10 @@ trait DataSource {
     * This function closes the DataSource, if it is not yet closed, and deletes all the files used by it.
     */
   def destroy(): Unit
+}
+
+object DataSource {
+  type Key = IndexedSeq[Byte]
+  type Value = IndexedSeq[Byte]
+  type Namespace = IndexedSeq[Byte]
 }

--- a/src/main/scala/io/iohk/ethereum/db/dataSource/EphemDataSource.scala
+++ b/src/main/scala/io/iohk/ethereum/db/dataSource/EphemDataSource.scala
@@ -1,6 +1,7 @@
 package io.iohk.ethereum.db.dataSource
 
 import java.nio.ByteBuffer
+import io.iohk.ethereum.db.dataSource.DataSource._
 
 class EphemDataSource(var storage: Map[ByteBuffer, Array[Byte]]) extends DataSource {
 

--- a/src/main/scala/io/iohk/ethereum/db/dataSource/IodbDataSource.scala
+++ b/src/main/scala/io/iohk/ethereum/db/dataSource/IodbDataSource.scala
@@ -5,7 +5,7 @@ import java.nio.ByteBuffer
 import java.util.concurrent.atomic.AtomicLong
 
 import io.iohk.iodb.{ByteArrayWrapper, LSMStore}
-
+import io.iohk.ethereum.db.dataSource.DataSource._
 class IodbDataSource private (lSMStore: LSMStore, keySize: Int, path: String) extends DataSource {
 
   import IodbDataSource._

--- a/src/main/scala/io/iohk/ethereum/db/dataSource/LevelDBDataSource.scala
+++ b/src/main/scala/io/iohk/ethereum/db/dataSource/LevelDBDataSource.scala
@@ -4,7 +4,7 @@ import java.io.File
 
 import org.iq80.leveldb.impl.Iq80DBFactory
 import org.iq80.leveldb.{ DB, Options }
-
+import io.iohk.ethereum.db.dataSource.DataSource._
 class LevelDBDataSource(private var db: DB, private val levelDbConfig: LevelDbConfig) extends DataSource {
 
   /**

--- a/src/main/scala/io/iohk/ethereum/db/storage/KeyValueStorage.scala
+++ b/src/main/scala/io/iohk/ethereum/db/storage/KeyValueStorage.scala
@@ -52,4 +52,18 @@ object Namespaces {
   val HeightsNamespace: IndexedSeq[Byte] = IndexedSeq[Byte]('i'.toByte)
   val FastSyncStateNamespace: IndexedSeq[Byte] = IndexedSeq[Byte]('h'.toByte)
   val TransactionMappingNamespace: IndexedSeq[Byte] = IndexedSeq[Byte]('l'.toByte)
+
+  val nsSeq = Seq(
+    ReceiptsNamespace,
+    HeaderNamespace,
+    BodyNamespace,
+    NodeNamespace,
+    CodeNamespace,
+    TotalDifficultyNamespace,
+    AppStateNamespace,
+    KnownNodesNamespace,
+    HeightsNamespace,
+    FastSyncStateNamespace,
+    TransactionMappingNamespace
+  )
 }

--- a/src/snappy/scala/io/iohk/ethereum/snappy/Prerequisites.scala
+++ b/src/snappy/scala/io/iohk/ethereum/snappy/Prerequisites.scala
@@ -3,15 +3,16 @@ package io.iohk.ethereum.snappy
 import io.iohk.ethereum.blockchain.data.GenesisDataLoader
 import io.iohk.ethereum.consensus.StdTestConsensusBuilder
 import io.iohk.ethereum.db.components.Storages.PruningModeComponent
-import io.iohk.ethereum.db.components.{ DataSourcesComponent, SharedLevelDBDataSources, SharedRocksDbDataSources, Storages }
+import io.iohk.ethereum.db.components.{DataSourcesComponent, SharedLevelDBDataSources, SharedRocksDbDataSources, Storages}
 import io.iohk.ethereum.db.dataSource._
-import io.iohk.ethereum.db.storage.pruning.{ ArchivePruning, PruningMode }
+import io.iohk.ethereum.db.storage.Namespaces
+import io.iohk.ethereum.db.storage.pruning.{ArchivePruning, PruningMode}
 import io.iohk.ethereum.domain.BlockchainImpl
 import io.iohk.ethereum.ledger.Ledger.VMImpl
-import io.iohk.ethereum.ledger.{ Ledger, LedgerImpl }
+import io.iohk.ethereum.ledger.{Ledger, LedgerImpl}
 import io.iohk.ethereum.nodebuilder._
-import io.iohk.ethereum.snappy.Config.{ DualDB, SingleDB }
-import io.iohk.ethereum.snappy.Prerequisites.{ LevelDbStorages, RocksDbStorages, Storages }
+import io.iohk.ethereum.snappy.Config.{DualDB, SingleDB}
+import io.iohk.ethereum.snappy.Prerequisites.{LevelDbStorages, RocksDbStorages, Storages}
 
 object Prerequisites {
   trait NoPruning extends PruningModeComponent {
@@ -51,7 +52,7 @@ class Prerequisites(config: Config) {
       override val levelCompaction: Boolean = true
       override val blockSize: Long = 16384
       override val blockCacheSize: Long = 33554432
-    })
+    }, Namespaces.nsSeq)
 
   private def dbSelection(source: String, dbPath: String): Storages = {
     source match {

--- a/src/test/scala/io/iohk/ethereum/db/dataSource/DataSourceTestBehavior.scala
+++ b/src/test/scala/io/iohk/ethereum/db/dataSource/DataSourceTestBehavior.scala
@@ -14,7 +14,7 @@ trait DataSourceTestBehavior
   this: FlatSpec =>
 
   val KeySizeWithoutPrefix: Int = 32
-  val OtherNamespace: IndexedSeq[Byte] = IndexedSeq[Byte]('e'.toByte)
+  val OtherNamespace: IndexedSeq[Byte] = IndexedSeq[Byte]('r'.toByte)
 
   def withDir(testCode: String => Any): Unit = {
     val path = Files.createTempDirectory("testdb").getFileName.toString
@@ -81,7 +81,7 @@ trait DataSourceTestBehavior
     }
 
     it should "allow using multiple namespaces with the same key" in {
-      val OtherNamespace2: IndexedSeq[Byte] = IndexedSeq[Byte]('o'.toByte)
+      val OtherNamespace2: IndexedSeq[Byte] = IndexedSeq[Byte]('h'.toByte)
       val someByteString = byteStringOfLengthNGen(KeySizeWithoutPrefix).sample.get
       val someValue1 = 1.toByte +: someByteString
       val someValue2 = 2.toByte +: someByteString

--- a/src/test/scala/io/iohk/ethereum/db/dataSource/RocksDbDataSourceTest.scala
+++ b/src/test/scala/io/iohk/ethereum/db/dataSource/RocksDbDataSourceTest.scala
@@ -2,6 +2,7 @@ package io.iohk.ethereum.db.dataSource
 
 import java.nio.file.Files
 
+import io.iohk.ethereum.db.storage.Namespaces
 import org.scalatest.FlatSpec
 
 class RocksDbDataSourceTest extends FlatSpec with DataSourceTestBehavior {
@@ -19,7 +20,7 @@ class RocksDbDataSourceTest extends FlatSpec with DataSourceTestBehavior {
       override val levelCompaction: Boolean = true
       override val blockSize: Long = 16384
       override val blockCacheSize: Long = 33554432
-    })
+    }, Namespaces.nsSeq)
   }
 
   it should behave like dataSource(createDataSource)

--- a/src/test/scala/io/iohk/ethereum/mpt/PersistentStorage.scala
+++ b/src/test/scala/io/iohk/ethereum/mpt/PersistentStorage.scala
@@ -4,7 +4,7 @@ import java.io.File
 import java.nio.file.Files
 
 import io.iohk.ethereum.db.dataSource._
-import io.iohk.ethereum.db.storage.{ ArchiveNodeStorage, NodeStorage }
+import io.iohk.ethereum.db.storage.{ArchiveNodeStorage, Namespaces, NodeStorage}
 
 trait PersistentStorage {
 
@@ -20,7 +20,7 @@ trait PersistentStorage {
       override val levelCompaction: Boolean = true
       override val blockSize: Long = 16384
       override val blockCacheSize: Long = 33554432
-    })
+    }, Namespaces.nsSeq)
 
     testExecution(testCode, dbPath, dataSource)
     dataSource.destroy()


### PR DESCRIPTION
Pr:
1. Add usage of native rocks db column families, which improve mantis performance.
Some measurments (syncing 1h from master node)
 `Baseline - 250305 blocks synced`
`columnfamilies- 375553 blocks synced`
2. Add some missing `close` calls to rocks db objects,  which lack of could result in potential memory leaks

Change tested by syncing to the top of the chain via fast sync and then regular syncing for around 1day.