### PR TITLE
[ETCM-129] prepare for Scala 2.13 replace ⇒ to =>

### DIFF
--- a/src/main/scala/io/iohk/ethereum/consensus/ConsensusBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/ConsensusBuilder.scala
@@ -17,7 +17,7 @@ trait ConsensusBuilder {
  *      [[io.iohk.ethereum.consensus.ethash.EthashConsensus EthashConsensus]],
  */
 trait StdConsensusBuilder extends ConsensusBuilder {
-  self: VmBuilder with BlockchainBuilder with BlockchainConfigBuilder with ConsensusConfigBuilder with Logger ⇒
+  self: VmBuilder with BlockchainBuilder with BlockchainConfigBuilder with ConsensusConfigBuilder with Logger =>
 
   private lazy val mantisConfig = Config.config
 
@@ -38,7 +38,7 @@ trait StdConsensusBuilder extends ConsensusBuilder {
 
     val consensus =
       config.protocol match {
-        case Protocol.Ethash | Protocol.MockedPow ⇒ buildEthashConsensus()
+        case Protocol.Ethash | Protocol.MockedPow => buildEthashConsensus()
       }
     log.info(s"Using '${protocol.name}' consensus [${consensus.getClass.getName}]")
 

--- a/src/main/scala/io/iohk/ethereum/consensus/ConsensusConfig.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/ConsensusConfig.scala
@@ -41,7 +41,7 @@ object ConsensusConfig extends Logger {
     Protocol.Names.MockedPow
   )
 
-  final val AllowedProtocolsError = (s: String) ⇒ Keys.Consensus +
+  final val AllowedProtocolsError = (s: String) => Keys.Consensus +
     " is configured as '" + s + "'" +
     " but it should be one of " +
     AllowedProtocols.map("'" + _ + "'").mkString(",")

--- a/src/main/scala/io/iohk/ethereum/consensus/ConsensusConfigBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/ConsensusConfigBuilder.scala
@@ -3,7 +3,7 @@ package io.iohk.ethereum.consensus
 import io.iohk.ethereum.nodebuilder.ShutdownHookBuilder
 import io.iohk.ethereum.utils.Config
 
-trait ConsensusConfigBuilder { self: ShutdownHookBuilder ⇒
+trait ConsensusConfigBuilder { self: ShutdownHookBuilder =>
   protected def buildConsensusConfig(): ConsensusConfig = ConsensusConfig(Config.config)(this)
 
   lazy val consensusConfig: ConsensusConfig = buildConsensusConfig()

--- a/src/main/scala/io/iohk/ethereum/consensus/TestConsensusBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/TestConsensusBuilder.scala
@@ -7,7 +7,7 @@ import io.iohk.ethereum.utils.Logger
  * A [[io.iohk.ethereum.consensus.ConsensusBuilder ConsensusBuilder]] that builds a
  * [[io.iohk.ethereum.consensus.TestConsensus TestConsensus]]
  */
-trait TestConsensusBuilder { self: StdConsensusBuilder ⇒
+trait TestConsensusBuilder { self: StdConsensusBuilder =>
   protected def buildTestConsensus(): TestConsensus =
     buildConsensus().asInstanceOf[TestConsensus] // we are in tests, so if we get an exception, so be it
 }

--- a/src/main/scala/io/iohk/ethereum/consensus/ethash/EthashConfig.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/ethash/EthashConfig.scala
@@ -2,7 +2,7 @@ package io.iohk.ethereum
 package consensus
 package ethash
 
-import com.typesafe.config.{Config ⇒ TypesafeConfig}
+import com.typesafe.config.{Config => TypesafeConfig}
 
 import scala.concurrent.duration.{FiniteDuration, _}
 

--- a/src/main/scala/io/iohk/ethereum/consensus/ethash/EthashConsensus.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/ethash/EthashConsensus.scala
@@ -54,7 +54,7 @@ class EthashConsensus private(
 
   private[this] def startMiningProcess(node: Node): Unit = {
     atomicMiner.get() match {
-      case None ⇒
+      case None =>
         val miner = config.generic.protocol match {
           case Ethash => EthashMiner(node)
           case MockedPow => MockedMiner(node)
@@ -62,7 +62,7 @@ class EthashConsensus private(
         atomicMiner.set(Some(miner))
         sendMiner(MinerProtocol.StartMining)
 
-      case _ ⇒
+      case _ =>
     }
   }
 
@@ -95,7 +95,7 @@ class EthashConsensus private(
   /** Internal API, used for testing */
   protected def newBlockGenerator(validators: Validators): EthashBlockGenerator = {
     validators match {
-      case _validators: ValidatorsExecutor ⇒
+      case _validators: ValidatorsExecutor =>
         val blockPreparator = new BlockPreparator(
           vm = vm,
           signedTxValidator = validators.signedTransactionValidator,
@@ -112,7 +112,7 @@ class EthashConsensus private(
           blockTimestampProvider = blockGenerator.blockTimestampProvider
         )
 
-      case _ ⇒
+      case _ =>
         wrongValidatorsArgument[ValidatorsExecutor](validators)
     }
   }
@@ -121,7 +121,7 @@ class EthashConsensus private(
   /** Internal API, used for testing */
   def withValidators(validators: Validators): EthashConsensus = {
     validators match {
-      case _validators: ValidatorsExecutor ⇒
+      case _validators: ValidatorsExecutor =>
         val blockGenerator = newBlockGenerator(validators)
 
         new EthashConsensus(
@@ -133,7 +133,7 @@ class EthashConsensus private(
           blockGenerator = blockGenerator
         )
 
-      case _ ⇒
+      case _ =>
         wrongValidatorsArgument[ValidatorsExecutor](validators)
     }
   }

--- a/src/main/scala/io/iohk/ethereum/consensus/ethash/EthashMiner.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/ethash/EthashMiner.scala
@@ -198,7 +198,7 @@ object EthashMiner {
 
   def apply(node: Node): ActorRef = {
     node.consensus match {
-      case consensus: EthashConsensus ⇒
+      case consensus: EthashConsensus =>
         val blockCreator = new EthashBlockCreator(
           pendingTransactionsManager = node.pendingTransactionsManager,
           getTransactionFromPoolTimeout = node.txPoolConfig.getTransactionFromPoolTimeout,
@@ -212,7 +212,7 @@ object EthashMiner {
           ethService = node.ethService
         )
         node.system.actorOf(minerProps)
-      case consensus ⇒
+      case consensus =>
         wrongConsensusArgument[EthashConsensus](consensus)
     }
   }

--- a/src/main/scala/io/iohk/ethereum/consensus/ethash/MockedMiner.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/ethash/MockedMiner.scala
@@ -107,7 +107,7 @@ object MockedMiner {
 
   def apply(node: Node): ActorRef = {
     node.consensus match {
-      case consensus: EthashConsensus ⇒
+      case consensus: EthashConsensus =>
         val blockCreator = new EthashBlockCreator(
           pendingTransactionsManager = node.pendingTransactionsManager,
           getTransactionFromPoolTimeout = node.txPoolConfig.getTransactionFromPoolTimeout,
@@ -120,7 +120,7 @@ object MockedMiner {
           syncEventListener = node.syncController
         )
         node.system.actorOf(minerProps)
-      case consensus ⇒
+      case consensus =>
         wrongConsensusArgument[EthashConsensus](consensus)
     }
   }

--- a/src/main/scala/io/iohk/ethereum/consensus/package.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/package.scala
@@ -13,8 +13,8 @@ import scala.reflect.ClassTag
  * Different consensus protocols are implemented in sub-packages.
  */
 package object consensus {
-  final type GetBlockHeaderByHash = ByteString ⇒ Option[BlockHeader]
-  final type GetNBlocksBack = (ByteString, Int) ⇒ Seq[Block]
+  final type GetBlockHeaderByHash = ByteString => Option[BlockHeader]
+  final type GetNBlocksBack = (ByteString, Int) => Seq[Block]
 
   def wrongConsensusArgument[T <: Consensus : ClassTag](consensus: Consensus): Nothing = {
     val requiredClass = implicitly[ClassTag[T]].runtimeClass
@@ -42,10 +42,10 @@ package object consensus {
      * if we run under [[io.iohk.ethereum.consensus.ethash.EthashConsensus EthashConsensus]]
      * then the `_then` function is called, otherwise the `_else` value is computed.
      */
-    def ifEthash[A](_then: EthashConsensus ⇒ A)(_else: ⇒ A): A =
+    def ifEthash[A](_then: EthashConsensus => A)(_else: => A): A =
       consensus match {
-        case ethash: EthashConsensus ⇒ _then(ethash)
-        case _ ⇒ _else
+        case ethash: EthashConsensus => _then(ethash)
+        case _ => _else
       }
   }
 }

--- a/src/main/scala/io/iohk/ethereum/healthcheck/Healthcheck.scala
+++ b/src/main/scala/io/iohk/ethereum/healthcheck/Healthcheck.scala
@@ -18,19 +18,19 @@ import scala.util.{Failure, Success}
   */
 case class Healthcheck[Error, Result](
     description: String,
-    f: () ⇒ Future[Either[Error, Result]],
-    mapResultToError: Result ⇒ Option[String] = (_: Result) ⇒ None,
-    mapErrorToError: Error ⇒ Option[String] = (error: Error) ⇒ Some(String.valueOf(error)),
-    mapExceptionToError: Throwable ⇒ Option[String] = (t: Throwable) ⇒ Some(String.valueOf(t))
+    f: () => Future[Either[Error, Result]],
+    mapResultToError: Result => Option[String] = (_: Result) => None,
+    mapErrorToError: Error => Option[String] = (error: Error) => Some(String.valueOf(error)),
+    mapExceptionToError: Throwable => Option[String] = (t: Throwable) => Some(String.valueOf(t))
 ) {
 
   def apply()(implicit ec: ExecutionContext): Future[HealthcheckResult] = {
     f().transform {
-      case Success(Left(error)) ⇒
+      case Success(Left(error)) =>
         Success(HealthcheckResult(description, mapErrorToError(error)))
-      case Success(Right(result)) ⇒
+      case Success(Right(result)) =>
         Success(HealthcheckResult(description, mapResultToError(result)))
-      case Failure(t) ⇒
+      case Failure(t) =>
         Success(HealthcheckResult(description, mapExceptionToError(t)))
     }
   }

--- a/src/main/scala/io/iohk/ethereum/healthcheck/HealthcheckResult.scala
+++ b/src/main/scala/io/iohk/ethereum/healthcheck/HealthcheckResult.scala
@@ -12,7 +12,7 @@ object HealthcheckResult {
   def apply(description: String, error: Option[String]): HealthcheckResult =
     new HealthcheckResult(
       description = description,
-      status = error.fold(HealthcheckStatus.OK)(_ ⇒ HealthcheckStatus.ERROR),
+      status = error.fold(HealthcheckStatus.OK)(_ => HealthcheckStatus.ERROR),
       error = error
     )
 }

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/EthService.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/EthService.scala
@@ -219,9 +219,9 @@ class EthService(
   private[this] def fullConsensusConfig = consensus.config
   private[this] def consensusConfig: ConsensusConfig = fullConsensusConfig.generic
 
-  private[this] def ifEthash[Req, Res](req: Req)(f: Req ⇒ Res): ServiceResponse[Res] = {
+  private[this] def ifEthash[Req, Res](req: Req)(f: Req => Res): ServiceResponse[Res] = {
     @inline def F[A](x: A): Future[A] = Future.successful(x)
-    consensus.ifEthash[ServiceResponse[Res]](_ ⇒ F(Right(f(req))))(F(Left(JsonRpcErrors.ConsensusIsNotEthash)))
+    consensus.ifEthash[ServiceResponse[Res]](_ => F(Right(f(req))))(F(Left(JsonRpcErrors.ConsensusIsNotEthash)))
   }
 
   def protocolVersion(req: ProtocolVersionRequest): ServiceResponse[ProtocolVersionResponse] =
@@ -435,7 +435,7 @@ class EthService(
   }
 
   def submitHashRate(req: SubmitHashRateRequest): ServiceResponse[SubmitHashRateResponse] =
-    ifEthash(req) { req ⇒
+    ifEthash(req) { req =>
       reportActive()
       hashRate.updateAndGet((t: Map[ByteString, (BigInt, Date)]) => {
         val now = new Date
@@ -464,7 +464,7 @@ class EthService(
   }
 
   def getMining(req: GetMiningRequest): ServiceResponse[GetMiningResponse] =
-    ifEthash(req) { _ ⇒
+    ifEthash(req) { _ =>
       val isMining = lastActive
         .updateAndGet((e: Option[Date]) => {
           e.filter { time =>
@@ -478,11 +478,11 @@ class EthService(
 
   private def reportActive(): Option[Date] = {
     val now = new Date()
-    lastActive.updateAndGet(_ ⇒ Some(now))
+    lastActive.updateAndGet(_ => Some(now))
   }
 
   def getHashRate(req: GetHashRateRequest): ServiceResponse[GetHashRateResponse] =
-    ifEthash(req) { _ ⇒
+    ifEthash(req) { _ =>
       val hashRates: Map[ByteString, (BigInt, Date)] = hashRate.updateAndGet((t: Map[ByteString, (BigInt, Date)]) => {
         removeObsoleteHashrates(new Date, t)
       })
@@ -502,7 +502,7 @@ class EthService(
   }
 
   def getWork(req: GetWorkRequest): ServiceResponse[GetWorkResponse] =
-    consensus.ifEthash(ethash ⇒ {
+    consensus.ifEthash(ethash => {
       reportActive()
       import io.iohk.ethereum.consensus.ethash.EthashUtils.{epoch, seed}
 
@@ -531,7 +531,7 @@ class EthService(
     })(Future.successful(Left(JsonRpcErrors.ConsensusIsNotEthash)))
 
   private def getOmmersFromPool(blockNumber: BigInt): Future[OmmersPool.Ommers] =
-    consensus.ifEthash(ethash ⇒ {
+    consensus.ifEthash(ethash => {
       val miningConfig = ethash.config.specific
       implicit val timeout: Timeout = Timeout(miningConfig.ommerPoolQueryTimeout)
 
@@ -559,7 +559,7 @@ class EthService(
     Future.successful(Right(GetCoinbaseResponse(consensusConfig.coinbase)))
 
   def submitWork(req: SubmitWorkRequest): ServiceResponse[SubmitWorkResponse] =
-    consensus.ifEthash[ServiceResponse[SubmitWorkResponse]](ethash ⇒ {
+    consensus.ifEthash[ServiceResponse[SubmitWorkResponse]](ethash => {
       reportActive()
       Future {
         ethash.blockGenerator.getPrepared(req.powHeaderHash) match {

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/JsonRpcHealthcheck.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/JsonRpcHealthcheck.scala
@@ -5,5 +5,5 @@ import io.iohk.ethereum.healthcheck.Healthcheck
 object JsonRpcHealthcheck {
   type T[R] = Healthcheck[JsonRpcError, R]
 
-  def apply[R](description: String, f: () ⇒ ServiceResponse[R]): T[R] = Healthcheck(description, f)
+  def apply[R](description: String, f: () => ServiceResponse[R]): T[R] = Healthcheck(description, f)
 }

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/NodeJsonRpcHealthChecker.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/NodeJsonRpcHealthChecker.scala
@@ -14,19 +14,19 @@ class NodeJsonRpcHealthChecker(
 
   protected def mainService: String = "node health"
 
-  final val listeningHC = JsonRpcHealthcheck("listening", () ⇒ netService.listening(NetService.ListeningRequest()))
-  final val peerCountHC = JsonRpcHealthcheck("peerCount", () ⇒ netService.peerCount(PeerCountRequest()))
+  final val listeningHC = JsonRpcHealthcheck("listening", () => netService.listening(NetService.ListeningRequest()))
+  final val peerCountHC = JsonRpcHealthcheck("peerCount", () => netService.peerCount(PeerCountRequest()))
   final val earliestBlockHC = JsonRpcHealthcheck(
     "earliestBlock",
-    () ⇒ ethService.getBlockByNumber(BlockByNumberRequest(BlockParam.Earliest, true))
+    () => ethService.getBlockByNumber(BlockByNumberRequest(BlockParam.Earliest, true))
   )
   final val latestBlockHC = JsonRpcHealthcheck(
     "latestBlock",
-    () ⇒ ethService.getBlockByNumber(BlockByNumberRequest(BlockParam.Latest, true))
+    () => ethService.getBlockByNumber(BlockByNumberRequest(BlockParam.Latest, true))
   )
   final val pendingBlockHC = JsonRpcHealthcheck(
     "pendingBlock",
-    () ⇒ ethService.getBlockByNumber(BlockByNumberRequest(BlockParam.Pending, true))
+    () => ethService.getBlockByNumber(BlockByNumberRequest(BlockParam.Pending, true))
   )
 
   override def healthCheck(): Future[HealthcheckResponse] = {

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/server/http/JsonRpcHttpServer.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/server/http/JsonRpcHttpServer.scala
@@ -64,12 +64,12 @@ trait JsonRpcHttpServer extends Json4sSupport {
     val responseF = jsonRpcHealthChecker.healthCheck()
     val httpResponseF =
       responseF.map {
-        case response if response.isOK ⇒
+        case response if response.isOK =>
           HttpResponse(
             status = StatusCodes.OK,
             entity = HttpEntity(ContentTypes.`application/json`, serialization.writePretty(response))
           )
-        case response ⇒
+        case response =>
           HttpResponse(
             status = StatusCodes.InternalServerError,
             entity = HttpEntity(ContentTypes.`application/json`, serialization.writePretty(response))

--- a/src/main/scala/io/iohk/ethereum/metrics/DeltaSpikeGauge.scala
+++ b/src/main/scala/io/iohk/ethereum/metrics/DeltaSpikeGauge.scala
@@ -21,7 +21,7 @@ class DeltaSpikeGauge(name: String, metrics: Metrics) {
     }
   }
 
-  private[this] final val gauge = metrics.gauge(name, () ⇒ getValue)
+  private[this] final val gauge = metrics.gauge(name, () => getValue)
 
   def trigger(): Unit = {
     if (isTriggeredRef.compareAndSet(false, true)) {

--- a/src/main/scala/io/iohk/ethereum/metrics/Metrics.scala
+++ b/src/main/scala/io/iohk/ethereum/metrics/Metrics.scala
@@ -31,13 +31,13 @@ case class Metrics(metricsPrefix: String, registry: MeterRegistry, serverPort: I
     * Returns a [[io.micrometer.core.instrument.Gauge Gauge]].
     * @param computeValue A function that computes the current gauge value.
     */
-  def gauge(name: String, computeValue: () ⇒ Double): Gauge =
+  def gauge(name: String, computeValue: () => Double): Gauge =
     Gauge
     // Note Never use `null` as the value for the second parameter.
     //      If you do, you risk getting no metrics out of the gauge.
     //      So we just use a vanilla `this` but any other non-`null`
     //      value would also do.
-      .builder(mkName(name), this, (_: Any) ⇒ computeValue())
+      .builder(mkName(name), this, (_: Any) => computeValue())
       .register(registry)
 
   /**

--- a/src/main/scala/io/iohk/ethereum/metrics/MetricsConfig.scala
+++ b/src/main/scala/io/iohk/ethereum/metrics/MetricsConfig.scala
@@ -1,6 +1,6 @@
 package io.iohk.ethereum.metrics
 
-import com.typesafe.config.{Config ⇒ TypesafeConfig}
+import com.typesafe.config.{Config => TypesafeConfig}
 
 final case class MetricsConfig(
     enabled: Boolean,

--- a/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
@@ -498,7 +498,7 @@ trait SyncControllerBuilder {
 }
 
 trait ShutdownHookBuilder {
-  self: Logger ⇒
+  self: Logger =>
   def shutdown(): Unit = {
     /* No default behaviour during shutdown. */
   }
@@ -511,10 +511,10 @@ trait ShutdownHookBuilder {
     }
   })
 
-  def shutdownOnError[A](f: ⇒ A): A = {
+  def shutdownOnError[A](f: => A): A = {
     Try(f) match {
-      case Success(v) ⇒ v
-      case Failure(t) ⇒
+      case Success(v) => v
+      case Failure(t) =>
         log.error(t.getMessage, t)
         shutdown()
         throw t

--- a/src/main/scala/io/iohk/ethereum/utils/Ref.scala
+++ b/src/main/scala/io/iohk/ethereum/utils/Ref.scala
@@ -9,11 +9,11 @@ class Ref[T <: AnyRef] {
   private[this] final val ref = new AtomicReference[Option[T]](None)
 
   // set once (but not necessarily compute once)
-  final def setOnce(t: ⇒ T): Boolean = ref.get().isEmpty && ref.compareAndSet(None, Some(t))
+  final def setOnce(t: => T): Boolean = ref.get().isEmpty && ref.compareAndSet(None, Some(t))
 
   final def isDefined: Boolean = ref.get().isDefined
   final def isEmpty: Boolean = ref.get().isEmpty
 
-  final def map[U](f: T ⇒ U): Option[U] = ref.get().map(f)
-  final def foreach[U](f: T ⇒ U): Unit = map(f)
+  final def map[U](f: T => U): Option[U] = ref.get().map(f)
+  final def foreach[U](f: T => U): Unit = map(f)
 }

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/EthServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/EthServiceSpec.scala
@@ -122,9 +122,9 @@ class EthServiceSpec
   }
 
   it should "answer eth_getBlockByNumber with the correct block when the pending block is requested" in new TestSetup {
-    (ledger.consensus _: (() ⇒ Consensus)).expects().returns(consensus)
+    (ledger.consensus _: (() => Consensus)).expects().returns(consensus)
 
-    (appStateStorage.getBestBlockNumber _: () ⇒ BigInt).expects().returns(blockToRequest.header.number)
+    (appStateStorage.getBestBlockNumber _: () => BigInt).expects().returns(blockToRequest.header.number)
 
     (blockGenerator.getPendingBlockAndState _)
       .expects()
@@ -144,7 +144,7 @@ class EthServiceSpec
 
   it should "answer eth_getBlockByNumber with the latest block pending block is requested and there are no pending ones" in new TestSetup {
 
-    (ledger.consensus _: (() ⇒ Consensus)).expects().returns(consensus)
+    (ledger.consensus _: (() => Consensus)).expects().returns(consensus)
 
     blockchain
       .storeBlock(blockToRequest)
@@ -418,7 +418,7 @@ class EthServiceSpec
   }
 
   it should "return requested work" in new TestSetup {
-    (ledger.consensus _: (() ⇒ Consensus)).expects().returns(consensus).anyNumberOfTimes()
+    (ledger.consensus _: (() => Consensus)).expects().returns(consensus).anyNumberOfTimes()
 
     (blockGenerator.generateBlock _).expects(parentBlock, Nil, *, *).returning(Right(PendingBlock(block, Nil)))
     blockchain.save(parentBlock, Nil, parentBlock.header.difficulty, true)
@@ -434,7 +434,7 @@ class EthServiceSpec
   }
 
   it should "accept submitted correct PoW" in new TestSetup {
-    (ledger.consensus _: (() ⇒ Consensus)).expects().returns(consensus)
+    (ledger.consensus _: (() => Consensus)).expects().returns(consensus)
 
     val headerHash = ByteString(Hex.decode("01" * 32))
 
@@ -448,7 +448,7 @@ class EthServiceSpec
   }
 
   it should "reject submitted correct PoW when header is no longer in cache" in new TestSetup {
-    (ledger.consensus _: (() ⇒ Consensus)).expects().returns(consensus)
+    (ledger.consensus _: (() => Consensus)).expects().returns(consensus)
 
     val headerHash = ByteString(Hex.decode("01" * 32))
 
@@ -573,7 +573,7 @@ class EthServiceSpec
   }
 
   it should "accept and report hashrate" in new TestSetup {
-    (ledger.consensus _: (() ⇒ Consensus)).expects().returns(consensus).anyNumberOfTimes()
+    (ledger.consensus _: (() => Consensus)).expects().returns(consensus).anyNumberOfTimes()
 
     val rate: BigInt = 42
     val id = ByteString("id")
@@ -588,7 +588,7 @@ class EthServiceSpec
   }
 
   it should "combine hashrates from many miners and remove timed out rates" in new TestSetup {
-    (ledger.consensus _: (() ⇒ Consensus)).expects().returns(consensus).anyNumberOfTimes()
+    (ledger.consensus _: (() => Consensus)).expects().returns(consensus).anyNumberOfTimes()
 
     val rate: BigInt = 42
     val id1 = ByteString("id1")
@@ -611,7 +611,7 @@ class EthServiceSpec
   }
 
   it should "return if node is mining base on getWork" in new TestSetup {
-    (ledger.consensus _: (() ⇒ Consensus)).expects().returns(consensus).anyNumberOfTimes()
+    (ledger.consensus _: (() => Consensus)).expects().returns(consensus).anyNumberOfTimes()
 
     ethService.getMining(GetMiningRequest()).futureValue shouldEqual Right(GetMiningResponse(false))
 
@@ -625,7 +625,7 @@ class EthServiceSpec
   }
 
   it should "return if node is mining base on submitWork" in new TestSetup {
-    (ledger.consensus _: (() ⇒ Consensus)).expects().returns(consensus).anyNumberOfTimes()
+    (ledger.consensus _: (() => Consensus)).expects().returns(consensus).anyNumberOfTimes()
 
     ethService.getMining(GetMiningRequest()).futureValue shouldEqual Right(GetMiningResponse(false))
 
@@ -641,7 +641,7 @@ class EthServiceSpec
   }
 
   it should "return if node is mining base on submitHashRate" in new TestSetup {
-    (ledger.consensus _: (() ⇒ Consensus)).expects().returns(consensus).anyNumberOfTimes()
+    (ledger.consensus _: (() => Consensus)).expects().returns(consensus).anyNumberOfTimes()
 
     ethService.getMining(GetMiningRequest()).futureValue shouldEqual Right(GetMiningResponse(false))
 
@@ -653,7 +653,7 @@ class EthServiceSpec
   }
 
   it should "return if node is mining after time out" in new TestSetup {
-    (ledger.consensus _: (() ⇒ Consensus)).expects().returns(consensus).anyNumberOfTimes()
+    (ledger.consensus _: (() => Consensus)).expects().returns(consensus).anyNumberOfTimes()
 
     (blockGenerator.generateBlock _).expects(parentBlock, *, *, *).returning(Right(PendingBlock(block, Nil)))
     blockchain.storeBlock(parentBlock).commit()
@@ -667,7 +667,7 @@ class EthServiceSpec
   }
 
   it should "return correct coinbase" in new TestSetup {
-    (ledger.consensus _: (() ⇒ Consensus)).expects().returns(consensus)
+    (ledger.consensus _: (() => Consensus)).expects().returns(consensus)
 
     val response = ethService.getCoinbase(GetCoinbaseRequest())
     response.futureValue shouldEqual Right(GetCoinbaseResponse(consensusConfig.coinbase))
@@ -807,7 +807,7 @@ class EthServiceSpec
   }
 
   it should "handle get transaction by hash if the tx is not on the blockchain and not in the tx pool" in new TestSetup {
-    (ledger.consensus _: (() ⇒ Consensus)).expects().returns(consensus)
+    (ledger.consensus _: (() => Consensus)).expects().returns(consensus)
 
     val request = GetTransactionByHashRequest(txToRequestHash)
     val response = ethService.getTransactionByHash(request)
@@ -819,7 +819,7 @@ class EthServiceSpec
   }
 
   it should "handle get transaction by hash if the tx is still pending" in new TestSetup {
-    (ledger.consensus _: (() ⇒ Consensus)).expects().returns(consensus)
+    (ledger.consensus _: (() => Consensus)).expects().returns(consensus)
 
     val request = GetTransactionByHashRequest(txToRequestHash)
     val response = ethService.getTransactionByHash(request)
@@ -833,7 +833,7 @@ class EthServiceSpec
   }
 
   it should "handle get transaction by hash if the tx was already executed" in new TestSetup {
-    (ledger.consensus _: (() ⇒ Consensus)).expects().returns(consensus)
+    (ledger.consensus _: (() => Consensus)).expects().returns(consensus)
 
     val blockWithTx = Block(Fixtures.Blocks.Block3125369.header, Fixtures.Blocks.Block3125369.body)
     blockchain.storeBlock(blockWithTx).commit()
@@ -896,7 +896,7 @@ class EthServiceSpec
   }
 
   it should "return account recent transactions in newest -> oldest order" in new TestSetup {
-    (ledger.consensus _: (() ⇒ Consensus)).expects().returns(consensus)
+    (ledger.consensus _: (() => Consensus)).expects().returns(consensus)
 
     val address = Address("0xee4439beb5c71513b080bbf9393441697a29f478")
 
@@ -945,7 +945,7 @@ class EthServiceSpec
   }
 
   it should "not return account recent transactions from older blocks and return pending txs" in new TestSetup {
-    (ledger.consensus _: (() ⇒ Consensus)).expects().returns(consensus)
+    (ledger.consensus _: (() => Consensus)).expects().returns(consensus)
 
     val blockWithTx = Block(Fixtures.Blocks.Block3125369.header, Fixtures.Blocks.Block3125369.body)
     blockchain.storeBlock(blockWithTx).commit()

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerSpec.scala
@@ -600,12 +600,12 @@ class JsonRpcControllerSpec
 
   it should "eth_getWork" in new TestSetup {
     // Just record the fact that this is going to be called, we do not care about the returned value
-    (validators.signedTransactionValidator _: (() ⇒ SignedTransactionValidator))
+    (validators.signedTransactionValidator _: (() => SignedTransactionValidator))
       .expects()
       .returns(null)
       .anyNumberOfTimes()
 
-    (ledger.consensus _: (() ⇒ Consensus)).expects().returns(consensus).anyNumberOfTimes()
+    (ledger.consensus _: (() => Consensus)).expects().returns(consensus).anyNumberOfTimes()
 
     val seed = s"""0x${"00" * 32}"""
     val target = "0x1999999999999999999999999999999999999999999999999999999999999999"
@@ -648,12 +648,12 @@ class JsonRpcControllerSpec
 
   it should "eth_getWork when fail to get ommers and transactions" in new TestSetup {
     // Just record the fact that this is going to be called, we do not care about the returned value
-    (validators.signedTransactionValidator _: (() ⇒ SignedTransactionValidator))
+    (validators.signedTransactionValidator _: (() => SignedTransactionValidator))
       .expects()
       .returns(null)
       .anyNumberOfTimes()
 
-    (ledger.consensus _: (() ⇒ Consensus)).expects().returns(consensus).anyNumberOfTimes()
+    (ledger.consensus _: (() => Consensus)).expects().returns(consensus).anyNumberOfTimes()
 
     val seed = s"""0x${"00" * 32}"""
     val target = "0x1999999999999999999999999999999999999999999999999999999999999999"
@@ -694,12 +694,12 @@ class JsonRpcControllerSpec
 
   it should "eth_submitWork" in new TestSetup {
     // Just record the fact that this is going to be called, we do not care about the returned value
-    (validators.signedTransactionValidator _: (() ⇒ SignedTransactionValidator))
+    (validators.signedTransactionValidator _: (() => SignedTransactionValidator))
       .expects()
       .returns(null)
       .anyNumberOfTimes()
 
-    (ledger.consensus _: (() ⇒ Consensus)).expects().returns(consensus).anyNumberOfTimes()
+    (ledger.consensus _: (() => Consensus)).expects().returns(consensus).anyNumberOfTimes()
 
     val nonce = s"0x0000000000000001"
     val mixHash = s"""0x${"01" * 32}"""
@@ -734,12 +734,12 @@ class JsonRpcControllerSpec
 
   it should "eth_submitHashrate" in new TestSetup {
     // Just record the fact that this is going to be called, we do not care about the returned value
-    (validators.signedTransactionValidator _: (() ⇒ SignedTransactionValidator))
+    (validators.signedTransactionValidator _: (() => SignedTransactionValidator))
       .expects()
       .returns(null)
       .anyNumberOfTimes()
 
-    (ledger.consensus _: (() ⇒ Consensus)).expects().returns(consensus).anyNumberOfTimes()
+    (ledger.consensus _: (() => Consensus)).expects().returns(consensus).anyNumberOfTimes()
 
     val request: JsonRpcRequest = JsonRpcRequest(
       "2.0",
@@ -764,12 +764,12 @@ class JsonRpcControllerSpec
 
   it should "eth_hashrate" in new TestSetup {
     // Just record the fact that this is going to be called, we do not care about the returned value
-    (validators.signedTransactionValidator _: (() ⇒ SignedTransactionValidator))
+    (validators.signedTransactionValidator _: (() => SignedTransactionValidator))
       .expects()
       .returns(null)
       .anyNumberOfTimes()
 
-    (ledger.consensus _: (() ⇒ Consensus)).expects().returns(consensus).anyNumberOfTimes()
+    (ledger.consensus _: (() => Consensus)).expects().returns(consensus).anyNumberOfTimes()
 
     val request: JsonRpcRequest = JsonRpcRequest(
       "2.0",
@@ -1044,12 +1044,12 @@ class JsonRpcControllerSpec
 
   it should "eth_coinbase " in new TestSetup {
     // Just record the fact that this is going to be called, we do not care about the returned value
-    (validators.signedTransactionValidator _: (() ⇒ SignedTransactionValidator))
+    (validators.signedTransactionValidator _: (() => SignedTransactionValidator))
       .expects()
       .returns(null)
       .anyNumberOfTimes()
 
-    (ledger.consensus _: (() ⇒ Consensus)).expects().returns(consensus).anyNumberOfTimes()
+    (ledger.consensus _: (() => Consensus)).expects().returns(consensus).anyNumberOfTimes()
 
     val request: JsonRpcRequest = JsonRpcRequest(
       "2.0",


### PR DESCRIPTION
# Description

After switching to Scala 2.13 there are many errors. Fixing some is tricky. I want to start from the low-risk ones.
This PR fix errors caused by the usage of Unicode symbol ⇒

# Proposed Solution

replace ⇒ to =>

# Important Changes Introduced

# Testing