### PR TITLE
[ETCM-402] Decode messages with the correct protocol version

### DIFF
--- a/src/benchmark/scala/io/iohk/ethereum/rlp/RLPSpeedSuite.scala
+++ b/src/benchmark/scala/io/iohk/ethereum/rlp/RLPSpeedSuite.scala
@@ -4,7 +4,7 @@ import akka.util.ByteString
 import io.iohk.ethereum.ObjectGenerators
 import io.iohk.ethereum.domain.Block._
 import io.iohk.ethereum.domain._
-import io.iohk.ethereum.network.p2p.messages.CommonMessages.SignedTransactions._
+import io.iohk.ethereum.network.p2p.messages.PV60.SignedTransactions._
 import io.iohk.ethereum.utils.Logger
 import io.iohk.ethereum.utils.Hex
 import org.scalacheck.Gen

--- a/src/ets/scala/io/iohk/ethereum/ets/blockchain/BlockchainTestConfig.scala
+++ b/src/ets/scala/io/iohk/ethereum/ets/blockchain/BlockchainTestConfig.scala
@@ -30,6 +30,7 @@ object BlockchainTestConfig {
     difficultyBombRemovalBlockNumber = 5900000,
     chainId = 0x1.toByte,
     networkId = 1,
+    protocolVersion = 63,
     customGenesisFileOpt = Some("test-genesis.json"),
     monetaryPolicyConfig =
       MonetaryPolicyConfig(5000000, 0.2, BigInt("5000000000000000000"), BigInt("3000000000000000000")),

--- a/src/it/scala/io/iohk/ethereum/txExecTest/ECIP1017Test.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/ECIP1017Test.scala
@@ -22,6 +22,7 @@ class ECIP1017Test extends AnyFlatSpec with Matchers {
       maxCodeSize = None,
       chainId = 0x3d.toByte,
       networkId = 1,
+      protocolVersion = 63,
       frontierBlockNumber = 0,
       homesteadBlockNumber = 1150000,
       eip106BlockNumber = Long.MaxValue,

--- a/src/it/scala/io/iohk/ethereum/txExecTest/ForksTest.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/ForksTest.scala
@@ -27,6 +27,7 @@ class ForksTest extends AnyFlatSpec with Matchers {
       // unused
       bootstrapNodes = Set(),
       networkId = 1,
+      protocolVersion = 63,
       maxCodeSize = None,
       eip161BlockNumber = Long.MaxValue,
       customGenesisFileOpt = None,

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -34,11 +34,6 @@ mantis {
   }
 
   network {
-    # Ethereum protocol version
-    # Supported versions:
-    # 63, 64 (experimental version which enables usage of messages with checkpointing information. In the future after ETCM-355, ETCM-356, it will be 66 probably)
-    protocol-version = 63
-
     server-address {
       # Listening interface for Ethereum protocol connections
       interface = "0.0.0.0"

--- a/src/main/resources/chains/etc-chain.conf
+++ b/src/main/resources/chains/etc-chain.conf
@@ -3,6 +3,11 @@
   # 1 - mainnet, 3 - ropsten, 7 - mordor
   network-id = 1
 
+  # Ethereum protocol version
+  # Supported versions:
+  # 63, 64 (experimental version which enables usage of messages with checkpointing information. In the future after ETCM-355, ETCM-356, it will be 66 probably)
+  network.protocol-version = 63
+
   # Possibility to set Proof of Work target time for testing purposes.
   # null means that the standard difficulty calculation rules are used
   pow-target-time = null

--- a/src/main/resources/chains/eth-chain.conf
+++ b/src/main/resources/chains/eth-chain.conf
@@ -3,6 +3,11 @@
   # 1 - mainnet, 3 - ropsten, 7 - mordor
   network-id = 1
 
+  # Ethereum protocol version
+  # Supported versions:
+  # 63, 64 (experimental version which enables usage of messages with checkpointing information. In the future after ETCM-355, ETCM-356, it will be 66 probably)
+  network.protocol-version = 63
+
   # Possibility to set Proof of Work target time for testing purposes.
   # null means that the standard difficulty calculation rules are used
   pow-target-time = null

--- a/src/main/resources/chains/mordor-chain.conf
+++ b/src/main/resources/chains/mordor-chain.conf
@@ -3,6 +3,11 @@
   # 1 - mainnet, 3 - ropsten, 7 - mordor
   network-id = 7
 
+  # Ethereum protocol version
+  # Supported versions:
+  # 63, 64 (experimental version which enables usage of messages with checkpointing information. In the future after ETCM-355, ETCM-356, it will be 66 probably)
+  network.protocol-version = 63
+
   # Possibility to set Proof of Work target time for testing purposes.
   # null means that the standard difficulty calculation rules are used
   pow-target-time = null

--- a/src/main/resources/chains/ropsten-chain.conf
+++ b/src/main/resources/chains/ropsten-chain.conf
@@ -3,6 +3,11 @@
   # 1 - mainnet, 3 - ropsten, 7 - mordor
   network-id = 3
 
+  # Ethereum protocol version
+  # Supported versions:
+  # 63, 64 (experimental version which enables usage of messages with checkpointing information. In the future after ETCM-355, ETCM-356, it will be 66 probably)
+  network.protocol-version = 63
+
   # Possibility to set Proof of Work target time for testing purposes.
   # null means that the standard difficulty calculation rules are used
   pow-target-time = null

--- a/src/main/resources/chains/test-chain.conf
+++ b/src/main/resources/chains/test-chain.conf
@@ -3,6 +3,11 @@
   # 1 - mainnet, 7 - mordor
   network-id = 1
 
+  # Ethereum protocol version
+  # Supported versions:
+  # 63, 64 (experimental version which enables usage of messages with checkpointing information. In the future after ETCM-355, ETCM-356, it will be 66 probably)
+  network.protocol-version = 63
+
   # Possibility to set Proof of Work target time for testing purposes.
   # null means that the standard difficulty calculation rules are used
   pow-target-time = null

--- a/src/main/resources/chains/testnet-internal-gac-chain.conf
+++ b/src/main/resources/chains/testnet-internal-gac-chain.conf
@@ -3,6 +3,11 @@
     # 1 - mainnet, 3 - ropsten, 7 - mordor
     network-id = 42
 
+    # Ethereum protocol version
+    # Supported versions:
+    # 63, 64 (experimental version which enables usage of messages with checkpointing information. In the future after ETCM-355, ETCM-356, it will be 66 probably)
+    network.protocol-version = 63
+
     # Possibility to set Proof of Work target time for testing purposes.
     # null means that the standard difficulty calculation rules are used
     pow-target-time = null

--- a/src/main/resources/chains/testnet-internal-nomad-chain.conf
+++ b/src/main/resources/chains/testnet-internal-nomad-chain.conf
@@ -3,6 +3,11 @@
     # 1 - mainnet, 3 - ropsten, 7 - mordor
     network-id = 42
 
+    # Ethereum protocol version
+    # Supported versions:
+    # 63, 64 (experimental version which enables usage of messages with checkpointing information. In the future after ETCM-355, ETCM-356, it will be 66 probably)
+    network.protocol-version = 63
+
     # Possibility to set Proof of Work target time for testing purposes.
     # null means that the standard difficulty calculation rules are used
     pow-target-time = 30 seconds

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/regular/BlockBroadcast.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/regular/BlockBroadcast.scala
@@ -6,7 +6,7 @@ import io.iohk.ethereum.domain.{Block, ChainWeight}
 import io.iohk.ethereum.network.EtcPeerManagerActor.PeerInfo
 import io.iohk.ethereum.network.p2p.MessageSerializable
 import io.iohk.ethereum.network.p2p.messages.PV62.BlockHash
-import io.iohk.ethereum.network.p2p.messages.{CommonMessages, PV62, PV64, ProtocolVersions}
+import io.iohk.ethereum.network.p2p.messages.{PV60, PV62, PV64, ProtocolVersions}
 import io.iohk.ethereum.network.{EtcPeerManagerActor, Peer}
 
 import scala.util.Random
@@ -71,7 +71,7 @@ object BlockBroadcast {
     * (they are different versions of NewBlock msg)
     */
   case class BlockToBroadcast(block: Block, chainWeight: ChainWeight) {
-    def as63: CommonMessages.NewBlock = CommonMessages.NewBlock(block, chainWeight.totalDifficulty)
+    def as63: PV60.NewBlock = PV60.NewBlock(block, chainWeight.totalDifficulty)
     def as64: PV64.NewBlock = PV64.NewBlock(block, chainWeight)
   }
 }

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/regular/BlockFetcher.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/regular/BlockFetcher.scala
@@ -21,7 +21,7 @@ import io.iohk.ethereum.network.PeerEventBusActor.PeerEvent.MessageFromPeer
 import io.iohk.ethereum.network.PeerEventBusActor.SubscriptionClassifier.MessageClassifier
 import io.iohk.ethereum.network.PeerEventBusActor.{PeerSelector, Subscribe, Unsubscribe}
 import io.iohk.ethereum.network.PeerId
-import io.iohk.ethereum.network.p2p.messages.{Codes, CommonMessages, PV64}
+import io.iohk.ethereum.network.p2p.messages.{Codes, PV60, PV64}
 import io.iohk.ethereum.network.p2p.messages.PV62._
 import io.iohk.ethereum.network.p2p.messages.PV63.{GetNodeData, NodeData}
 import io.iohk.ethereum.utils.ByteStringUtils
@@ -197,7 +197,8 @@ class BlockFetcher(
       }
       supervisor ! ProgressProtocol.GotNewBlock(newState.knownTop)
       fetchBlocks(newState)
-    case MessageFromPeer(CommonMessages.NewBlock(block, _), peerId) =>
+    // Remember to always add match for every new version of NewBlock message
+    case MessageFromPeer(PV60.NewBlock(block, _), peerId) =>
       handleNewBlock(block, peerId, state)
     case MessageFromPeer(PV64.NewBlock(block, _), peerId) =>
       handleNewBlock(block, peerId, state)

--- a/src/main/scala/io/iohk/ethereum/domain/Block.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/Block.scala
@@ -29,7 +29,7 @@ case class Block(header: BlockHeader, body: BlockBody) {
 object Block {
 
   implicit class BlockEnc(val obj: Block) extends RLPSerializable {
-    import io.iohk.ethereum.network.p2p.messages.CommonMessages.SignedTransactions._
+    import io.iohk.ethereum.network.p2p.messages.PV60.SignedTransactions._
 
     override def toRLPEncodable: RLPEncodeable = RLPList(
       obj.header.toRLPEncodable,
@@ -39,7 +39,7 @@ object Block {
   }
 
   implicit class BlockDec(val bytes: Array[Byte]) extends AnyVal {
-    import io.iohk.ethereum.network.p2p.messages.CommonMessages.SignedTransactions._
+    import io.iohk.ethereum.network.p2p.messages.PV60.SignedTransactions._
     def toBlock: Block = rawDecode(bytes) match {
       case RLPList(header: RLPList, stx: RLPList, uncles: RLPList) =>
         Block(

--- a/src/main/scala/io/iohk/ethereum/domain/BlockBody.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/BlockBody.scala
@@ -31,7 +31,7 @@ object BlockBody {
 
   implicit class BlockBodyEnc(msg: BlockBody) extends RLPSerializable {
     override def toRLPEncodable: RLPEncodeable = {
-      import io.iohk.ethereum.network.p2p.messages.CommonMessages.SignedTransactions._
+      import io.iohk.ethereum.network.p2p.messages.PV60.SignedTransactions._
 
       blockBodyToRlpEncodable(
         msg,
@@ -61,7 +61,7 @@ object BlockBody {
 
   implicit class BlockBodyRLPEncodableDec(val rlpEncodeable: RLPEncodeable) {
     def toBlockBody: BlockBody = {
-      import io.iohk.ethereum.network.p2p.messages.CommonMessages.SignedTransactions._
+      import io.iohk.ethereum.network.p2p.messages.PV60.SignedTransactions._
 
       rlpEncodableToBlockBody(
         rlpEncodeable,

--- a/src/main/scala/io/iohk/ethereum/domain/SignedTransaction.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/SignedTransaction.scala
@@ -5,16 +5,17 @@ import com.google.common.cache.{Cache, CacheBuilder}
 import io.iohk.ethereum.crypto
 import io.iohk.ethereum.crypto.{ECDSASignature, kec256}
 import io.iohk.ethereum.mpt.ByteArraySerializable
-import io.iohk.ethereum.network.p2p.messages.CommonMessages.SignedTransactions._
+import io.iohk.ethereum.network.p2p.messages.PV60.SignedTransactions._
 import io.iohk.ethereum.rlp.RLPImplicitConversions._
 import io.iohk.ethereum.rlp.RLPImplicits._
 import io.iohk.ethereum.rlp.{encode => rlpEncode, _}
-import java.math.BigInteger
-import java.util.concurrent.Executors
 import monix.eval.Task
 import monix.execution.Scheduler
 import org.bouncycastle.crypto.AsymmetricCipherKeyPair
 import org.bouncycastle.util.encoders.Hex
+
+import java.math.BigInteger
+import java.util.concurrent.Executors
 import scala.util.Try
 
 object SignedTransaction {

--- a/src/main/scala/io/iohk/ethereum/faucet/jsonrpc/WalletService.scala
+++ b/src/main/scala/io/iohk/ethereum/faucet/jsonrpc/WalletService.scala
@@ -7,7 +7,7 @@ import io.iohk.ethereum.faucet.FaucetConfig
 import io.iohk.ethereum.jsonrpc.client.RpcClient.RpcError
 import io.iohk.ethereum.keystore.KeyStore.KeyStoreError
 import io.iohk.ethereum.keystore.{KeyStore, Wallet}
-import io.iohk.ethereum.network.p2p.messages.CommonMessages.SignedTransactions.SignedTransactionEnc
+import io.iohk.ethereum.network.p2p.messages.PV60.SignedTransactions.SignedTransactionEnc
 import io.iohk.ethereum.rlp
 import io.iohk.ethereum.utils.{ByteStringUtils, Logger}
 import monix.eval.Task

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/EthTxService.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/EthTxService.scala
@@ -168,7 +168,7 @@ class EthTxService(
   }
 
   def sendRawTransaction(req: SendRawTransactionRequest): ServiceResponse[SendRawTransactionResponse] = {
-    import io.iohk.ethereum.network.p2p.messages.CommonMessages.SignedTransactions.SignedTransactionDec
+    import io.iohk.ethereum.network.p2p.messages.PV60.SignedTransactions.SignedTransactionDec
 
     Try(req.data.toArray.toSignedTransaction) match {
       case Success(signedTransaction) =>

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/RawTransactionCodec.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/RawTransactionCodec.scala
@@ -2,7 +2,7 @@ package io.iohk.ethereum.jsonrpc
 
 import akka.util.ByteString
 import io.iohk.ethereum.domain.SignedTransaction
-import io.iohk.ethereum.network.p2p.messages.CommonMessages.SignedTransactions.SignedTransactionEnc
+import io.iohk.ethereum.network.p2p.messages.PV60.SignedTransactions.SignedTransactionEnc
 import io.iohk.ethereum.rlp
 
 object RawTransactionCodec {

--- a/src/main/scala/io/iohk/ethereum/network/EtcPeerManagerActor.scala
+++ b/src/main/scala/io/iohk/ethereum/network/EtcPeerManagerActor.scala
@@ -13,7 +13,7 @@ import io.iohk.ethereum.network.handshaker.Handshaker.HandshakeResult
 import io.iohk.ethereum.network.p2p.messages.PV62.{BlockHeaders, GetBlockHeaders, NewBlockHashes}
 import io.iohk.ethereum.network.p2p.messages.PV64.NewBlock
 import io.iohk.ethereum.network.p2p.messages.WireProtocol.Disconnect
-import io.iohk.ethereum.network.p2p.messages.{Codes, CommonMessages, PV64}
+import io.iohk.ethereum.network.p2p.messages.{Codes, PV60, PV64}
 import io.iohk.ethereum.network.p2p.{Message, MessageSerializable}
 import io.iohk.ethereum.utils.ByteStringUtils
 
@@ -159,7 +159,7 @@ class EtcPeerManagerActor(
     */
   private def updateChainWeight(message: Message)(initialPeerInfo: PeerInfo): PeerInfo =
     message match {
-      case newBlock: CommonMessages.NewBlock =>
+      case newBlock: PV60.NewBlock =>
         initialPeerInfo.copy(chainWeight = ChainWeight.totalDifficultyOnly(newBlock.totalDifficulty))
       case newBlock: PV64.NewBlock => initialPeerInfo.copy(chainWeight = newBlock.chainWeight)
       case _ => initialPeerInfo
@@ -220,7 +220,7 @@ class EtcPeerManagerActor(
     message match {
       case m: BlockHeaders =>
         update(m.headers.map(header => (header.number, header.hash)))
-      case m: CommonMessages.NewBlock =>
+      case m: PV60.NewBlock =>
         update(Seq((m.block.header.number, m.block.header.hash)))
       case m: NewBlock =>
         update(Seq((m.block.header.number, m.block.header.hash)))
@@ -263,7 +263,7 @@ object EtcPeerManagerActor {
       RemoteStatus(status.protocolVersion, status.networkId, status.chainWeight, status.bestHash, status.genesisHash)
     }
 
-    def apply(status: CommonMessages.Status): RemoteStatus = {
+    def apply(status: PV60.Status): RemoteStatus = {
       RemoteStatus(
         status.protocolVersion,
         status.networkId,

--- a/src/main/scala/io/iohk/ethereum/network/PeerActor.scala
+++ b/src/main/scala/io/iohk/ethereum/network/PeerActor.scala
@@ -12,8 +12,8 @@ import io.iohk.ethereum.network.PeerManagerActor.PeerConfiguration
 import io.iohk.ethereum.network.handshaker.Handshaker
 import io.iohk.ethereum.network.handshaker.Handshaker.HandshakeComplete.{HandshakeFailure, HandshakeSuccess}
 import io.iohk.ethereum.network.handshaker.Handshaker.{HandshakeResult, NextMessage}
-import io.iohk.ethereum.network.p2p.Message.Version
 import io.iohk.ethereum.network.p2p._
+import io.iohk.ethereum.network.p2p.messages.ProtocolNegotiator
 import io.iohk.ethereum.network.p2p.messages.WireProtocol._
 import io.iohk.ethereum.network.rlpx.RLPxConnectionHandler.RLPxConfiguration
 import io.iohk.ethereum.network.rlpx.{AuthHandshaker, RLPxConnectionHandler}
@@ -304,12 +304,12 @@ object PeerActor {
       handshaker: Handshaker[R],
       authHandshaker: AuthHandshaker,
       messageDecoder: MessageDecoder,
-      bestProtocolVersion: Version
+      protocolNegotiator: ProtocolNegotiator
   ): Props =
     Props(
       new PeerActor(
         peerAddress,
-        rlpxConnectionFactory(authHandshaker, messageDecoder, peerConfiguration.rlpxConfiguration, bestProtocolVersion),
+        rlpxConnectionFactory(authHandshaker, messageDecoder, peerConfiguration.rlpxConfiguration, protocolNegotiator),
         peerConfiguration,
         peerEventBus,
         knownNodesManager,
@@ -323,11 +323,11 @@ object PeerActor {
       authHandshaker: AuthHandshaker,
       messageDecoder: MessageDecoder,
       rlpxConfiguration: RLPxConfiguration,
-      bestProtocolVersion: Version
+      protocolNegotiator: ProtocolNegotiator
   ): ActorContext => ActorRef = { ctx =>
     ctx.actorOf(
       RLPxConnectionHandler
-        .props(NetworkMessageDecoder orElse messageDecoder, bestProtocolVersion, authHandshaker, rlpxConfiguration),
+        .props(NetworkMessageDecoder orElse messageDecoder, protocolNegotiator, authHandshaker, rlpxConfiguration),
       "rlpx-connection"
     )
   }

--- a/src/main/scala/io/iohk/ethereum/network/PeerManagerActor.scala
+++ b/src/main/scala/io/iohk/ethereum/network/PeerManagerActor.scala
@@ -13,7 +13,7 @@ import io.iohk.ethereum.network.PeerManagerActor.PeerConfiguration
 import io.iohk.ethereum.network.discovery.{DiscoveryConfig, Node, PeerDiscoveryManager}
 import io.iohk.ethereum.network.handshaker.Handshaker
 import io.iohk.ethereum.network.handshaker.Handshaker.HandshakeResult
-import io.iohk.ethereum.network.p2p.Message.Version
+import io.iohk.ethereum.network.p2p.messages.ProtocolNegotiator
 import io.iohk.ethereum.network.p2p.messages.WireProtocol.Disconnect
 import io.iohk.ethereum.network.p2p.{MessageDecoder, MessageSerializable}
 import io.iohk.ethereum.network.rlpx.AuthHandshaker
@@ -411,7 +411,7 @@ object PeerManagerActor {
       authHandshaker: AuthHandshaker,
       messageDecoder: MessageDecoder,
       discoveryConfig: DiscoveryConfig,
-      bestProtocolVersion: Version
+      protocolNegotiator: ProtocolNegotiator
   ): Props = {
     val factory: (ActorContext, InetSocketAddress, Boolean) => ActorRef =
       peerFactory(
@@ -421,7 +421,7 @@ object PeerManagerActor {
         handshaker,
         authHandshaker,
         messageDecoder,
-        bestProtocolVersion
+        protocolNegotiator
       )
 
     Props(
@@ -445,7 +445,7 @@ object PeerManagerActor {
       handshaker: Handshaker[R],
       authHandshaker: AuthHandshaker,
       messageDecoder: MessageDecoder,
-      bestProtocolVersion: Version
+      protocolNegotiator: ProtocolNegotiator
   ): (ActorContext, InetSocketAddress, Boolean) => ActorRef = { (ctx, address, incomingConnection) =>
     val id: String = address.toString.filterNot(_ == '/')
     val props = PeerActor.props(
@@ -457,7 +457,7 @@ object PeerManagerActor {
       handshaker,
       authHandshaker,
       messageDecoder,
-      bestProtocolVersion
+      protocolNegotiator
     )
     ctx.actorOf(props, id)
   }

--- a/src/main/scala/io/iohk/ethereum/network/handshaker/EtcHandshaker.scala
+++ b/src/main/scala/io/iohk/ethereum/network/handshaker/EtcHandshaker.scala
@@ -7,6 +7,8 @@ import io.iohk.ethereum.domain.Blockchain
 import io.iohk.ethereum.network.EtcPeerManagerActor.PeerInfo
 import io.iohk.ethereum.network.ForkResolver
 import io.iohk.ethereum.network.PeerManagerActor.PeerConfiguration
+import io.iohk.ethereum.network.p2p.Message.Version
+import io.iohk.ethereum.network.p2p.messages.ProtocolNegotiator
 import io.iohk.ethereum.utils.NodeStatus
 
 case class EtcHandshaker private (
@@ -22,8 +24,11 @@ case class EtcHandshaker private (
 
 object EtcHandshaker {
 
-  def apply(handshakerConfiguration: EtcHandshakerConfiguration): EtcHandshaker = {
-    val initialState = EtcHelloExchangeState(handshakerConfiguration)
+  def apply(
+      handshakerConfiguration: EtcHandshakerConfiguration,
+      protocolNegotiator: ProtocolNegotiator
+  ): EtcHandshaker = {
+    val initialState = EtcHelloExchangeState(handshakerConfiguration, protocolNegotiator)
     EtcHandshaker(initialState, handshakerConfiguration)
   }
 
@@ -35,5 +40,5 @@ trait EtcHandshakerConfiguration {
   val appStateStorage: AppStateStorage
   val peerConfiguration: PeerConfiguration
   val forkResolverOpt: Option[ForkResolver]
-  val protocolVersion: Int
+  val protocolVersion: Version
 }

--- a/src/main/scala/io/iohk/ethereum/network/handshaker/EtcHelloExchangeState.scala
+++ b/src/main/scala/io/iohk/ethereum/network/handshaker/EtcHelloExchangeState.scala
@@ -4,14 +4,14 @@ import akka.util.ByteString
 import io.iohk.ethereum.network.EtcPeerManagerActor.PeerInfo
 import io.iohk.ethereum.network.handshaker.Handshaker.NextMessage
 import io.iohk.ethereum.network.p2p.Message
-import io.iohk.ethereum.network.p2p.messages.Capability.Capabilities
-import io.iohk.ethereum.network.p2p.messages.Capability.Capabilities._
-import io.iohk.ethereum.network.p2p.messages.ProtocolVersions
+import io.iohk.ethereum.network.p2p.messages.{ProtocolNegotiator, ProtocolVersions}
 import io.iohk.ethereum.network.p2p.messages.WireProtocol.{Disconnect, Hello}
 import io.iohk.ethereum.utils.{Config, Logger, ServerStatus}
 
-case class EtcHelloExchangeState(handshakerConfiguration: EtcHandshakerConfiguration)
-    extends InProgressState[PeerInfo]
+case class EtcHelloExchangeState(
+    handshakerConfiguration: EtcHandshakerConfiguration,
+    protocolNegotiator: ProtocolNegotiator
+) extends InProgressState[PeerInfo]
     with Logger {
 
   import handshakerConfiguration._
@@ -26,19 +26,17 @@ case class EtcHelloExchangeState(handshakerConfiguration: EtcHandshakerConfigura
 
   override def applyResponseMessage: PartialFunction[Message, HandshakerState[PeerInfo]] = { case hello: Hello =>
     log.debug("Protocol handshake finished with peer ({})", hello)
-    if (
-      handshakerConfiguration.protocolVersion == ProtocolVersions.PV64 && hello.capabilities.contains(Etc64Capability)
-    )
-      EtcNodeStatus64ExchangeState(handshakerConfiguration)
-    else if (hello.capabilities.contains(Eth63Capability))
-      EtcNodeStatus63ExchangeState(handshakerConfiguration)
-    else {
-      log.debug(
-        s"Connected peer does not support eth ${ProtocolVersions.PV63.toByte} / ${ProtocolVersions.PV64.toByte} protocol. Disconnecting."
-      )
-      DisconnectedState(Disconnect.Reasons.IncompatibleP2pProtocolVersion)
+    protocolNegotiator.negotiate(hello.capabilities) match {
+      case Some(ProtocolVersions.PV64) =>
+        EtcNodeStatus64ExchangeState(handshakerConfiguration)
+      case Some(ProtocolVersions.PV63) =>
+        EtcNodeStatus60ExchangeState(handshakerConfiguration)
+      case _ =>
+        log.debug(
+          s"Connected peer does not support any of eth ${protocolNegotiator.capabilities.map(_.version).mkString("/")} protocol. Disconnecting."
+        )
+        DisconnectedState(Disconnect.Reasons.IncompatibleP2pProtocolVersion)
     }
-
   }
 
   override def processTimeout: HandshakerState[PeerInfo] = {
@@ -52,13 +50,11 @@ case class EtcHelloExchangeState(handshakerConfiguration: EtcHandshakerConfigura
       case ServerStatus.Listening(address) => address.getPort
       case ServerStatus.NotListening => 0
     }
-    val capabilities =
-      if (handshakerConfiguration.protocolVersion == ProtocolVersions.PV64) Capabilities.All else Seq(Eth63Capability)
 
     Hello(
       p2pVersion = EtcHelloExchangeState.P2pVersion,
       clientId = Config.clientId,
-      capabilities = capabilities,
+      capabilities = protocolNegotiator.capabilities,
       listenPort = listenPort,
       nodeId = ByteString(nodeStatus.nodeId)
     )

--- a/src/main/scala/io/iohk/ethereum/network/handshaker/EtcNodeStatus60ExchangeState.scala
+++ b/src/main/scala/io/iohk/ethereum/network/handshaker/EtcNodeStatus60ExchangeState.scala
@@ -1,25 +1,27 @@
 package io.iohk.ethereum.network.handshaker
 
 import io.iohk.ethereum.network.EtcPeerManagerActor.{PeerInfo, RemoteStatus}
-import io.iohk.ethereum.network.p2p.messages.{CommonMessages, ProtocolVersions}
+import io.iohk.ethereum.network.p2p.messages.{PV60, ProtocolVersions}
 import io.iohk.ethereum.network.p2p.{Message, MessageSerializable}
 
-case class EtcNodeStatus63ExchangeState(
+/*
+  It's used by 60-63 protocols
+ */
+case class EtcNodeStatus60ExchangeState(
     handshakerConfiguration: EtcHandshakerConfiguration
-) extends EtcNodeStatusExchangeState[CommonMessages.Status] {
+) extends EtcNodeStatusExchangeState[PV60.Status] {
 
   import handshakerConfiguration._
 
-  def applyResponseMessage: PartialFunction[Message, HandshakerState[PeerInfo]] = {
-    case status: CommonMessages.Status =>
-      applyRemoteStatusMessage(RemoteStatus(status))
+  def applyResponseMessage: PartialFunction[Message, HandshakerState[PeerInfo]] = { case status: PV60.Status =>
+    applyRemoteStatusMessage(RemoteStatus(status))
   }
 
   override protected def createStatusMsg(): MessageSerializable = {
     val bestBlockHeader = getBestBlockHeader()
     val chainWeight = blockchain.getChainWeightByHash(bestBlockHeader.hash).get
 
-    val status = CommonMessages.Status(
+    val status = PV60.Status(
       protocolVersion = ProtocolVersions.PV63,
       networkId = peerConfiguration.networkId,
       totalDifficulty = chainWeight.totalDifficulty,

--- a/src/main/scala/io/iohk/ethereum/network/p2p/MessageDecoders.scala
+++ b/src/main/scala/io/iohk/ethereum/network/p2p/MessageDecoders.scala
@@ -2,7 +2,7 @@ package io.iohk.ethereum.network.p2p
 
 import io.iohk.ethereum.network.p2p.Message.Version
 import io.iohk.ethereum.network.p2p.messages.Codes
-import io.iohk.ethereum.network.p2p.messages.CommonMessages.SignedTransactions._
+import io.iohk.ethereum.network.p2p.messages.PV60.SignedTransactions._
 import io.iohk.ethereum.network.p2p.messages.PV61.BlockHashesFromNumber._
 import io.iohk.ethereum.network.p2p.messages.PV62.BlockBodies._
 import io.iohk.ethereum.network.p2p.messages.PV62.BlockHeaders._
@@ -28,7 +28,7 @@ object NetworkMessageDecoder extends MessageDecoder {
       case Ping.code => payload.toPing
       case Pong.code => payload.toPong
       case Hello.code => payload.toHello
-      case _ => throw new RuntimeException(s"Unknown message type: ${msgCode}")
+      case _ => throw new RuntimeException("Unknown message type: " + msgCode)
     }
 
 }
@@ -46,13 +46,13 @@ object EthereumMessageDecoder extends MessageDecoder {
     }
   }
 
-  private def handleCommonMessages(msgCode: Int, payload: Array[Byte]): Message = {
+  private def handlePV60(msgCode: Int, payload: Array[Byte]): Message = {
     msgCode match {
       case Codes.StatusCode =>
-        import io.iohk.ethereum.network.p2p.messages.CommonMessages.Status._
+        import io.iohk.ethereum.network.p2p.messages.PV60.Status._
         payload.toStatus
       case Codes.NewBlockCode =>
-        import io.iohk.ethereum.network.p2p.messages.CommonMessages.NewBlock._
+        import io.iohk.ethereum.network.p2p.messages.PV60.NewBlock._
         payload.toNewBlock
       case Codes.SignedTransactionsCode =>
         payload.toSignedTransactions
@@ -68,7 +68,7 @@ object EthereumMessageDecoder extends MessageDecoder {
         payload.toNewBlockHashes
       case Codes.BlockHashesFromNumberCode =>
         payload.toBlockHashesFromNumber
-      case _ => handleCommonMessages(msgCode, payload)
+      case _ => handlePV60(msgCode, payload)
     }
   }
 
@@ -79,7 +79,7 @@ object EthereumMessageDecoder extends MessageDecoder {
       case Codes.BlockHeadersCode => payload.toBlockHeaders
       case Codes.GetBlockBodiesCode => payload.toGetBlockBodies
       case Codes.BlockBodiesCode => payload.toBlockBodies
-      case _ => handleCommonMessages(msgCode, payload)
+      case _ => handlePV60(msgCode, payload)
     }
   }
 

--- a/src/main/scala/io/iohk/ethereum/network/p2p/messages/PV60.scala
+++ b/src/main/scala/io/iohk/ethereum/network/p2p/messages/PV60.scala
@@ -10,7 +10,7 @@ import io.iohk.ethereum.rlp._
 import io.iohk.ethereum.utils.Config
 import org.bouncycastle.util.encoders.Hex
 
-object CommonMessages {
+object PV60 {
   object Status {
     implicit class StatusEnc(val underlyingMsg: Status)
         extends MessageSerializableImplicit[Status](underlyingMsg)

--- a/src/main/scala/io/iohk/ethereum/network/p2p/messages/PV64.scala
+++ b/src/main/scala/io/iohk/ethereum/network/p2p/messages/PV64.scala
@@ -83,7 +83,7 @@ object PV64 {
     implicit class NewBlockEnc(val underlyingMsg: NewBlock)
         extends MessageSerializableImplicit[NewBlock](underlyingMsg)
         with RLPSerializable {
-      import io.iohk.ethereum.network.p2p.messages.CommonMessages.SignedTransactions._
+      import io.iohk.ethereum.network.p2p.messages.PV60.SignedTransactions._
 
       override def code: Int = Codes.NewBlockCode
 
@@ -102,7 +102,7 @@ object PV64 {
     }
 
     implicit class NewBlockDec(val bytes: Array[Byte]) extends AnyVal {
-      import io.iohk.ethereum.network.p2p.messages.CommonMessages.SignedTransactions._
+      import io.iohk.ethereum.network.p2p.messages.PV60.SignedTransactions._
 
       def toNewBlock: NewBlock = rawDecode(bytes) match {
         case RLPList(

--- a/src/main/scala/io/iohk/ethereum/network/p2p/messages/ProtocolNegotiator.scala
+++ b/src/main/scala/io/iohk/ethereum/network/p2p/messages/ProtocolNegotiator.scala
@@ -1,0 +1,17 @@
+package io.iohk.ethereum.network.p2p.messages
+
+import io.iohk.ethereum.network.p2p.Message.Version
+import io.iohk.ethereum.network.p2p.messages.Capability.Capabilities
+import io.iohk.ethereum.network.p2p.messages.Capability.Capabilities.Eth63Capability
+
+class ProtocolNegotiator(val protocolVersion: Version) {
+
+  val capabilities =
+    if (protocolVersion == ProtocolVersions.PV64) Capabilities.All else Seq(Eth63Capability)
+
+  def negotiate(remoteCapabilities: Seq[Capability]): Option[Version] = {
+    val commonCapabilities = remoteCapabilities.intersect(capabilities)
+    commonCapabilities.sortBy(-_.version).headOption.map(_.version)
+  }
+
+}

--- a/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
@@ -1,10 +1,12 @@
 package io.iohk.ethereum.nodebuilder
 
-import java.time.Clock
 import akka.actor.{ActorRef, ActorSystem}
+import akka.util.ByteString
+import cats.implicits._
 import io.iohk.ethereum.blockchain.data.GenesisDataLoader
 import io.iohk.ethereum.blockchain.sync.{Blacklist, BlockchainHostActor, CacheBasedBlacklist, SyncController}
 import io.iohk.ethereum.consensus._
+import io.iohk.ethereum.consensus.blocks.CheckpointBlockGenerator
 import io.iohk.ethereum.db.components.Storages.PruningModeComponent
 import io.iohk.ethereum.db.components._
 import io.iohk.ethereum.db.storage.AppStateStorage
@@ -12,7 +14,6 @@ import io.iohk.ethereum.db.storage.pruning.PruningMode
 import io.iohk.ethereum.domain._
 import io.iohk.ethereum.jsonrpc.NetService.NetServiceConfig
 import io.iohk.ethereum.jsonrpc._
-import io.iohk.ethereum.security.{SSLContextBuilder, SecureRandomBuilder}
 import io.iohk.ethereum.jsonrpc.server.controllers.ApisBase
 import io.iohk.ethereum.jsonrpc.server.controllers.JsonRpcBaseController.JsonRpcConfig
 import io.iohk.ethereum.jsonrpc.server.http.JsonRpcHttpServer
@@ -25,25 +26,25 @@ import io.iohk.ethereum.network.PeerManagerActor.PeerConfiguration
 import io.iohk.ethereum.network.discovery.{DiscoveryConfig, DiscoveryServiceBuilder, PeerDiscoveryManager}
 import io.iohk.ethereum.network.handshaker.{EtcHandshaker, EtcHandshakerConfiguration, Handshaker}
 import io.iohk.ethereum.network.p2p.EthereumMessageDecoder
+import io.iohk.ethereum.network.p2p.Message.Version
+import io.iohk.ethereum.network.p2p.messages.ProtocolNegotiator
 import io.iohk.ethereum.network.rlpx.AuthHandshaker
 import io.iohk.ethereum.network.{PeerManagerActor, ServerActor, _}
 import io.iohk.ethereum.ommers.OmmersPool
+import io.iohk.ethereum.security.{SSLContextBuilder, SecureRandomBuilder}
 import io.iohk.ethereum.testmode.{TestLedgerBuilder, TestmodeConsensusBuilder}
 import io.iohk.ethereum.transactions.{PendingTransactionsManager, TransactionHistoryService}
 import io.iohk.ethereum.utils.Config.SyncConfig
 import io.iohk.ethereum.utils._
-
-import java.util.concurrent.atomic.AtomicReference
-import io.iohk.ethereum.consensus.blocks.CheckpointBlockGenerator
+import monix.eval.Task
+import monix.execution.Scheduler
 import org.bouncycastle.crypto.AsymmetricCipherKeyPair
 
+import java.time.Clock
+import java.util.concurrent.atomic.AtomicReference
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.{Failure, Success, Try}
-import akka.util.ByteString
-import monix.execution.Scheduler
-import cats.implicits._
-import monix.eval.Task
 
 // scalastyle:off number.of.types
 trait BlockchainConfigBuilder {
@@ -164,12 +165,19 @@ trait ForkResolverBuilder {
 
 }
 
+trait ProtocolNegotiatorBuilder {
+  self: BlockchainConfigBuilder =>
+  val protocolNegotiator = new ProtocolNegotiator(blockchainConfig.protocolVersion)
+}
+
 trait HandshakerBuilder {
   self: BlockchainBuilder
     with NodeStatusBuilder
     with StorageBuilder
     with PeerManagerActorBuilder
-    with ForkResolverBuilder =>
+    with ForkResolverBuilder
+    with ProtocolNegotiatorBuilder
+    with BlockchainConfigBuilder =>
 
   private val handshakerConfiguration: EtcHandshakerConfiguration =
     new EtcHandshakerConfiguration {
@@ -178,10 +186,10 @@ trait HandshakerBuilder {
       override val peerConfiguration: PeerConfiguration = self.peerConfiguration
       override val blockchain: Blockchain = self.blockchain
       override val appStateStorage: AppStateStorage = self.storagesInstance.storages.appStateStorage
-      override val protocolVersion: Int = Config.Network.protocolVersion
+      override val protocolVersion: Version = blockchainConfig.protocolVersion
     }
 
-  lazy val handshaker: Handshaker[PeerInfo] = EtcHandshaker(handshakerConfiguration)
+  lazy val handshaker: Handshaker[PeerInfo] = EtcHandshaker(handshakerConfiguration, protocolNegotiator)
 }
 
 trait AuthHandshakerBuilder {
@@ -224,7 +232,8 @@ trait PeerManagerActorBuilder {
     with DiscoveryConfigBuilder
     with StorageBuilder
     with KnownNodesManagerBuilder
-    with PeerStatisticsBuilder =>
+    with PeerStatisticsBuilder
+    with ProtocolNegotiatorBuilder =>
 
   lazy val peerConfiguration: PeerConfiguration = Config.Network.peer
 
@@ -239,7 +248,7 @@ trait PeerManagerActorBuilder {
       authHandshaker,
       EthereumMessageDecoder,
       discoveryConfig,
-      Config.Network.protocolVersion
+      protocolNegotiator
     ),
     "peer-manager"
   )
@@ -393,7 +402,7 @@ trait EthInfoServiceBuilder {
     stxLedger,
     keyStore,
     syncController,
-    Config.Network.protocolVersion,
+    blockchainConfig.protocolVersion,
     asyncConfig.askTimeout
   )
 }
@@ -757,8 +766,10 @@ trait Node
     with ActorSystemBuilder
     with StorageBuilder
     with BlockchainBuilder
+    with BlockchainConfigBuilder
     with NodeStatusBuilder
     with ForkResolverBuilder
+    with ProtocolNegotiatorBuilder
     with HandshakerBuilder
     with PeerStatisticsBuilder
     with PeerManagerActorBuilder
@@ -789,7 +800,6 @@ trait Node
     with ShutdownHookBuilder
     with Logger
     with GenesisDataLoaderBuilder
-    with BlockchainConfigBuilder
     with VmConfigBuilder
     with PeerEventBusBuilder
     with PendingTransactionsManagerBuilder.Default

--- a/src/main/scala/io/iohk/ethereum/transactions/PendingTransactionsManager.scala
+++ b/src/main/scala/io/iohk/ethereum/transactions/PendingTransactionsManager.scala
@@ -7,7 +7,7 @@ import io.iohk.ethereum.domain.{SignedTransaction, SignedTransactionWithSender}
 import io.iohk.ethereum.metrics.MetricsContainer
 import io.iohk.ethereum.network.PeerEventBusActor.{PeerEvent, Subscribe, SubscriptionClassifier}
 import io.iohk.ethereum.network.PeerManagerActor.Peers
-import io.iohk.ethereum.network.p2p.messages.CommonMessages.SignedTransactions
+import io.iohk.ethereum.network.p2p.messages.PV60.SignedTransactions
 import io.iohk.ethereum.network.{EtcPeerManagerActor, Peer, PeerId, PeerManagerActor}
 import io.iohk.ethereum.transactions.SignedTransactionsFilterActor.ProperSignedTransactions
 import io.iohk.ethereum.utils.TxPoolConfig

--- a/src/main/scala/io/iohk/ethereum/transactions/SignedTransactionsFilterActor.scala
+++ b/src/main/scala/io/iohk/ethereum/transactions/SignedTransactionsFilterActor.scala
@@ -8,7 +8,7 @@ import io.iohk.ethereum.network.PeerEventBusActor.{PeerSelector, Subscribe}
 import io.iohk.ethereum.network.PeerEventBusActor.SubscriptionClassifier.MessageClassifier
 import io.iohk.ethereum.network.PeerId
 import io.iohk.ethereum.network.p2p.messages.Codes
-import io.iohk.ethereum.network.p2p.messages.CommonMessages.SignedTransactions
+import io.iohk.ethereum.network.p2p.messages.PV60.SignedTransactions
 import io.iohk.ethereum.transactions.SignedTransactionsFilterActor.ProperSignedTransactions
 
 class SignedTransactionsFilterActor(pendingTransactionsManager: ActorRef, peerEventBus: ActorRef)

--- a/src/main/scala/io/iohk/ethereum/utils/BlockchainConfig.scala
+++ b/src/main/scala/io/iohk/ethereum/utils/BlockchainConfig.scala
@@ -3,6 +3,7 @@ package io.iohk.ethereum.utils
 import akka.util.ByteString
 import com.typesafe.config.{Config => TypesafeConfig}
 import io.iohk.ethereum.domain.{Address, UInt256}
+import io.iohk.ethereum.network.p2p.Message.Version
 import io.iohk.ethereum.utils.NumericUtils._
 
 import scala.jdk.CollectionConverters._
@@ -36,6 +37,7 @@ case class BlockchainConfig(
     accountStartNonce: UInt256,
     chainId: Byte,
     networkId: Int,
+    protocolVersion: Version,
     monetaryPolicyConfig: MonetaryPolicyConfig,
     gasTieBreaker: Boolean,
     ethCompatibleStorage: Boolean,
@@ -97,6 +99,7 @@ object BlockchainConfig {
     }
 
     val networkId: Int = blockchainConfig.getInt("network-id")
+    val protocolVersion = blockchainConfig.getInt("network.protocol-version")
 
     val monetaryPolicyConfig = MonetaryPolicyConfig(blockchainConfig.getConfig("monetary-policy"))
 
@@ -138,6 +141,7 @@ object BlockchainConfig {
       accountStartNonce = accountStartNonce,
       chainId = chainId,
       networkId = networkId,
+      protocolVersion = protocolVersion,
       monetaryPolicyConfig = monetaryPolicyConfig,
       gasTieBreaker = gasTieBreaker,
       ethCompatibleStorage = ethCompatibleStorage,

--- a/src/main/scala/io/iohk/ethereum/utils/Config.scala
+++ b/src/main/scala/io/iohk/ethereum/utils/Config.scala
@@ -40,8 +40,6 @@ object Config {
   object Network {
     private val networkConfig = config.getConfig("network")
 
-    val protocolVersion = networkConfig.getInt("protocol-version")
-
     val automaticPortForwarding = networkConfig.getBoolean("automatic-port-forwarding")
 
     object Server {

--- a/src/rpcTest/scala/io/iohk/ethereum/rpcTest/RpcApiTests.scala
+++ b/src/rpcTest/scala/io/iohk/ethereum/rpcTest/RpcApiTests.scala
@@ -17,7 +17,7 @@ import org.web3j.protocol.core.DefaultBlockParameter
 import org.web3j.protocol.core.methods.request.{EthFilter, Transaction}
 import org.web3j.protocol.core.methods.response.EthBlock.{TransactionHash, TransactionObject}
 import org.web3j.protocol.http.HttpService
-import io.iohk.ethereum.network.p2p.messages.CommonMessages.SignedTransactions.SignedTransactionEnc
+import io.iohk.ethereum.network.p2p.messages.PV60.SignedTransactions.SignedTransactionEnc
 import org.web3j.protocol.core.methods.response.EthLog.{Hash, LogObject}
 import io.iohk.ethereum.rpcTest.TestContracts._
 import io.iohk.ethereum.rpcTest.TestData._

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -55,6 +55,8 @@ mantis {
 
       network-id = 42
 
+      network.protocol-version = 63
+
       gas-tie-breaker = false
 
       eth-compatible-storage = true

--- a/src/test/scala/io/iohk/ethereum/ObjectGenerators.scala
+++ b/src/test/scala/io/iohk/ethereum/ObjectGenerators.scala
@@ -11,8 +11,7 @@ import io.iohk.ethereum.domain.BlockHeader.HeaderExtraFields._
 import io.iohk.ethereum.domain._
 import io.iohk.ethereum.mpt.HexPrefix.bytesToNibbles
 import io.iohk.ethereum.mpt.{BranchNode, ExtensionNode, HashNode, LeafNode, MptNode, MptTraversals}
-import io.iohk.ethereum.network.p2p.messages.CommonMessages.NewBlock
-import io.iohk.ethereum.network.p2p.messages.PV64
+import io.iohk.ethereum.network.p2p.messages.{PV60, PV64}
 import org.bouncycastle.crypto.AsymmetricCipherKeyPair
 import org.scalacheck.{Arbitrary, Gen, Shrink}
 
@@ -148,12 +147,12 @@ trait ObjectGenerators {
     }
   }
 
-  def newBlockGen(secureRandom: SecureRandom, chainId: Option[Byte]): Gen[NewBlock] = for {
+  def newBlock60Gen(secureRandom: SecureRandom, chainId: Option[Byte]): Gen[PV60.NewBlock] = for {
     blockHeader <- blockHeaderGen
     stxs <- signedTxSeqGen(10, secureRandom, chainId)
     uncles <- seqBlockHeaderGen
     td <- bigIntGen
-  } yield NewBlock(Block(blockHeader, BlockBody(stxs, uncles)), td)
+  } yield PV60.NewBlock(Block(blockHeader, BlockBody(stxs, uncles)), td)
 
   def newBlock64Gen(secureRandom: SecureRandom, chainId: Option[Byte]): Gen[PV64.NewBlock] = for {
     blockHeader <- blockHeaderGen

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/BlockBroadcastSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/BlockBroadcastSpec.scala
@@ -10,7 +10,7 @@ import io.iohk.ethereum.domain.{Block, BlockBody, BlockHeader, ChainWeight}
 import io.iohk.ethereum.network.EtcPeerManagerActor.{PeerInfo, RemoteStatus}
 import io.iohk.ethereum.network.p2p.messages.PV62.NewBlockHashes
 import io.iohk.ethereum.network.p2p.messages.PV64.NewBlock
-import io.iohk.ethereum.network.p2p.messages.{CommonMessages, PV62, ProtocolVersions}
+import io.iohk.ethereum.network.p2p.messages.{PV60, PV62, ProtocolVersions}
 import io.iohk.ethereum.network.{EtcPeerManagerActor, Peer}
 import io.iohk.ethereum.{Fixtures, WithActorSystemShutDown}
 import org.scalatest.flatspec.AnyFlatSpecLike
@@ -48,7 +48,7 @@ class BlockBroadcastSpec
       .copy(remoteStatus = peerStatus.copy(protocolVersion = ProtocolVersions.PV63))
       .withChainWeight(ChainWeight.totalDifficultyOnly(initialPeerInfo.chainWeight.totalDifficulty))
     val newBlock =
-      CommonMessages.NewBlock(Block(blockHeader, BlockBody(Nil, Nil)), peerInfo.chainWeight.totalDifficulty + 2)
+      PV60.NewBlock(Block(blockHeader, BlockBody(Nil, Nil)), peerInfo.chainWeight.totalDifficulty + 2)
 
     //when
     blockBroadcast.broadcastBlock(

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/PivotBlockSelectorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/PivotBlockSelectorSpec.scala
@@ -14,7 +14,7 @@ import io.iohk.ethereum.network.PeerEventBusActor.PeerEvent.MessageFromPeer
 import io.iohk.ethereum.network.PeerEventBusActor.SubscriptionClassifier.{MessageClassifier, PeerDisconnectedClassifier}
 import io.iohk.ethereum.network.PeerEventBusActor.{PeerSelector, Subscribe, Unsubscribe}
 import io.iohk.ethereum.network.p2p.Message
-import io.iohk.ethereum.network.p2p.messages.CommonMessages.NewBlock
+import io.iohk.ethereum.network.p2p.messages.PV60.NewBlock
 import io.iohk.ethereum.network.p2p.messages.PV62._
 import io.iohk.ethereum.network.p2p.messages.{Codes, ProtocolVersions}
 import io.iohk.ethereum.network.{EtcPeerManagerActor, Peer}

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/StateSyncSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/StateSyncSpec.scala
@@ -10,13 +10,6 @@ import akka.util.ByteString
 import io.iohk.ethereum.blockchain.sync.StateSyncUtils.{MptNodeData, TrieProvider}
 import io.iohk.ethereum.blockchain.sync.fast.SyncStateSchedulerActor._
 import io.iohk.ethereum.blockchain.sync.fast.{SyncStateScheduler, SyncStateSchedulerActor}
-import io.iohk.ethereum.blockchain.sync.fast.SyncStateSchedulerActor.{
-  RestartRequested,
-  StartSyncingTo,
-  StateSyncFinished,
-  StateSyncStats,
-  WaitingForNewTargetBlock
-}
 import io.iohk.ethereum.db.dataSource.RocksDbDataSource.IterationError
 import io.iohk.ethereum.domain.{Address, BlockchainImpl, ChainWeight}
 import io.iohk.ethereum.network.EtcPeerManagerActor._

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/regular/BlockFetcherSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/regular/BlockFetcherSpec.scala
@@ -16,7 +16,7 @@ import io.iohk.ethereum.network.Peer
 import io.iohk.ethereum.network.PeerEventBusActor.PeerEvent.MessageFromPeer
 import io.iohk.ethereum.network.PeerEventBusActor.SubscriptionClassifier.MessageClassifier
 import io.iohk.ethereum.network.PeerEventBusActor.{PeerSelector, Subscribe}
-import io.iohk.ethereum.network.p2p.messages.CommonMessages.NewBlock
+import io.iohk.ethereum.network.p2p.messages.PV60.NewBlock
 import io.iohk.ethereum.network.p2p.messages.PV62._
 import io.iohk.ethereum.network.p2p.messages.{Codes, PV64}
 import io.iohk.ethereum.security.SecureRandomBuilder

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/regular/RegularSyncSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/regular/RegularSyncSpec.scala
@@ -20,7 +20,7 @@ import io.iohk.ethereum.network.EtcPeerManagerActor.{GetHandshakedPeers, Handsha
 import io.iohk.ethereum.network.PeerEventBusActor.PeerEvent.MessageFromPeer
 import io.iohk.ethereum.network.PeerEventBusActor.SubscriptionClassifier.MessageClassifier
 import io.iohk.ethereum.network.PeerEventBusActor.{PeerSelector, Subscribe}
-import io.iohk.ethereum.network.p2p.messages.{Codes, CommonMessages, ProtocolVersions}
+import io.iohk.ethereum.network.p2p.messages.{Codes, PV60, ProtocolVersions}
 import io.iohk.ethereum.network.p2p.messages.PV62._
 import io.iohk.ethereum.network.p2p.messages.PV63.{GetNodeData, NodeData}
 import io.iohk.ethereum.network.p2p.messages.PV64.NewBlock
@@ -603,12 +603,12 @@ class RegularSyncSpec
           etcPeerManager.expectMsg(GetHandshakedPeers)
           etcPeerManager.reply(HandshakedPeers(Map(peerWithPV63._1 -> peerWithPV63._2)))
 
-          blockFetcher ! MessageFromPeer(CommonMessages.NewBlock(newBlock, newBlock.number), defaultPeer.id)
+          blockFetcher ! MessageFromPeer(PV60.NewBlock(newBlock, newBlock.number), defaultPeer.id)
 
           etcPeerManager.fishForSpecificMessageMatching() {
             case EtcPeerManagerActor.SendMessage(message, _) =>
               message.underlyingMsg match {
-                case CommonMessages.NewBlock(`newBlock`, _) => true
+                case PV60.NewBlock(`newBlock`, _) => true
                 case _ => false
               }
             case _ => false

--- a/src/test/scala/io/iohk/ethereum/consensus/BlockGeneratorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/BlockGeneratorSpec.scala
@@ -218,6 +218,7 @@ class BlockGeneratorSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
       monetaryPolicyConfig =
         MonetaryPolicyConfig(5000000, 0.2, 5000000000000000000L, 3000000000000000000L, 2000000000000000000L),
       // unused
+      protocolVersion = 63,
       maxCodeSize = None,
       eip160BlockNumber = Long.MaxValue,
       eip150BlockNumber = Long.MaxValue,
@@ -290,6 +291,7 @@ class BlockGeneratorSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
       monetaryPolicyConfig =
         MonetaryPolicyConfig(5000000, 0.2, 5000000000000000000L, 3000000000000000000L, 2000000000000000000L),
       // unused
+      protocolVersion = 63,
       maxCodeSize = None,
       eip160BlockNumber = Long.MaxValue,
       eip150BlockNumber = Long.MaxValue,
@@ -569,6 +571,7 @@ class BlockGeneratorSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
       monetaryPolicyConfig =
         MonetaryPolicyConfig(5000000, 0.2, 5000000000000000000L, 3000000000000000000L, 2000000000000000000L),
       // unused
+      protocolVersion = 63,
       maxCodeSize = None,
       eip160BlockNumber = Long.MaxValue,
       eip150BlockNumber = Long.MaxValue,

--- a/src/test/scala/io/iohk/ethereum/consensus/validators/BlockHeaderValidatorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/validators/BlockHeaderValidatorSpec.scala
@@ -463,6 +463,7 @@ class BlockHeaderValidatorSpec
       eip106BlockNumber = 0,
       chainId = 0x3d.toByte,
       networkId = 1,
+      protocolVersion = 63,
       monetaryPolicyConfig = null,
       customGenesisFileOpt = None,
       accountStartNonce = UInt256.Zero,

--- a/src/test/scala/io/iohk/ethereum/consensus/validators/RestrictedEthashBlockHeaderValidatorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/validators/RestrictedEthashBlockHeaderValidatorSpec.scala
@@ -86,6 +86,7 @@ class RestrictedEthashBlockHeaderValidatorSpec
         eip106BlockNumber = 0,
         chainId = 0x3d.toByte,
         networkId = 1,
+        protocolVersion = 63,
         monetaryPolicyConfig = null,
         customGenesisFileOpt = None,
         accountStartNonce = UInt256.Zero,

--- a/src/test/scala/io/iohk/ethereum/db/storage/BlockBodiesStorageSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/db/storage/BlockBodiesStorageSpec.scala
@@ -2,13 +2,13 @@ package io.iohk.ethereum.db.storage
 
 import io.iohk.ethereum.ObjectGenerators
 import io.iohk.ethereum.db.dataSource.EphemDataSource
+import io.iohk.ethereum.network.p2p.messages.PV60
+import io.iohk.ethereum.network.p2p.messages.PV60.NewBlock
 import io.iohk.ethereum.security.SecureRandomBuilder
-import io.iohk.ethereum.network.p2p.messages.CommonMessages
-import io.iohk.ethereum.network.p2p.messages.CommonMessages.NewBlock
 import org.bouncycastle.util.encoders.Hex
 import org.scalacheck.Gen
-import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
 class BlockBodiesStorageSpec
     extends AnyWordSpec
@@ -21,7 +21,7 @@ class BlockBodiesStorageSpec
   "BlockBodiesStorage" should {
 
     "insert block body properly" in {
-      forAll(Gen.listOfN(32, ObjectGenerators.newBlockGen(secureRandom, chainId))) { newBlocks =>
+      forAll(Gen.listOfN(32, ObjectGenerators.newBlock60Gen(secureRandom, chainId))) { newBlocks =>
         val blocks = newBlocks.distinct
         val totalStorage = insertBlockBodiesMapping(newBlocks)
 
@@ -32,7 +32,7 @@ class BlockBodiesStorageSpec
     }
 
     "delete block body properly" in {
-      forAll(Gen.listOfN(32, ObjectGenerators.newBlockGen(secureRandom, chainId))) { newBlocks =>
+      forAll(Gen.listOfN(32, ObjectGenerators.newBlock60Gen(secureRandom, chainId))) { newBlocks =>
         val blocks = newBlocks.distinct
         val storage = insertBlockBodiesMapping(newBlocks)
 
@@ -52,7 +52,7 @@ class BlockBodiesStorageSpec
       }
     }
 
-    def insertBlockBodiesMapping(newBlocks: Seq[CommonMessages.NewBlock]): BlockBodiesStorage = {
+    def insertBlockBodiesMapping(newBlocks: Seq[PV60.NewBlock]): BlockBodiesStorage = {
       val storage = new BlockBodiesStorage(EphemDataSource())
 
       val batchUpdates = newBlocks.foldLeft(storage.emptyBatchUpdate) { case (updates, NewBlock(block, _)) =>

--- a/src/test/scala/io/iohk/ethereum/faucet/jsonrpc/WalletServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/faucet/jsonrpc/WalletServiceSpec.scala
@@ -9,7 +9,7 @@ import io.iohk.ethereum.faucet.{FaucetConfig, RpcClientConfig, SupervisorConfig}
 import io.iohk.ethereum.jsonrpc.client.RpcClient.ConnectionError
 import io.iohk.ethereum.keystore.KeyStore.DecryptionFailed
 import io.iohk.ethereum.keystore.{KeyStore, Wallet}
-import io.iohk.ethereum.network.p2p.messages.CommonMessages.SignedTransactions.SignedTransactionEnc
+import io.iohk.ethereum.network.p2p.messages.PV60.SignedTransactions.SignedTransactionEnc
 import io.iohk.ethereum.{crypto, rlp}
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/PersonalServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/PersonalServiceSpec.scala
@@ -401,6 +401,7 @@ class PersonalServiceSpec
       chainId = 0x03.toByte,
       //unused
       networkId = 1,
+      protocolVersion = 63,
       maxCodeSize = None,
       eip161BlockNumber = 0,
       frontierBlockNumber = 0,

--- a/src/test/scala/io/iohk/ethereum/ledger/StxLedgerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/StxLedgerSpec.scala
@@ -109,6 +109,7 @@ trait ScenarioSetup extends EphemBlockchainTestSetup {
     eip155BlockNumber = 0,
     chainId = 0x03.toByte,
     networkId = 1,
+    protocolVersion = 63,
     maxCodeSize = None,
     eip161BlockNumber = 0,
     frontierBlockNumber = 0,

--- a/src/test/scala/io/iohk/ethereum/network/EtcPeerManagerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/network/EtcPeerManagerSpec.scala
@@ -14,7 +14,7 @@ import io.iohk.ethereum.network.PeerActor.DisconnectPeer
 import io.iohk.ethereum.network.PeerEventBusActor.PeerEvent.{MessageFromPeer, PeerDisconnected, PeerHandshakeSuccessful}
 import io.iohk.ethereum.network.PeerEventBusActor.SubscriptionClassifier._
 import io.iohk.ethereum.network.PeerEventBusActor.{PeerSelector, Subscribe}
-import io.iohk.ethereum.network.p2p.messages.CommonMessages.NewBlock
+import io.iohk.ethereum.network.p2p.messages.PV60.NewBlock
 import io.iohk.ethereum.network.p2p.messages.PV62._
 import io.iohk.ethereum.network.p2p.messages.WireProtocol.Disconnect
 import io.iohk.ethereum.network.p2p.messages.{Codes, PV64, ProtocolVersions}
@@ -43,7 +43,7 @@ class EtcPeerManagerSpec extends AnyFlatSpec with Matchers {
     requestSender.expectMsg(HandshakedPeers(Map(peer1 -> peer1Info, peer2 -> peer2Info)))
   }
 
-  it should "update max peer when receiving new block PV63" in new TestSetup {
+  it should "update max peer when receiving new block PV60-PV63" in new TestSetup {
     peerEventBus.expectMsg(Subscribe(PeerHandshaked))
     setupNewPeer(peer1, peer1Probe, peer1Info)
 
@@ -127,7 +127,7 @@ class EtcPeerManagerSpec extends AnyFlatSpec with Matchers {
     )
   }
 
-  it should "update the peer total difficulty when receiving a NewBlock" in new TestSetup {
+  it should "update the peer total difficulty when receiving a PV60.NewBlock" in new TestSetup {
     peerEventBus.expectMsg(Subscribe(PeerHandshaked))
     setupNewPeer(peer1, peer1Probe, peer1Info)
 

--- a/src/test/scala/io/iohk/ethereum/network/PeerActorHandshakingSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/network/PeerActorHandshakingSpec.scala
@@ -15,7 +15,7 @@ import io.iohk.ethereum.network.handshaker.Handshaker.NextMessage
 import io.iohk.ethereum.network.handshaker._
 import io.iohk.ethereum.network.p2p.Message
 import io.iohk.ethereum.network.p2p.messages.Capability.Capabilities._
-import io.iohk.ethereum.network.p2p.messages.CommonMessages.Status
+import io.iohk.ethereum.network.p2p.messages.PV60.Status
 import io.iohk.ethereum.network.p2p.messages.ProtocolVersions
 import io.iohk.ethereum.network.p2p.messages.WireProtocol.{Disconnect, Hello, Pong}
 import io.iohk.ethereum.network.rlpx.RLPxConnectionHandler

--- a/src/test/scala/io/iohk/ethereum/network/PeerManagerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/network/PeerManagerSpec.scala
@@ -14,7 +14,7 @@ import io.iohk.ethereum.network.PeerEventBusActor.SubscriptionClassifier.PeerHan
 import io.iohk.ethereum.network.PeerEventBusActor.{PeerEvent, Publish, Subscribe}
 import io.iohk.ethereum.network.PeerManagerActor.{GetPeers, PeerConfiguration, Peers, SendMessage}
 import io.iohk.ethereum.network.discovery.{DiscoveryConfig, Node, PeerDiscoveryManager}
-import io.iohk.ethereum.network.p2p.messages.CommonMessages.NewBlock
+import io.iohk.ethereum.network.p2p.messages.PV60.NewBlock
 import io.iohk.ethereum.network.p2p.messages.ProtocolVersions
 import io.iohk.ethereum.network.p2p.messages.WireProtocol.Disconnect
 import io.iohk.ethereum.utils.Config

--- a/src/test/scala/io/iohk/ethereum/network/p2p/MessageCodecSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/network/p2p/MessageCodecSpec.scala
@@ -3,8 +3,8 @@ package io.iohk.ethereum.network.p2p
 import akka.util.ByteString
 import io.iohk.ethereum.network.handshaker.EtcHelloExchangeState
 import io.iohk.ethereum.network.p2p.messages.Capability.Capabilities._
-import io.iohk.ethereum.network.p2p.messages.CommonMessages.Status
-import io.iohk.ethereum.network.p2p.messages.ProtocolVersions
+import io.iohk.ethereum.network.p2p.messages.PV60.Status
+import io.iohk.ethereum.network.p2p.messages.{ProtocolNegotiator, ProtocolVersions}
 import io.iohk.ethereum.network.p2p.messages.WireProtocol.Hello
 import io.iohk.ethereum.network.rlpx.{FrameCodec, MessageCodec}
 import io.iohk.ethereum.utils.Config
@@ -73,6 +73,7 @@ class MessageCodecSpec extends AnyFlatSpec with Matchers {
   trait TestSetup extends SecureChannelSetup {
     val frameCodec = new FrameCodec(secrets)
     val remoteFrameCodec = new FrameCodec(remoteSecrets)
+    val protocolNegotiator = new ProtocolNegotiator(ProtocolVersions.PV63)
 
     val helloV5 = Hello(
       p2pVersion = EtcHelloExchangeState.P2pVersion,
@@ -94,8 +95,8 @@ class MessageCodecSpec extends AnyFlatSpec with Matchers {
 
     val decoder = NetworkMessageDecoder orElse EthereumMessageDecoder
 
-    val messageCodec = new MessageCodec(frameCodec, decoder, ProtocolVersions.PV63)
-    val remoteMessageCodec = new MessageCodec(remoteFrameCodec, decoder, ProtocolVersions.PV63)
+    val messageCodec = new MessageCodec(frameCodec, decoder, protocolNegotiator)
+    val remoteMessageCodec = new MessageCodec(remoteFrameCodec, decoder, protocolNegotiator)
 
   }
 

--- a/src/test/scala/io/iohk/ethereum/network/p2p/MessageDecodersSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/network/p2p/MessageDecodersSpec.scala
@@ -4,7 +4,7 @@ import akka.util.ByteString
 import io.iohk.ethereum.{Fixtures, ObjectGenerators}
 import io.iohk.ethereum.domain.ChainWeight
 import io.iohk.ethereum.network.p2p.messages.Capability.Capabilities._
-import io.iohk.ethereum.network.p2p.messages.CommonMessages.SignedTransactions
+import io.iohk.ethereum.network.p2p.messages.PV60.SignedTransactions
 import io.iohk.ethereum.network.p2p.messages._
 import io.iohk.ethereum.security.SecureRandomBuilder
 import org.bouncycastle.util.encoders.Hex
@@ -181,25 +181,25 @@ class MessageDecodersSpec extends AnyFlatSpec with Matchers with SecureRandomBui
   }
 
   it should "decode Status message for all supported versions of protocol" in {
-    val status63 = CommonMessages.Status(ProtocolVersions.PV63, 1, BigInt(100), exampleHash, exampleHash)
-    val status63Bytes: Array[Byte] = status63.toBytes
+    val status60 = PV60.Status(ProtocolVersions.PV63, 1, BigInt(100), exampleHash, exampleHash)
+    val status60Bytes: Array[Byte] = status60.toBytes
     val status64 = PV64.Status(ProtocolVersions.PV63, 1, ChainWeight(1, BigInt(100)), exampleHash, exampleHash)
 
     // it's not 100 % true as Status message was different in PV61, but we are not supporting old message
-    decode(Codes.StatusCode, status63Bytes, ProtocolVersions.PV61) shouldBe status63
-    decode(Codes.StatusCode, status63Bytes, ProtocolVersions.PV62) shouldBe status63
-    decode(Codes.StatusCode, status63Bytes, ProtocolVersions.PV63) shouldBe status63
+    decode(Codes.StatusCode, status60Bytes, ProtocolVersions.PV61) shouldBe status60
+    decode(Codes.StatusCode, status60Bytes, ProtocolVersions.PV62) shouldBe status60
+    decode(Codes.StatusCode, status60Bytes, ProtocolVersions.PV63) shouldBe status60
     decode(Codes.StatusCode, status64.toBytes, ProtocolVersions.PV64) shouldBe status64
   }
 
   it should "decode NewBlock message for all supported versions of protocol" in {
-    val newBlock63 = ObjectGenerators.newBlockGen(secureRandom, None).sample.get
-    val newBlock63Bytes: Array[Byte] = newBlock63.toBytes
+    val newBlock60 = ObjectGenerators.newBlock60Gen(secureRandom, None).sample.get
+    val newBlock60Bytes: Array[Byte] = newBlock60.toBytes
     val newBlock64 = ObjectGenerators.newBlock64Gen(secureRandom, None).sample.get
 
-    decode(Codes.NewBlockCode, newBlock63Bytes, ProtocolVersions.PV61) shouldBe newBlock63
-    decode(Codes.NewBlockCode, newBlock63Bytes, ProtocolVersions.PV62) shouldBe newBlock63
-    decode(Codes.NewBlockCode, newBlock63Bytes, ProtocolVersions.PV63) shouldBe newBlock63
+    decode(Codes.NewBlockCode, newBlock60Bytes, ProtocolVersions.PV61) shouldBe newBlock60
+    decode(Codes.NewBlockCode, newBlock60Bytes, ProtocolVersions.PV62) shouldBe newBlock60
+    decode(Codes.NewBlockCode, newBlock60Bytes, ProtocolVersions.PV63) shouldBe newBlock60
     decode(Codes.NewBlockCode, newBlock64.toBytes, ProtocolVersions.PV64) shouldBe newBlock64
   }
 

--- a/src/test/scala/io/iohk/ethereum/network/p2p/PeerActorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/network/p2p/PeerActorSpec.scala
@@ -20,11 +20,11 @@ import io.iohk.ethereum.network.PeerManagerActor.{FastSyncHostConfiguration, Pee
 import io.iohk.ethereum.network.handshaker.{EtcHandshaker, EtcHandshakerConfiguration}
 import io.iohk.ethereum.network.p2p.Message.Version
 import io.iohk.ethereum.network.p2p.messages.Capability.Capabilities._
-import io.iohk.ethereum.network.p2p.messages.CommonMessages.Status
-import io.iohk.ethereum.network.p2p.messages.CommonMessages.Status.StatusEnc
+import io.iohk.ethereum.network.p2p.messages.PV60.Status
+import io.iohk.ethereum.network.p2p.messages.PV60.Status.StatusEnc
 import io.iohk.ethereum.network.p2p.messages.PV62.GetBlockHeaders.GetBlockHeadersEnc
 import io.iohk.ethereum.network.p2p.messages.PV62._
-import io.iohk.ethereum.network.p2p.messages.{PV64, ProtocolVersions}
+import io.iohk.ethereum.network.p2p.messages.{PV64, ProtocolNegotiator, ProtocolVersions}
 import io.iohk.ethereum.network.p2p.messages.WireProtocol.Disconnect.Reasons
 import io.iohk.ethereum.network.p2p.messages.WireProtocol.Hello.HelloEnc
 import io.iohk.ethereum.network.p2p.messages.WireProtocol.Pong.PongEnc
@@ -540,7 +540,9 @@ class PeerActorSpec
       override val protocolVersion: Int = protocol
     }
 
-    val handshaker = EtcHandshaker(handshakerConfiguration)
+    val protocolNegotiator = new ProtocolNegotiator(protocol)
+
+    val handshaker = EtcHandshaker(handshakerConfiguration, protocolNegotiator)
   }
 
   trait TestSetup extends NodeStatusSetup with BlockUtils with HandshakerSetup {

--- a/src/test/scala/io/iohk/ethereum/network/p2p/messages/MessagesSerializationSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/network/p2p/messages/MessagesSerializationSpec.scala
@@ -3,7 +3,7 @@ package io.iohk.ethereum.network.p2p.messages
 import akka.util.ByteString
 import io.iohk.ethereum.Fixtures
 import io.iohk.ethereum.domain.ChainWeight
-import io.iohk.ethereum.network.p2p.messages.CommonMessages._
+import io.iohk.ethereum.network.p2p.messages.PV60._
 import io.iohk.ethereum.network.p2p.messages.PV61.BlockHashesFromNumber
 import io.iohk.ethereum.network.p2p.messages.PV62._
 import io.iohk.ethereum.network.p2p.messages.WireProtocol._
@@ -16,7 +16,6 @@ class MessagesSerializationSpec extends AnyWordSpec with ScalaCheckPropertyCheck
 
   // TODO: add tests for messages from PV63
   "Wire Protocol" when {
-
     "encoding and decoding Hello" should {
       "return same result" in {
         verify(
@@ -52,9 +51,9 @@ class MessagesSerializationSpec extends AnyWordSpec with ScalaCheckPropertyCheck
     }
   }
 
-  "Common Messages" when {
+  "PV60" when {
     "encoding and decoding Status" should {
-      "return same result for Status v63" in {
+      "return same result for Status v60-63" in {
         val msg = Status(1, 2, 2, ByteString("HASH"), ByteString("HASH2"))
         verify(msg, (m: Status) => m.toBytes, Codes.StatusCode, ProtocolVersions.PV63)
       }
@@ -68,7 +67,7 @@ class MessagesSerializationSpec extends AnyWordSpec with ScalaCheckPropertyCheck
     }
 
     "encoding and decoding NewBlock" should {
-      "return same result for NewBlock v63" in {
+      "return same result for NewBlock v60-63" in {
         val msg = NewBlock(Fixtures.Blocks.Block3125369.block, 2323)
         verify(msg, (m: NewBlock) => m.toBytes, Codes.NewBlockCode, ProtocolVersions.PV63)
       }

--- a/src/test/scala/io/iohk/ethereum/network/p2p/messages/NewBlockSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/network/p2p/messages/NewBlockSpec.scala
@@ -3,7 +3,7 @@ package io.iohk.ethereum.network.p2p.messages
 import akka.util.ByteString
 import io.iohk.ethereum.ObjectGenerators
 import io.iohk.ethereum.domain.{Block, BlockBody, BlockHeader, ChainWeight}
-import io.iohk.ethereum.network.p2p.messages.CommonMessages.NewBlock
+import io.iohk.ethereum.network.p2p.messages.PV60.NewBlock
 import org.bouncycastle.util.encoders.Hex
 import NewBlock._
 import io.iohk.ethereum.security.SecureRandomBuilder
@@ -14,8 +14,8 @@ class NewBlockSpec extends AnyFunSuite with ScalaCheckPropertyChecks with Object
 
   val chainId = Hex.decode("3d").head
 
-  test("NewBlock v63 messages are encoded and decoded properly") {
-    forAll(newBlockGen(secureRandom, Some(chainId))) { newBlock =>
+  test("NewBlock v60 messages are encoded and decoded properly") {
+    forAll(newBlock60Gen(secureRandom, Some(chainId))) { newBlock =>
       val encoded: Array[Byte] = newBlock.toBytes
       val decoded: NewBlock = encoded.toNewBlock
       assert(decoded == newBlock)
@@ -32,10 +32,10 @@ class NewBlockSpec extends AnyFunSuite with ScalaCheckPropertyChecks with Object
   }
 
   test("NewBlock messages are properly encoded") {
-    val obtainEncoded = Hex.toHexString(newBlock.toBytes)
-    val expectedEncoded =
+    val obtainEncoded60 = Hex.toHexString(newBlock60.toBytes)
+    val expectedEncoded60 =
       "f90200f901f9f901f4a00000000000000000000000000000000000000000000000000000000000000000a01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347943333333333333333333333333333333333333333a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421b9010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000830f0000808408000000808000a0000000000000000000000000000000000000000000000000000000000000000088deadbeefdeadbeefc0c0830f0000"
-    assert(obtainEncoded == expectedEncoded)
+    assert(obtainEncoded60 == expectedEncoded60)
 
     val obtainEncoded64 = Hex.toHexString(newBlock64.toBytes)
     val expectedEncoded64 =
@@ -43,7 +43,7 @@ class NewBlockSpec extends AnyFunSuite with ScalaCheckPropertyChecks with Object
     assert(obtainEncoded64 == expectedEncoded64)
   }
 
-  val newBlock = NewBlock(
+  val newBlock60 = NewBlock(
     Block(
       BlockHeader(
         parentHash = ByteString(Hex.decode("0000000000000000000000000000000000000000000000000000000000000000")),

--- a/src/test/scala/io/iohk/ethereum/network/p2p/messages/ProtocolNegotiatorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/network/p2p/messages/ProtocolNegotiatorSpec.scala
@@ -1,0 +1,52 @@
+package io.iohk.ethereum.network.p2p.messages
+
+import io.iohk.ethereum.network.p2p.messages.Capability.Capabilities
+import io.iohk.ethereum.network.p2p.messages.Capability.Capabilities.Eth63Capability
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+
+class ProtocolNegotiatorSpec extends AnyWordSpec with ScalaCheckPropertyChecks with Matchers {
+
+  private val protocolNegotiatorPV63 = new ProtocolNegotiator(ProtocolVersions.PV63)
+  private val protocolNegotiatorPV64 = new ProtocolNegotiator(ProtocolVersions.PV64)
+  private val remoteCapabilities = Capability("eth", 65) +: Capabilities.All
+  private val eth64Capability = Capability("eth", 64)
+
+  "Protocol negotiator" when {
+    s"protocol version is ${ProtocolVersions.PV63}" should {
+      s"return ${ProtocolVersions.PV63} as possible capability" in {
+        protocolNegotiatorPV63.capabilities shouldBe Seq(Eth63Capability)
+      }
+
+      s"return ${ProtocolVersions.PV63} as negotiated protocol" in {
+        protocolNegotiatorPV63.negotiate(remoteCapabilities) shouldBe Some(ProtocolVersions.PV63)
+      }
+
+      s"return no negotiated protocol" in {
+        val peerCapabilities = Seq(eth64Capability)
+        protocolNegotiatorPV63.negotiate(peerCapabilities) shouldBe None
+      }
+    }
+
+    s"protocol version is ${ProtocolVersions.PV64}" should {
+      s"return ${Capabilities.All} as possible capabilities" in {
+        protocolNegotiatorPV64.capabilities shouldBe Capabilities.All
+      }
+
+      s"return ${ProtocolVersions.PV64} as negotiated protocol" in {
+        protocolNegotiatorPV64.negotiate(remoteCapabilities) shouldBe Some(ProtocolVersions.PV64)
+      }
+
+      s"return ${ProtocolVersions.PV63} as negotiated protocol" in {
+        val peerCapabilities = eth64Capability +: remoteCapabilities.filterNot(_.name == "etc")
+        protocolNegotiatorPV64.negotiate(peerCapabilities) shouldBe Some(ProtocolVersions.PV63)
+      }
+
+      s"return no negotiated protocol" in {
+        val peerCapabilities = Seq(eth64Capability)
+        protocolNegotiatorPV64.negotiate(peerCapabilities) shouldBe None
+      }
+    }
+  }
+}

--- a/src/test/scala/io/iohk/ethereum/network/rlpx/RLPxConnectionHandlerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/network/rlpx/RLPxConnectionHandlerSpec.scala
@@ -9,7 +9,7 @@ import akka.util.ByteString
 import io.iohk.ethereum.{Timeouts, WithActorSystemShutDown}
 import io.iohk.ethereum.network.p2p.Message.Version
 import io.iohk.ethereum.network.p2p.{MessageDecoder, MessageSerializable}
-import io.iohk.ethereum.network.p2p.messages.ProtocolVersions
+import io.iohk.ethereum.network.p2p.messages.{ProtocolNegotiator, ProtocolVersions}
 import io.iohk.ethereum.network.p2p.messages.WireProtocol.Ping
 import io.iohk.ethereum.network.rlpx.RLPxConnectionHandler.RLPxConfiguration
 import io.iohk.ethereum.security.SecureRandomBuilder
@@ -178,6 +178,7 @@ class RLPxConnectionHandlerSpec
         throw new Exception("Mock message decoder fails to decode all messages")
     }
     val protocolVersion = ProtocolVersions.PV63
+    val protocolNegotiator = new ProtocolNegotiator(protocolVersion)
     val mockHandshaker = mock[AuthHandshaker]
     val connection = TestProbe()
     val mockMessageCodec = mock[MessageCodec]
@@ -200,7 +201,7 @@ class RLPxConnectionHandlerSpec
       Props(
         new RLPxConnectionHandler(
           mockMessageDecoder,
-          protocolVersion,
+          protocolNegotiator,
           mockHandshaker,
           (_, _, _) => mockMessageCodec,
           rlpxConfiguration

--- a/src/test/scala/io/iohk/ethereum/transactions/PendingTransactionsManagerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/transactions/PendingTransactionsManagerSpec.scala
@@ -12,7 +12,7 @@ import io.iohk.ethereum.network.PeerActor.Status.Handshaked
 import io.iohk.ethereum.network.PeerEventBusActor.PeerEvent
 import io.iohk.ethereum.network.PeerManagerActor.Peers
 import io.iohk.ethereum.network.handshaker.Handshaker.HandshakeResult
-import io.iohk.ethereum.network.p2p.messages.CommonMessages.SignedTransactions
+import io.iohk.ethereum.network.p2p.messages.PV60.SignedTransactions
 import io.iohk.ethereum.network.{EtcPeerManagerActor, Peer, PeerId, PeerManagerActor}
 import io.iohk.ethereum.transactions.PendingTransactionsManager._
 import io.iohk.ethereum.{NormalPatience, Timeouts, crypto}


### PR DESCRIPTION
# Description

Currently, we are decoding our messages base on information which is the best protocol we support and assumption that the newest protocol includes older protocol versions.

We should use the protocol negotiated with peer.

# Proposed Solution

Create a component which can negotiate protocol version and have our capabilities information. Use it to set up correct protocol version in MessageCodec and EtcHelloExchangeState

# Important Changes Introduced

- introduced protocol negotiator

# Testing

I synced with mordor testnet successfully.