### PR TITLE
Refactored Caches, synchronized to TrieMaps

### DIFF
--- a/src/main/scala/io/iohk/ethereum/db/cache/Cache.scala
+++ b/src/main/scala/io/iohk/ethereum/db/cache/Cache.scala
@@ -3,8 +3,20 @@ package io.iohk.ethereum.db.cache
 import io.iohk.ethereum.common.SimpleMap
 import scala.collection.Seq
 
+
 trait Cache[K, V] extends SimpleMap[K, V, Cache[K, V]] {
   def getValues: Seq[(K, V)]
-  def clear(): Unit
+
+  /**
+    * Entries are removed from the concurrent map one by one
+    *
+    * Cache is not guaranteed to be empty after the operation
+    * As it can be updated from the other threads
+    *
+    * @return all the values that were removed from the cache
+    */
+  def drain: Seq[(K, V)]
+
+
   def shouldPersist: Boolean
 }

--- a/src/main/scala/io/iohk/ethereum/db/cache/MapCache.scala
+++ b/src/main/scala/io/iohk/ethereum/db/cache/MapCache.scala
@@ -29,7 +29,7 @@ class MapCache[K, V](val cache: CMap[K, V], config: NodeCacheConfig) extends Cac
 
   override def drain: Seq[(K, V)] = {
     lastClear = System.nanoTime()
-    cache.toList.flatMap { case tuple @ (k, _) =>
+    cache.toList.flatMap { case (k, _) =>
       cache.remove(k).map( v => k -> v )
     }
   }

--- a/src/main/scala/io/iohk/ethereum/db/cache/MapCache.scala
+++ b/src/main/scala/io/iohk/ethereum/db/cache/MapCache.scala
@@ -1,26 +1,21 @@
 package io.iohk.ethereum.db.cache
 
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicLong
 
 import io.iohk.ethereum.utils.Config.NodeCacheConfig
 
-import scala.collection.{Seq, mutable}
+import scala.collection.Seq
+import scala.collection.concurrent.{TrieMap, Map => CMap}
 import scala.concurrent.duration.FiniteDuration
 
-//TODO EC-492 Investigate more carefully possibility of having read cache in front of db
-// class is not entirely thread safe
-// All updates need to be atomic and visible in respect to get, as get may be called from other threads.
-// Other methods are only called from actor context, and all updates are always visible to them
-class MapCache[K, V](val cache: mutable.Map[K, V], config: NodeCacheConfig) extends Cache[K, V] {
 
-  private val lastClear = new AtomicLong(System.nanoTime())
+class MapCache[K, V](val cache: CMap[K, V], config: NodeCacheConfig) extends Cache[K, V] {
+
+  @volatile private[this] var lastClear = System.nanoTime()
 
   override def update(toRemove: Seq[K], toUpsert: Seq[(K, V)]): Cache[K, V] = {
-    this.synchronized {
-      toRemove.foreach(key => cache -= key)
-      toUpsert.foreach(element => cache += element._1 -> element._2)
-    }
+    toRemove.foreach(key => cache -= key)
+    toUpsert.foreach(element => cache += element._1 -> element._2)
     this
   }
 
@@ -29,14 +24,15 @@ class MapCache[K, V](val cache: mutable.Map[K, V], config: NodeCacheConfig) exte
   }
 
   override def get(key: K): Option[V] = {
-    this.synchronized {
-      cache.get(key)
-    }
+    cache.get(key)
   }
 
-  override def clear: Unit = {
-    lastClear.getAndSet(System.nanoTime())
-    cache.clear()
+  override def drain: Seq[(K, V)] = {
+    lastClear = System.nanoTime()
+    cache.toList.map { case tuple @ (k, _) =>
+      cache -= k
+      tuple
+    }
   }
 
   override def shouldPersist: Boolean = {
@@ -44,16 +40,13 @@ class MapCache[K, V](val cache: mutable.Map[K, V], config: NodeCacheConfig) exte
   }
 
   private def isTimeToClear: Boolean = {
-    FiniteDuration(System.nanoTime(), TimeUnit.NANOSECONDS) - FiniteDuration(
-      lastClear.get(),
-      TimeUnit.NANOSECONDS
-    ) >= config.maxHoldTime
+    FiniteDuration(System.nanoTime() - lastClear, TimeUnit.NANOSECONDS) >= config.maxHoldTime
   }
 }
 
 object MapCache {
 
-  def getMap[K, V]: mutable.Map[K, V] = mutable.Map.empty
+  def getMap[K, V]: CMap[K, V] = TrieMap.empty
 
   def createCache[K, V](config: NodeCacheConfig): MapCache[K, V] = {
     new MapCache[K, V](getMap[K, V], config)
@@ -68,4 +61,5 @@ object MapCache {
   ): Cache[K, V] = {
     createCache[K, V](TestCacheConfig(maxSize, maxHoldTime))
   }
+
 }

--- a/src/main/scala/io/iohk/ethereum/db/cache/MapCache.scala
+++ b/src/main/scala/io/iohk/ethereum/db/cache/MapCache.scala
@@ -29,9 +29,8 @@ class MapCache[K, V](val cache: CMap[K, V], config: NodeCacheConfig) extends Cac
 
   override def drain: Seq[(K, V)] = {
     lastClear = System.nanoTime()
-    cache.toList.map { case tuple @ (k, _) =>
-      cache -= k
-      tuple
+    cache.toList.flatMap { case tuple @ (k, _) =>
+      cache.remove(k).map( v => k -> v )
     }
   }
 

--- a/src/main/scala/io/iohk/ethereum/db/storage/CachedKeyValueStorage.scala
+++ b/src/main/scala/io/iohk/ethereum/db/storage/CachedKeyValueStorage.scala
@@ -27,8 +27,8 @@ trait CachedKeyValueStorage[K, V, T <: CachedKeyValueStorage[K, V, T]] extends S
   }
 
   def forcePersist(): Unit = {
-    storage.update(Nil, cache.getValues)
-    cache.clear()
+    val contents = cache.drain
+    storage.update(Nil, contents)
   }
 
   // TODO EC-491 Consider other persist strategy like sliding window (save and clear only old stuff which survived long enough)

--- a/src/main/scala/io/iohk/ethereum/db/storage/CachedReferenceCountedStorage.scala
+++ b/src/main/scala/io/iohk/ethereum/db/storage/CachedReferenceCountedStorage.scala
@@ -98,10 +98,9 @@ object CachedReferenceCountedStorage {
       ser: ByteArraySerializable[V]
   ): Boolean = {
     if (cache.shouldPersist || forced) {
-      val values = cache.getValues
+      val values = cache.drain
       val serialized = values.map { case (key, value) => key -> ser.toBytes(value) }
       storage.update(Nil, serialized)
-      cache.clear()
       true
     } else {
       false


### PR DESCRIPTION
# Description

`Cache` methods were synchronized, but its usage (`.getValues()` and after a while `.clear()`) was not.
There was a risk of losing the values in cache between those calls for both `MapCache` and `LruCache`.

MapCache methods were synchronized (synchronization locked the instance itself).

# Proposed Solution

Do a fine-grained locks, `concurrent.Map` is recommended instead of `mutable.Map` 

# Important Changes Introduced

`.drain()` method replaced `.clear()`
It returns all the values that were removed and guarantees that no values are lost
