### PR TITLE
[ETCM-269] Add missing runToFuture to healthcheck endpoint

### DIFF
--- a/src/main/scala/io/iohk/ethereum/jsonrpc/server/http/JsonRpcHttpServer.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/server/http/JsonRpcHttpServer.scala
@@ -103,7 +103,7 @@ trait JsonRpcHttpServer extends Json4sSupport with RateLimit with Logger {
             entity = HttpEntity(ContentTypes.`application/json`, serialization.writePretty(response))
           )
       }
-    complete(httpResponseF)
+    complete(httpResponseF.runToFuture)
   }
 
   private def handleRequest(request: JsonRpcRequest) = {


### PR DESCRIPTION
# Description

The health check endpoint was returning an unusable String. The reason was that a Monix task was being used in the `complete` method of Akka-http.

# Proposed Solution

Add `runToFuture` to the Monix task in the highest layer of the call stack.

# Important Changes Introduced

# Testing

Unit test added.
