### PR TITLE
Made some tests able to succeed more than once

### DIFF
--- a/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
@@ -74,7 +74,7 @@ trait AsyncConfigBuilder {
 }
 
 trait ActorSystemBuilder {
-  implicit lazy val system: ActorSystem = ActorSystem("mantis_system")
+  implicit lazy val system: ActorSystem = ActorSystem("mantis_system", classLoader = Some(getClass.getClassLoader))
 }
 
 trait PruningConfigBuilder extends PruningModeComponent {

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/regular/RegularSyncSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/regular/RegularSyncSpec.scala
@@ -47,13 +47,13 @@ class RegularSyncSpec
   type Fixture = RegularSyncFixture
 
   val actorSystemResource =
-    Resource.make(Task { ActorSystem() })(system => Task { TestKit.shutdownActorSystem(system) })
+    Resource.make(Task { ActorSystem("default", classLoader = Some(getClass.getClassLoader)) })(system => Task { TestKit.shutdownActorSystem(system) })
   val fixtureResource = actorSystemResource.map(new Fixture(_))
 
   // Used only in sync tests
   var testSystem: ActorSystem = _
   override def beforeEach: Unit =
-    testSystem = ActorSystem()
+    testSystem = ActorSystem("default", classLoader = Some(getClass.getClassLoader))
   override def afterEach: Unit =
     TestKit.shutdownActorSystem(testSystem)
 


### PR DESCRIPTION
# Description

Some of the tests, where the `ActorSystem` was involved could be run successfully only once:
-`MantisServiceSpec`
-`TransactionHistoryServiceSpec`
-`RegularSyncSpec`

On the second run a `ClassCastException` was thrown

```
[info] MantisServiceSpec:                                                                                                                                                                                                                          
[info] Mantis Service                                                                                                                                                                                                                              
[info] - should get account's transaction history (1 second, 351 milliseconds)                                                                                                                                                                     
[info] - should validate range size against configuration *** FAILED *** (83 milliseconds)                                                                                                                                                         
[info]   java.lang.ClassCastException: interface akka.event.LoggingFilter is not assignable from class akka.event.slf4j.Slf4jLoggingFilter
```

Initial research told that something is spoiling the environment, because clean run always succeeded.
But the main source of the problem lied deeper - in a classloader! 

This seems not to be very suspicious:
```java.lang.ClassCastException: interface akka.event.LoggingFilter is not assignable from class akka.event.slf4j.Slf4jLoggingFilter```

But this situation:
```java.lang.ClassCastException: interface akka.event.LoggingFilter is not assignable from class akka.event.DefaultLoggingFilter```

...in a single jvm can be caused only when:
- LoggingFilter was loaded with ClassLoader 1
- DefaultLoggingFilter was loaded using ClassLoader 2

And here is a proof that it is a very annoying bug in akka itself:
https://samwrx.surge.sh/akka/2016/01/11/akkaloggingfilters.html


# Proposed Solution

**Always** specify a classloader when creating an ActorSystem.
This might seem ugly, but it works... And there's not much one can do with an upstream issue.