### PR TITLE
Fix #841 tests

### DIFF
--- a/src/main/scala/io/iohk/ethereum/extvm/VMServer.scala
+++ b/src/main/scala/io/iohk/ethereum/extvm/VMServer.scala
@@ -70,10 +70,11 @@ class VMServer(messageHandler: MessageHandler) extends Logger {
 
   private def awaitHello(): Unit = {
     val helloMsg = messageHandler.awaitMessage[msg.Hello]
-    require(helloMsg.version == ApiVersionProvider.version,
-      s"Wrong Hello message version. Expected ${ApiVersionProvider.version} but was ${helloMsg.version}")
-    require(helloMsg.config.isEthereumConfig,
-      "Hello message ethereum config must be true")
+    require(
+      helloMsg.version == ApiVersionProvider.version,
+      s"Wrong Hello message version. Expected ${ApiVersionProvider.version} but was ${helloMsg.version}"
+    )
+    require(helloMsg.config.isEthereumConfig, "Hello message ethereum config must be true")
     defaultBlockchainConfig = constructBlockchainConfig(helloMsg.config.ethereumConfig.get)
   }
 

--- a/src/main/scala/io/iohk/ethereum/extvm/VMServer.scala
+++ b/src/main/scala/io/iohk/ethereum/extvm/VMServer.scala
@@ -70,8 +70,10 @@ class VMServer(messageHandler: MessageHandler) extends Logger {
 
   private def awaitHello(): Unit = {
     val helloMsg = messageHandler.awaitMessage[msg.Hello]
-    require(helloMsg.version == ApiVersionProvider.version)
-    require(helloMsg.config.isEthereumConfig)
+    require(helloMsg.version == ApiVersionProvider.version,
+      s"Wrong Hello message version. Expected ${ApiVersionProvider.version} but was ${helloMsg.version}")
+    require(helloMsg.config.isEthereumConfig,
+      "Hello message ethereum config must be true")
     defaultBlockchainConfig = constructBlockchainConfig(helloMsg.config.ethereumConfig.get)
   }
 

--- a/src/test/scala/io/iohk/ethereum/extvm/VMServerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/extvm/VMServerSpec.scala
@@ -110,7 +110,7 @@ class VMServerSpec extends AnyFlatSpec with Matchers with MockFactory {
       accountStartNonce = blockchainConfig.accountStartNonce
     )
     val ethereumConfigMsg = msg.Hello.Config.EthereumConfig(ethereumConfig)
-    val helloMsg = msg.Hello(version = "1.1", config = ethereumConfigMsg)
+    val helloMsg = msg.Hello(version = "2.0", config = ethereumConfigMsg)
 
     val messageHandler = mock[MessageHandler]
     val vmServer = new VMServer(messageHandler)


### PR DESCRIPTION
# Description

Changes in #841 broke `VMServerSpec` because the test hello message wasn't updated from 1.1 to 2.0.

# Proposed Solution

Change hello message in tests to version 2.0.
