### PR TITLE
[FIX] Processing checkpoint blocks by fetcher

### DIFF
--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/regular/BlockFetcherState.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/regular/BlockFetcherState.scala
@@ -3,16 +3,16 @@ package io.iohk.ethereum.blockchain.sync.regular
 import akka.actor.ActorRef
 import akka.util.ByteString
 import cats.data.NonEmptyList
-import io.iohk.ethereum.consensus.validators.BlockValidator
 import cats.implicits._
 import io.iohk.ethereum.blockchain.sync.regular.BlockFetcherState._
+import io.iohk.ethereum.consensus.validators.BlockValidator
 import io.iohk.ethereum.domain.{Block, BlockBody, BlockHeader, HeadersSeq}
 import io.iohk.ethereum.network.PeerId
 import io.iohk.ethereum.network.p2p.messages.PV62.BlockHash
+import io.iohk.ethereum.utils.ByteStringUtils
 
-import scala.collection.immutable.Queue
 import scala.annotation.tailrec
-import io.iohk.ethereum.consensus.validators.BlockValidator
+import scala.collection.immutable.Queue
 
 // scalastyle:off number.of.methods
 /**
@@ -53,7 +53,7 @@ case class BlockFetcherState(
 
   private def hasEmptyBuffer: Boolean = readyBlocks.isEmpty && waitingHeaders.isEmpty
 
-  def hasFetchedTopHeader: Boolean = lastBlock == knownTop
+  def hasFetchedTopHeader: Boolean = nextBlockToFetch == knownTop + 1
 
   def isOnTop: Boolean = hasFetchedTopHeader && hasEmptyBuffer
 
@@ -83,10 +83,30 @@ case class BlockFetcherState(
       val lastNumber = HeadersSeq.lastNumber(validHeaders)
       withPossibleNewTopAt(lastNumber)
         .copy(
-          waitingHeaders = waitingHeaders ++ validHeaders,
-          lastBlock = lastNumber.getOrElse(lastBlock)
+          waitingHeaders = waitingHeaders ++ validHeaders
         )
     })
+
+  def tryInsertBlock(block: Block, peerId: PeerId): Either[String, BlockFetcherState] = {
+    val blockHash = block.hash
+    if (isExist(blockHash)) {
+      Right(this)
+    } else if (isExistInReadyBlocks(block.header.parentHash)) {
+      val newState = clearQueues()
+        .copy(
+          readyBlocks = readyBlocks.takeWhile(_.number < block.number).enqueue(block)
+        )
+        .withPeerForBlocks(peerId, Seq(block.number))
+        .withKnownTopAt(block.number)
+      Right(newState)
+    } else if (isExistInWaitingHeaders(block.header.parentHash)) {
+      val newState = copy(
+        waitingHeaders = waitingHeaders.takeWhile(_.number < block.number).enqueue(block.header)
+      )
+        .withKnownTopAt(block.number)
+      Right(newState)
+    } else Left(s"Cannot insert block [${ByteStringUtils.hash2string(blockHash)}] into the queues")
+  }
 
   /**
     * Validates received headers consistency and their compatibilty with the state
@@ -169,7 +189,6 @@ case class BlockFetcherState(
         if (waitingHeader.hash == block.hash)
           withPeerForBlocks(fromPeer, Seq(block.number))
             .withPossibleNewTopAt(block.number)
-            .withLastBlock(block.number)
             .copy(
               readyBlocks = readyBlocks.enqueue(block),
               waitingHeaders = waitingHeadersTail
@@ -182,7 +201,7 @@ case class BlockFetcherState(
   def pickBlocks(amount: Int): Option[(NonEmptyList[Block], BlockFetcherState)] =
     if (readyBlocks.nonEmpty) {
       val (picked, rest) = readyBlocks.splitAt(amount)
-      Some((NonEmptyList(picked.head, picked.tail.toList), copy(readyBlocks = rest)))
+      Some((NonEmptyList(picked.head, picked.tail.toList), copy(readyBlocks = rest, lastBlock = picked.last.number)))
     } else {
       None
     }
@@ -203,27 +222,40 @@ case class BlockFetcherState(
       .map(blocks => (NonEmptyList(blocks.head, blocks.tail.toList), copy(readyBlocks = Queue())))
   }
 
-  def invalidateBlocksFrom(nr: BigInt): (Option[PeerId], BlockFetcherState) = invalidateBlocksFrom(nr, Some(nr))
-
-  def invalidateBlocksFrom(nr: BigInt, toBlacklist: Option[BigInt]): (Option[PeerId], BlockFetcherState) = {
+  def clearQueues(): BlockFetcherState = {
     // We can't start completely from scratch as requests could be in progress, we have to keep special track of them
     val newFetchingHeadersState =
       if (fetchingHeadersState == AwaitingHeaders) AwaitingHeadersToBeIgnored else fetchingHeadersState
     val newFetchingBodiesState =
       if (fetchingBodiesState == AwaitingBodies) AwaitingBodiesToBeIgnored else fetchingBodiesState
 
-    (
-      toBlacklist.flatMap(blockProviders.get),
-      copy(
-        readyBlocks = Queue(),
-        waitingHeaders = Queue(),
-        lastBlock = (nr - 2).max(0),
-        fetchingHeadersState = newFetchingHeadersState,
-        fetchingBodiesState = newFetchingBodiesState,
-        blockProviders = blockProviders - nr
-      )
+    copy(
+      readyBlocks = Queue(),
+      waitingHeaders = Queue(),
+      fetchingHeadersState = newFetchingHeadersState,
+      fetchingBodiesState = newFetchingBodiesState
     )
   }
+
+  def invalidateBlocksFrom(nr: BigInt): (Option[PeerId], BlockFetcherState) = invalidateBlocksFrom(nr, Some(nr))
+
+  def invalidateBlocksFrom(nr: BigInt, toBlacklist: Option[BigInt]): (Option[PeerId], BlockFetcherState) = {
+    (
+      toBlacklist.flatMap(blockProviders.get),
+      this
+        .clearQueues()
+        .copy(
+          lastBlock = (nr - 2).max(0),
+          blockProviders = blockProviders - nr
+        )
+    )
+  }
+
+  def isExist(hash: ByteString): Boolean = isExistInReadyBlocks(hash) || isExistInWaitingHeaders(hash)
+
+  def isExistInWaitingHeaders(hash: ByteString): Boolean = waitingHeaders.exists(_.hash == hash)
+
+  def isExistInReadyBlocks(hash: ByteString): Boolean = readyBlocks.exists(_.hash == hash)
 
   def withLastBlock(nr: BigInt): BlockFetcherState = copy(lastBlock = nr)
 

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/regular/BlockImporter.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/regular/BlockImporter.scala
@@ -90,6 +90,8 @@ class BlockImporter(
         }
       }
 
+    case NewCheckpointBlock(block, peerId) => importNewBlock(block, peerId, state)
+
     case ImportNewBlock(block, peerId) if state.isOnTop && !state.importing => importNewBlock(block, peerId, state)
 
     case ImportDone(newBehavior) =>
@@ -376,6 +378,7 @@ object BlockImporter {
   case object NotOnTop extends ImporterMsg
   case class MinedBlock(block: Block) extends ImporterMsg
   case class NewCheckpoint(parentHash: ByteString, signatures: Seq[ECDSASignature]) extends ImporterMsg
+  case class NewCheckpointBlock(block: Block, peerId: PeerId) extends ImporterMsg
   case class ImportNewBlock(block: Block, peerId: PeerId) extends ImporterMsg
   case class ImportDone(newBehavior: NewBehavior) extends ImporterMsg
   case object PickBlocks extends ImporterMsg

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/regular/BlockFetcherSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/regular/BlockFetcherSpec.scala
@@ -1,55 +1,46 @@
 package io.iohk.ethereum.blockchain.sync.regular
 
-import java.net.InetSocketAddress
-
 import akka.actor.ActorSystem
 import akka.testkit.{TestKit, TestProbe}
+import cats.data.NonEmptyList
 import com.miguno.akka.testing.VirtualTime
-import io.iohk.ethereum.Mocks.{MockValidatorsAlwaysSucceed, MockValidatorsFailingOnBlockBodies}
-import io.iohk.ethereum.{BlockHelpers, Timeouts, WithActorSystemShutDown}
 import io.iohk.ethereum.Fixtures.{Blocks => FixtureBlocks}
+import io.iohk.ethereum.Mocks.{MockValidatorsAlwaysSucceed, MockValidatorsFailingOnBlockBodies}
 import io.iohk.ethereum.blockchain.sync.PeersClient.BlacklistPeer
 import io.iohk.ethereum.blockchain.sync.regular.BlockFetcher.{InternalLastBlockImport, InvalidateBlocksFrom, PickBlocks}
 import io.iohk.ethereum.blockchain.sync.{PeersClient, TestSyncConfig}
-import io.iohk.ethereum.domain.{Block, HeadersSeq}
+import io.iohk.ethereum.checkpointing.CheckpointingTestHelpers
+import io.iohk.ethereum.consensus.blocks.CheckpointBlockGenerator
+import io.iohk.ethereum.domain.{Block, ChainWeight, Checkpoint, HeadersSeq}
 import io.iohk.ethereum.network.Peer
 import io.iohk.ethereum.network.PeerEventBusActor.PeerEvent.MessageFromPeer
 import io.iohk.ethereum.network.PeerEventBusActor.SubscriptionClassifier.MessageClassifier
 import io.iohk.ethereum.network.PeerEventBusActor.{PeerSelector, Subscribe}
-import io.iohk.ethereum.network.p2p.messages.Codes
 import io.iohk.ethereum.network.p2p.messages.CommonMessages.NewBlock
 import io.iohk.ethereum.network.p2p.messages.PV62._
+import io.iohk.ethereum.network.p2p.messages.{Codes, PV64}
+import io.iohk.ethereum.security.SecureRandomBuilder
+import io.iohk.ethereum.{BlockHelpers, Timeouts, WithActorSystemShutDown, crypto}
 import org.scalatest.freespec.AnyFreeSpecLike
 import org.scalatest.matchers.should.Matchers
 
+import java.net.InetSocketAddress
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 
 class BlockFetcherSpec
     extends TestKit(ActorSystem("BlockFetcherSpec_System"))
     with AnyFreeSpecLike
     with WithActorSystemShutDown
-    with Matchers {
+    with Matchers
+    with SecureRandomBuilder {
 
   "BlockFetcher" - {
 
     "should not requests headers upon invalidation while a request is already in progress, should resume after response" in new TestSetup {
       startFetcher()
 
-      // First headers request
-      val firstGetBlockHeadersRequest =
-        GetBlockHeaders(Left(1), syncConfig.blockHeadersPerRequest, skip = 0, reverse = false)
-      peersClient.expectMsgPF() { case PeersClient.Request(msg, _, _) if msg == firstGetBlockHeadersRequest => () }
-
-      val firstBlocksBatch = BlockHelpers.generateChain(syncConfig.blockHeadersPerRequest, FixtureBlocks.Genesis.block)
-      val firstGetBlockHeadersResponse = BlockHeaders(firstBlocksBatch.map(_.header))
-      peersClient.reply(PeersClient.Response(fakePeer, firstGetBlockHeadersResponse))
-
-      // First bodies request
-      val firstGetBlockBodiesRequest = GetBlockBodies(firstBlocksBatch.map(_.hash))
-      peersClient.expectMsgPF() { case PeersClient.Request(msg, _, _) if msg == firstGetBlockBodiesRequest => () }
-
-      val firstGetBlockBodiesResponse = BlockBodies(firstBlocksBatch.map(_.body))
-      peersClient.reply(PeersClient.Response(fakePeer, firstGetBlockBodiesResponse))
+      handleFirstBlockBatch()
 
       triggerFetching()
 
@@ -82,21 +73,7 @@ class BlockFetcherSpec
     "should not requests headers upon invalidation while a request is already in progress, should resume after failure in response" in new TestSetup {
       startFetcher()
 
-      // First headers request
-      val firstGetBlockHeadersRequest =
-        GetBlockHeaders(Left(1), syncConfig.blockHeadersPerRequest, skip = 0, reverse = false)
-      peersClient.expectMsgPF() { case PeersClient.Request(msg, _, _) if msg == firstGetBlockHeadersRequest => () }
-
-      val firstBlocksBatch = BlockHelpers.generateChain(syncConfig.blockHeadersPerRequest, FixtureBlocks.Genesis.block)
-      val firstGetBlockHeadersResponse = BlockHeaders(firstBlocksBatch.map(_.header))
-      peersClient.reply(PeersClient.Response(fakePeer, firstGetBlockHeadersResponse))
-
-      // First bodies request
-      val firstGetBlockBodiesRequest = GetBlockBodies(firstBlocksBatch.map(_.hash))
-      peersClient.expectMsgPF() { case PeersClient.Request(msg, _, _) if msg == firstGetBlockBodiesRequest => () }
-
-      val firstGetBlockBodiesResponse = BlockBodies(firstBlocksBatch.map(_.body))
-      peersClient.reply(PeersClient.Response(fakePeer, firstGetBlockBodiesResponse))
+      handleFirstBlockBatch()
 
       triggerFetching()
 
@@ -132,24 +109,11 @@ class BlockFetcherSpec
 
       startFetcher()
 
-      val getBlockHeadersRequest =
-        GetBlockHeaders(Left(1), syncConfig.blockHeadersPerRequest, skip = 0, reverse = false)
-      peersClient.expectMsgPF() { case PeersClient.Request(msg, _, _) if msg == getBlockHeadersRequest => () }
-
-      val chain = BlockHelpers.generateChain(syncConfig.blockHeadersPerRequest, FixtureBlocks.Genesis.block)
-      val getBlockHeadersResponse = BlockHeaders(chain.map(_.header))
-      peersClient.reply(PeersClient.Response(fakePeer, getBlockHeadersResponse))
-
-      val getBlockBodiesRequest = GetBlockBodies(chain.map(_.hash))
-      peersClient.expectMsgPF() { case PeersClient.Request(msg, _, _) if msg == getBlockBodiesRequest => () }
-
-      // This response will be invalid given we are using a special validator!
-      val getBlockBodiesResponse = BlockBodies(chain.map(_.body))
-      peersClient.reply(PeersClient.Response(fakePeer, getBlockBodiesResponse))
+      handleFirstBlockBatch()
 
       // Fetcher should blacklist the peer and retry asking for the same bodies
       peersClient.expectMsgClass(classOf[BlacklistPeer])
-      peersClient.expectMsgPF() { case PeersClient.Request(msg, _, _) if msg == getBlockBodiesRequest => () }
+      peersClient.expectMsgPF() { case PeersClient.Request(msg, _, _) if msg == firstGetBlockBodiesRequest => () }
 
       // Fetcher should not enqueue any new block
       importer.send(blockFetcher, PickBlocks(syncConfig.blocksBatchSize))
@@ -161,27 +125,16 @@ class BlockFetcherSpec
 
       startFetcher()
 
-      val getBlockHeadersRequest =
-        GetBlockHeaders(Left(1), syncConfig.blockHeadersPerRequest, skip = 0, reverse = false)
-      peersClient.expectMsgPF() { case PeersClient.Request(msg, _, _) if msg == getBlockHeadersRequest => () }
+      handleFirstBlockBatchHeaders()
 
-      val chain = BlockHelpers.generateChain(syncConfig.blockHeadersPerRequest, FixtureBlocks.Genesis.block)
-
-      val getBlockHeadersResponse = BlockHeaders(chain.map(_.header))
-      peersClient.reply(PeersClient.Response(fakePeer, getBlockHeadersResponse))
-
-      val getBlockBodiesRequest1 = GetBlockBodies(chain.map(_.hash))
+      val getBlockBodiesRequest1 = GetBlockBodies(firstBlocksBatch.map(_.hash))
       peersClient.expectMsgPF() { case PeersClient.Request(msg, _, _) if msg == getBlockBodiesRequest1 => () }
 
       // It will receive all the requested bodies, but splitted in 2 parts.
-      val (subChain1, subChain2) = chain.splitAt(syncConfig.blockBodiesPerRequest / 2)
+      val (subChain1, subChain2) = firstBlocksBatch.splitAt(syncConfig.blockBodiesPerRequest / 2)
 
       val getBlockBodiesResponse1 = BlockBodies(subChain1.map(_.body))
       peersClient.reply(PeersClient.Response(fakePeer, getBlockBodiesResponse1))
-
-      val getBlockHeadersRequest2 =
-        GetBlockHeaders(Left(chain.last.number + 1), syncConfig.blockHeadersPerRequest, skip = 0, reverse = false)
-      peersClient.expectMsgPF() { case PeersClient.Request(msg, _, _) if msg == getBlockHeadersRequest2 => () }
 
       val getBlockBodiesRequest2 = GetBlockBodies(subChain2.map(_.hash))
       peersClient.expectMsgPF() { case PeersClient.Request(msg, _, _) if msg == getBlockBodiesRequest2 => () }
@@ -190,13 +143,14 @@ class BlockFetcherSpec
       peersClient.reply(PeersClient.Response(fakePeer, getBlockBodiesResponse2))
 
       // We need to wait a while in order to allow fetcher to process all the blocks
-      Thread.sleep(Timeouts.shortTimeout.toMillis)
+      system.scheduler.scheduleOnce(Timeouts.shortTimeout) {
+        // Fetcher should enqueue all the received blocks
+        importer.send(blockFetcher, PickBlocks(firstBlocksBatch.size))
+      }
 
-      // Fetcher should enqueue all the received blocks
-      importer.send(blockFetcher, PickBlocks(chain.size))
       importer.ignoreMsg({ case BlockImporter.NotOnTop => true })
       importer.expectMsgPF() { case BlockFetcher.PickedBlocks(blocks) =>
-        blocks.map(_.hash).toList shouldEqual chain.map(_.hash)
+        blocks.map(_.hash).toList shouldEqual firstBlocksBatch.map(_.hash)
       }
     }
 
@@ -204,27 +158,16 @@ class BlockFetcherSpec
 
       startFetcher()
 
-      val getBlockHeadersRequest =
-        GetBlockHeaders(Left(1), syncConfig.blockHeadersPerRequest, skip = 0, reverse = false)
-      peersClient.expectMsgPF() { case PeersClient.Request(msg, _, _) if msg == getBlockHeadersRequest => () }
+      handleFirstBlockBatchHeaders()
 
-      val chain = BlockHelpers.generateChain(syncConfig.blockHeadersPerRequest, FixtureBlocks.Genesis.block)
-
-      val getBlockHeadersResponse = BlockHeaders(chain.map(_.header))
-      peersClient.reply(PeersClient.Response(fakePeer, getBlockHeadersResponse))
-
-      val getBlockBodiesRequest1 = GetBlockBodies(chain.map(_.hash))
+      val getBlockBodiesRequest1 = GetBlockBodies(firstBlocksBatch.map(_.hash))
       peersClient.expectMsgPF() { case PeersClient.Request(msg, _, _) if msg == getBlockBodiesRequest1 => () }
 
       // It will receive part of the requested bodies.
-      val (subChain1, subChain2) = chain.splitAt(syncConfig.blockBodiesPerRequest / 2)
+      val (subChain1, subChain2) = firstBlocksBatch.splitAt(syncConfig.blockBodiesPerRequest / 2)
 
       val getBlockBodiesResponse1 = BlockBodies(subChain1.map(_.body))
       peersClient.reply(PeersClient.Response(fakePeer, getBlockBodiesResponse1))
-
-      val getBlockHeadersRequest2 =
-        GetBlockHeaders(Left(chain.last.number + 1), syncConfig.blockHeadersPerRequest, skip = 0, reverse = false)
-      peersClient.expectMsgPF() { case PeersClient.Request(msg, _, _) if msg == getBlockHeadersRequest2 => () }
 
       val getBlockBodiesRequest2 = GetBlockBodies(subChain2.map(_.hash))
       peersClient.expectMsgPF() { case PeersClient.Request(msg, _, _) if msg == getBlockBodiesRequest2 => () }
@@ -234,7 +177,7 @@ class BlockFetcherSpec
       peersClient.reply(PeersClient.Response(fakePeer, getBlockBodiesResponse2))
 
       // If we try to pick the whole chain we should only receive the first part
-      importer.send(blockFetcher, PickBlocks(chain.size))
+      importer.send(blockFetcher, PickBlocks(firstBlocksBatch.size))
       importer.ignoreMsg({ case BlockImporter.NotOnTop => true })
       importer.expectMsgPF() { case BlockFetcher.PickedBlocks(blocks) =>
         blocks.map(_.hash).toList shouldEqual subChain1.map(_.hash)
@@ -246,19 +189,11 @@ class BlockFetcherSpec
 
       triggerFetching()
 
-      val firstBlocksBatch = BlockHelpers.generateChain(syncConfig.blockHeadersPerRequest, FixtureBlocks.Genesis.block)
       val secondBlocksBatch = BlockHelpers.generateChain(syncConfig.blockHeadersPerRequest, firstBlocksBatch.last)
       val alternativeSecondBlocksBatch =
         BlockHelpers.generateChain(syncConfig.blockHeadersPerRequest, firstBlocksBatch.last)
 
-      // Fetcher requests for headers
-      val firstGetBlockHeadersRequest =
-        GetBlockHeaders(Left(1), syncConfig.blockHeadersPerRequest, skip = 0, reverse = false)
-      peersClient.expectMsgPF() { case PeersClient.Request(msg, _, _) if msg == firstGetBlockHeadersRequest => () }
-
-      // Respond first headers request
-      val firstGetBlockHeadersResponse = BlockHeaders(firstBlocksBatch.map(_.header))
-      peersClient.reply(PeersClient.Response(fakePeer, firstGetBlockHeadersResponse))
+      handleFirstBlockBatchHeaders()
 
       // Second headers request with response pending
       val secondGetBlockHeadersRequest = GetBlockHeaders(
@@ -273,7 +208,6 @@ class BlockFetcherSpec
       }
 
       // First bodies request
-      val firstGetBlockBodiesRequest = GetBlockBodies(firstBlocksBatch.map(_.hash))
       val refForAnswerFirstBodiesReq = peersClient.expectMsgPF() {
         case PeersClient.Request(msg, _, _) if msg == firstGetBlockBodiesRequest => peersClient.lastSender
       }
@@ -313,6 +247,179 @@ class BlockFetcherSpec
       }
     }
 
+    "should process checkpoint blocks when checkpoint can fit into ready blocks queue" in new TestSetup {
+      startFetcher()
+
+      triggerFetching(20)
+
+      val secondBlocksBatch = BlockHelpers.generateChain(syncConfig.blockHeadersPerRequest, firstBlocksBatch.last)
+      val checkpointBlock = (new CheckpointBlockGenerator)
+        .generate(
+          firstBlocksBatch.last,
+          Checkpoint(CheckpointingTestHelpers.createCheckpointSignatures(Seq(crypto.generateKeyPair(secureRandom)), firstBlocksBatch.last.hash))
+        )
+
+      handleFirstBlockBatchHeaders()
+
+      // Fetcher second request for headers
+      val secondGetBlockHeadersRequest =
+        GetBlockHeaders(Left(secondBlocksBatch.head.number), syncConfig.blockHeadersPerRequest, skip = 0, reverse = false)
+      peersClient.expectMsgPF() { case PeersClient.Request(msg, _, _) if msg == secondGetBlockHeadersRequest => () }
+
+      // Respond second headers request
+      val secondGetBlockHeadersResponse = BlockHeaders(secondBlocksBatch.map(_.header))
+      peersClient.reply(PeersClient.Response(fakePeer, secondGetBlockHeadersResponse))
+
+      handleFirstBlockBatchBodies()
+
+      // Second bodies request
+      val secondGetBlockBodiesRequest = GetBlockBodies(secondBlocksBatch.map(_.hash))
+      peersClient.expectMsgPF() { case PeersClient.Request(msg, _, _) if msg == secondGetBlockBodiesRequest => () }
+
+      // Second bodies response
+      val secondGetBlockBodiesResponse = BlockBodies(secondBlocksBatch.map(_.body))
+      peersClient.reply(PeersClient.Response(fakePeer, secondGetBlockBodiesResponse))
+
+      // send old checkpoint block
+      blockFetcher ! MessageFromPeer(PV64.NewBlock(checkpointBlock, ChainWeight(checkpointBlock.number, checkpointBlock.header.difficulty)), fakePeer.id)
+
+      importer.send(blockFetcher, PickBlocks(syncConfig.blocksBatchSize * 2))
+      importer.expectMsgPF() { case BlockFetcher.PickedBlocks(blocks) =>
+        val headers = blocks.map(_.header).toList
+
+        assert(HeadersSeq.areChain(headers))
+        assert(headers.lastOption.contains(checkpointBlock.header))
+      }
+    }
+
+    "should process checkpoint blocks when checkpoint can fit into waiting headers queue" in new TestSetup {
+      startFetcher()
+
+      triggerFetching(20)
+
+      val secondBlocksBatch = BlockHelpers.generateChain(syncConfig.blockHeadersPerRequest, firstBlocksBatch.last)
+      val secondBlocksBatchFirstPart = secondBlocksBatch.splitAt(5)._1
+      val checkpointBlock = (new CheckpointBlockGenerator)
+        .generate(
+          secondBlocksBatchFirstPart.last,
+          Checkpoint(CheckpointingTestHelpers.createCheckpointSignatures(Seq(crypto.generateKeyPair(secureRandom)), secondBlocksBatchFirstPart.last.hash))
+        )
+
+      val alternativeSecondBlocksBatch = secondBlocksBatchFirstPart :+ checkpointBlock
+
+      handleFirstBlockBatchHeaders()
+
+      // Fetcher second request for headers
+      val secondGetBlockHeadersRequest =
+        GetBlockHeaders(Left(secondBlocksBatch.head.number), syncConfig.blockHeadersPerRequest, skip = 0, reverse = false)
+      peersClient.expectMsgPF() { case PeersClient.Request(msg, _, _) if msg == secondGetBlockHeadersRequest => () }
+
+      // Respond second headers request
+      val secondGetBlockHeadersResponse = BlockHeaders(secondBlocksBatch.map(_.header))
+      peersClient.reply(PeersClient.Response(fakePeer, secondGetBlockHeadersResponse))
+
+      handleFirstBlockBatchBodies()
+
+      // send old checkpoint block
+      blockFetcher ! MessageFromPeer(PV64.NewBlock(checkpointBlock, ChainWeight(checkpointBlock.number, checkpointBlock.header.difficulty)), fakePeer.id)
+
+      // Second bodies request
+      val secondGetBlockBodiesRequest = GetBlockBodies(alternativeSecondBlocksBatch.map(_.hash))
+      peersClient.expectMsgPF() { case PeersClient.Request(msg, _, _) if msg == secondGetBlockBodiesRequest => () }
+
+      // Second bodies response
+      val secondGetBlockBodiesResponse = BlockBodies(alternativeSecondBlocksBatch.map(_.body))
+      peersClient.reply(PeersClient.Response(fakePeer, secondGetBlockBodiesResponse))
+
+      // We need to wait a while in order to allow fetcher to process all the blocks
+      system.scheduler.scheduleOnce(Timeouts.shortTimeout) {
+        importer.send(blockFetcher, PickBlocks(syncConfig.blocksBatchSize * 2))
+      }
+
+      importer.expectMsgPF() { case BlockFetcher.PickedBlocks(blocks) =>
+        val headers = blocks.map(_.header).toList
+
+        assert(HeadersSeq.areChain(headers))
+        assert(headers.contains(checkpointBlock.header))
+      }
+    }
+
+    "should process checkpoint blocks when checkpoint not fit into queues" in new TestSetup {
+      startFetcher()
+
+      triggerFetching(10)
+
+      val alternativeBlocksBatch = BlockHelpers.generateChain(syncConfig.blockHeadersPerRequest / 2, FixtureBlocks.Genesis.block)
+      val checkpointBlock = (new CheckpointBlockGenerator)
+        .generate(
+          alternativeBlocksBatch.last,
+          Checkpoint(CheckpointingTestHelpers.createCheckpointSignatures(Seq(crypto.generateKeyPair(secureRandom)), alternativeBlocksBatch.last.hash))
+        )
+
+      val alternativeBlocksBatchWithCheckpoint = alternativeBlocksBatch :+ checkpointBlock
+
+      handleFirstBlockBatch()
+
+      // send checkpoint block
+      blockFetcher ! MessageFromPeer(PV64.NewBlock(checkpointBlock, ChainWeight(checkpointBlock.number, checkpointBlock.header.difficulty)), fakePeer.id)
+
+      // Fetcher new request for headers
+      peersClient.expectMsgPF() { case PeersClient.Request(msg, _, _) if msg == firstGetBlockHeadersRequest => () }
+
+      // Respond first headers request
+      val newGetBlockHeadersResponse = BlockHeaders(alternativeBlocksBatchWithCheckpoint.map(_.header))
+      peersClient.reply(PeersClient.Response(fakePeer, newGetBlockHeadersResponse))
+
+      // new bodies request
+      val newGetBlockBodiesRequest = GetBlockBodies(alternativeBlocksBatchWithCheckpoint.map(_.hash))
+      peersClient.expectMsgPF() { case PeersClient.Request(msg, _, _) if msg == newGetBlockBodiesRequest => () }
+
+      // First bodies response
+      val newGetBlockBodiesResponse = BlockBodies(alternativeBlocksBatchWithCheckpoint.map(_.body))
+      peersClient.reply(PeersClient.Response(fakePeer, newGetBlockBodiesResponse))
+
+      // We need to wait a while in order to allow fetcher to process all the blocks
+      system.scheduler.scheduleOnce(Timeouts.shortTimeout) {
+        importer.send(blockFetcher, PickBlocks(syncConfig.blocksBatchSize))
+      }
+
+      importer.expectMsgPF() { case BlockFetcher.PickedBlocks(blocks) =>
+        val headers = blocks.map(_.header).toList
+
+        assert(HeadersSeq.areChain(headers))
+        assert(headers.contains(checkpointBlock.header))
+      }
+    }
+
+    "should inform importer when checkpoint block is older than last block" in new TestSetup {
+      startFetcher()
+
+      triggerFetching(10)
+
+      val alternativeBlocksBatch = BlockHelpers.generateChain(syncConfig.blockHeadersPerRequest / 2, FixtureBlocks.Genesis.block)
+      val checkpointBlock = (new CheckpointBlockGenerator)
+        .generate(
+          alternativeBlocksBatch.last,
+          Checkpoint(CheckpointingTestHelpers.createCheckpointSignatures(Seq(crypto.generateKeyPair(secureRandom)), alternativeBlocksBatch.last.hash))
+        )
+
+      handleFirstBlockBatch()
+
+      // We need to wait a while in order to allow fetcher to process all the blocks
+      system.scheduler.scheduleOnce(Timeouts.shortTimeout) {
+        importer.send(blockFetcher, PickBlocks(syncConfig.blocksBatchSize))
+      }
+
+      importer.expectMsg(BlockFetcher.PickedBlocks(NonEmptyList(firstBlocksBatch.head, firstBlocksBatch.tail)))
+
+      // send old checkpoint block
+      blockFetcher ! MessageFromPeer(PV64.NewBlock(checkpointBlock, ChainWeight(checkpointBlock.number, checkpointBlock.header.difficulty)), fakePeer.id)
+
+      importer.expectMsg(BlockImporter.OnTop)
+
+      importer.expectMsg(BlockImporter.NewCheckpointBlock(checkpointBlock, fakePeer.id))
+    }
+
     "should properly handle a request timeout" in new TestSetup {
       override lazy val syncConfig = defaultSyncConfig.copy(
         // Small timeout on ask pattern for testing it here
@@ -321,8 +428,6 @@ class BlockFetcherSpec
 
       startFetcher()
 
-      val firstGetBlockHeadersRequest =
-        GetBlockHeaders(Left(1), syncConfig.blockHeadersPerRequest, skip = 0, reverse = false)
       peersClient.expectMsgPF() { case PeersClient.Request(msg, _, _) if msg == firstGetBlockHeadersRequest => () }
 
       // Request should timeout without any response from the peer
@@ -346,6 +451,7 @@ class BlockFetcherSpec
       // Same request size was selected for simplification purposes of the flow
       blockHeadersPerRequest = 10,
       blockBodiesPerRequest = 10,
+      blocksBatchSize = 10,
       // Huge timeout on ask pattern
       peerResponseTimeout = 5.minutes
     )
@@ -379,11 +485,40 @@ class BlockFetcherSpec
 
     // Sending a far away block as a NewBlock message
     // Currently BlockFetcher only downloads first block-headers-per-request blocks without this
-    def triggerFetching(): Unit = {
+    def triggerFetching(startingNumber: BigInt = 1000): Unit = {
       val farAwayBlockTotalDifficulty = 100000
-      val farAwayBlock = Block(FixtureBlocks.ValidBlock.header.copy(number = 1000), FixtureBlocks.ValidBlock.body)
+      val farAwayBlock = Block(FixtureBlocks.ValidBlock.header.copy(number = startingNumber), FixtureBlocks.ValidBlock.body)
 
       blockFetcher ! MessageFromPeer(NewBlock(farAwayBlock, farAwayBlockTotalDifficulty), fakePeer.id)
+    }
+
+    val firstBlocksBatch = BlockHelpers.generateChain(syncConfig.blockHeadersPerRequest, FixtureBlocks.Genesis.block)
+
+    // Fetcher request for headers
+    val firstGetBlockHeadersRequest =
+      GetBlockHeaders(Left(1), syncConfig.blockHeadersPerRequest, skip = 0, reverse = false)
+
+    def handleFirstBlockBatchHeaders() = {
+      peersClient.expectMsgPF() { case PeersClient.Request(msg, _, _) if msg == firstGetBlockHeadersRequest => () }
+
+      // Respond first headers request
+      val firstGetBlockHeadersResponse = BlockHeaders(firstBlocksBatch.map(_.header))
+      peersClient.reply(PeersClient.Response(fakePeer, firstGetBlockHeadersResponse))
+    }
+
+    // First bodies request
+    val firstGetBlockBodiesRequest = GetBlockBodies(firstBlocksBatch.map(_.hash))
+    def handleFirstBlockBatchBodies() = {
+      peersClient.expectMsgPF() { case PeersClient.Request(msg, _, _) if msg == firstGetBlockBodiesRequest => () }
+
+      // First bodies response
+      val firstGetBlockBodiesResponse = BlockBodies(firstBlocksBatch.map(_.body))
+      peersClient.reply(PeersClient.Response(fakePeer, firstGetBlockBodiesResponse))
+    }
+
+    def handleFirstBlockBatch() = {
+      handleFirstBlockBatchHeaders()
+      handleFirstBlockBatchBodies()
     }
   }
 }

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/regular/BlockFetcherStateSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/regular/BlockFetcherStateSpec.scala
@@ -5,6 +5,7 @@ import akka.testkit.{TestKit, TestProbe}
 import io.iohk.ethereum.Mocks.MockValidatorsAlwaysSucceed
 import io.iohk.ethereum.{BlockHelpers, WithActorSystemShutDown}
 import io.iohk.ethereum.network.PeerId
+import io.iohk.ethereum.utils.ByteStringUtils
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
@@ -18,10 +19,15 @@ class BlockFetcherStateSpec
 
   lazy val validators = new MockValidatorsAlwaysSucceed
 
+  private val importer = TestProbe().ref
+
+  private val blocks = BlockHelpers.generateChain(5, BlockHelpers.genesis)
+
+  private val peer = PeerId("foo")
+
   "BlockFetcherState" when {
     "invalidating blocks" should {
       "not allow to go to negative block number" in {
-        val importer = TestProbe().ref
         val (_, actual) =
           BlockFetcherState.initial(importer, validators.blockValidator, 10).invalidateBlocksFrom(-5, None)
 
@@ -31,9 +37,7 @@ class BlockFetcherStateSpec
 
     "handling requested blocks" should {
       "clear headers queue if got empty list of blocks" in {
-        val importer = TestProbe().ref
-        val headers = BlockHelpers.generateChain(5, BlockHelpers.genesis).map(_.header)
-        val peer = PeerId("foo")
+        val headers = blocks.map(_.header)
 
         val result = BlockFetcherState
           .initial(importer, validators.blockValidator, 0)
@@ -41,13 +45,9 @@ class BlockFetcherStateSpec
           .map(_.handleRequestedBlocks(List(), peer))
 
         assert(result.map(_.waitingHeaders) === Right(Queue.empty))
-        assert(result.map(_.lastBlock) === Right(headers.last.number))
       }
 
       "enqueue requested blocks" in {
-        val importer = TestProbe().ref
-        val blocks = BlockHelpers.generateChain(5, BlockHelpers.genesis)
-        val peer = PeerId("foo")
 
         val result = BlockFetcherState
           .initial(importer, validators.blockValidator, 0)
@@ -55,11 +55,70 @@ class BlockFetcherStateSpec
           .map(_.handleRequestedBlocks(blocks, peer))
 
         assert(result.map(_.waitingHeaders) === Right(Queue.empty))
-        assert(result.map(_.lastBlock) === Right(blocks.last.number))
         blocks.foreach { block =>
           assert(result.map(_.blockProviders(block.number)) === Right(peer))
         }
         assert(result.map(_.knownTop) === Right(blocks.last.number))
+      }
+    }
+
+    "trying to insert block into the queues" should {
+      "insert block into the ready blocks queue" in {
+        val (front, _) = blocks.splitAt(2)
+        val testBlock = BlockHelpers.generateBlock(front.last)
+        val peerId = PeerId("bar")
+
+        val result = BlockFetcherState
+          .initial(importer, validators.blockValidator, 0)
+          .appendHeaders(blocks.map(_.header))
+          .map(_.handleRequestedBlocks(blocks, peer))
+          .flatMap(_.tryInsertBlock(testBlock, peerId))
+
+        assert(result.map(_.waitingHeaders) === Right(Queue.empty))
+        assert(result.map(_.readyBlocks) === Right(Queue.empty.enqueue(front :+ testBlock)))
+        front.foreach { block =>
+          assert(result.map(_.blockProviders(block.number)) === Right(peer))
+        }
+        assert(result.map(_.blockProviders(testBlock.number)) === Right(peerId))
+        assert(result.map(_.knownTop) === Right(testBlock.number))
+      }
+
+      "insert block into the waiting headers queue" in {
+        val (front, _) = blocks.splitAt(2)
+        val testBlock = BlockHelpers.generateBlock(front.last)
+
+        val result = BlockFetcherState
+          .initial(importer, validators.blockValidator, 0)
+          .appendHeaders(blocks.map(_.header))
+          .flatMap(_.tryInsertBlock(testBlock, peer))
+
+        assert(result.map(_.readyBlocks) === Right(Queue.empty))
+        assert(result.map(_.waitingHeaders) === Right(Queue.empty.enqueue((front :+ testBlock).map(_.header))))
+        assert(result.map(_.knownTop) === Right(testBlock.number))
+      }
+
+      "return state without changes when block is already in the queues" in {
+        val (front, _) = blocks.splitAt(2)
+        val testBlock = front.last
+
+        val initial = BlockFetcherState
+          .initial(importer, validators.blockValidator, 0)
+          .appendHeaders(blocks.map(_.header))
+
+        val result = initial.flatMap(_.tryInsertBlock(testBlock, peer))
+
+        assert(result === initial)
+      }
+
+      "return error msg when cannot insert block" in {
+        val testBlock = BlockHelpers.generateBlock(BlockHelpers.genesis)
+
+        val result = BlockFetcherState
+          .initial(importer, validators.blockValidator, 0)
+          .appendHeaders(blocks.map(_.header))
+          .flatMap(_.tryInsertBlock(testBlock, peer))
+
+        assert(result === Left(s"Cannot insert block [${ByteStringUtils.hash2string(testBlock.hash)}] into the queues"))
       }
     }
   }


### PR DESCRIPTION
# Description

Currently, the fetcher is not processing new checkpoint blocks which are older than the current top

# Important Changes Introduced

- changed processing of lastBlock in BlockFetcherState (reflects the last block imported by blockchain)
- added processing checkpoint blocks by BlockFetcher

# Testing

Syncing with Mordor testnet: ✔️ 
Need to be tested with federation nodes.

