### PR TITLE
fix - forking solves classloader issues within `ActorSystem`s in tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -160,6 +160,7 @@ lazy val node = {
         libraryDependencies in Compile
       ),
       buildInfoPackage := "io.iohk.ethereum.utils",
+      fork in Test := true,
       buildInfoOptions in Compile += BuildInfoOption.ToMap
     )
     .settings(commonSettings("mantis"): _*)


### PR DESCRIPTION
# Description

This request is a replacement for 
https://github.com/input-output-hk/mantis/pull/863

A proof that it is a very annoying bug in akka itself:
https://samwrx.surge.sh/akka/2016/01/11/akkaloggingfilters.html

# Proposed Solution

A feasible solution should force Akka to use **the only** classloader used to load classes in an app.
In order to fix the classloading issues in SBT tests are performed in a forked jvm now.