### PR TITLE
[FIX] Not starting miner

### DIFF
--- a/src/main/scala/io/iohk/ethereum/consensus/Consensus.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/Consensus.scala
@@ -61,9 +61,14 @@ trait Consensus {
   def stopProtocol(): Unit
 
   /**
+    * Sends msg to the internal miner and waits for the response
+    */
+  def askMiner(msg: MinerProtocol): Task[MinerResponse]
+
+  /**
     * Sends msg to the internal miner
     */
-  def sendMiner(msg: MinerProtocol): Task[MinerResponse]
+  def sendMiner(msg: MinerProtocol): Unit
 }
 
 /**

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/QAService.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/QAService.scala
@@ -33,7 +33,7 @@ class QAService(
     */
   def mineBlocks(req: MineBlocksRequest): ServiceResponse[MineBlocksResponse] = {
     consensus
-      .sendMiner(MineBlocks(req.numBlocks, req.withTransactions, req.parentBlock))
+      .askMiner(MineBlocks(req.numBlocks, req.withTransactions, req.parentBlock))
       .map(_ |> (MineBlocksResponse(_)) |> (_.asRight))
       .onErrorHandle { throwable =>
         log.warn("Unable to mine requested blocks", throwable)

--- a/src/main/scala/io/iohk/ethereum/testmode/TestmodeConsensus.scala
+++ b/src/main/scala/io/iohk/ethereum/testmode/TestmodeConsensus.scala
@@ -84,9 +84,14 @@ class TestmodeConsensus(
   override def stopProtocol(): Unit = {}
 
   /**
+    * Sends msg to the internal miner and waits for the response
+    */
+  override def askMiner(msg: MinerProtocol): Task[MinerResponse] = Task.now(MinerNotExist)
+
+  /**
     * Sends msg to the internal miner
     */
-  override def sendMiner(msg: MinerProtocol): Task[MinerResponse] = Task.now(MinerNotExist)
+  override def sendMiner(msg: MinerProtocol): Unit = {}
 }
 
 trait TestmodeConsensusBuilder extends ConsensusBuilder {

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/QAServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/QAServiceSpec.scala
@@ -25,7 +25,7 @@ class QAServiceSpec
 
   "QAService" should "send msg to miner and return miner's response" in testCaseM { fixture =>
     import fixture._
-    (testConsensus.sendMiner _)
+    (testConsensus.askMiner _)
       .expects(mineBlocksMsg)
       .returning(Task.now(MiningOrdered))
       .atLeastOnce()
@@ -35,7 +35,7 @@ class QAServiceSpec
 
   it should "send msg to miner and return InternalError in case of problems" in testCaseM { fixture =>
     import fixture._
-    (testConsensus.sendMiner _)
+    (testConsensus.askMiner _)
       .expects(mineBlocksMsg)
       .returning(Task.raiseError(new ClassCastException("error")))
       .atLeastOnce()


### PR DESCRIPTION
# Description

Currently, askFor method is designed for sending a message to the actor and waiting for the response. Also, Task was used.
SendMiner prepared to communicate with Miner is using askFor, but not every usage should wait for the response and not every usage was executing task.

# Important Changes Introduced

- divided sendMiner into sendMiner (used only for fire and forget message to the miner) and askMiner (previous sendMiner)

# Testing

run and check if miner is starting
