### PR TITLE
[ETCM-493] Increase eth_syncing ask timeout

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -597,7 +597,7 @@ mantis {
   }
 
   async {
-    ask-timeout = 100.millis
+    ask-timeout = 1.second
 
     dispatchers {
       block-forger {


### PR DESCRIPTION
# Description

During fast sync, the `FastSync` actor is busy and may take some time to respond to the _ask_ call from the `EthService`. Our current ask timeout for that call is 100 milliseconds, so from time to time if there are many requests, the service will timeout.
See https://github.com/input-output-hk/mantis/issues/852.

# Proposed Solution

To fix the issue now, we decided to increase the timeout because the actor eventually responds, it just takes more than 100 milliseconds.
A refactoring of all the sync-related actors is on the roadmap so it isn't worth to make an optimization for this `eth_syncing` endpoint right now.

# Testing

See steps to reproduce in https://github.com/input-output-hk/mantis/issues/852.

