### PR TITLE
[ETCM-491] Use etc.conf as default config file

### DIFF
--- a/src/universal/bin/mantis-launcher
+++ b/src/universal/bin/mantis-launcher
@@ -7,6 +7,8 @@ CONFIG_FILE="./conf/$1.conf"
 if [ -f "$CONFIG_FILE" ]; then
   shift
   CHAIN_PARAM="-Dconfig.file=$CONFIG_FILE"
+elif [ -z "$1" ]; then
+  CHAIN_PARAM="-Dconfig.file=./conf/etc.conf"
 fi
 
 ./bin/mantis ${CHAIN_PARAM:+"$CHAIN_PARAM"} "$@"

--- a/src/universal/bin/mantis-launcher.bat
+++ b/src/universal/bin/mantis-launcher.bat
@@ -5,15 +5,20 @@ cd "%~dp0\.."
 set "CONFIG_FILE=conf\%1.conf"
 set "RESTVAR=%*"
 
-if not exist %CONFIG_FILE% goto :skip
-    set "CHAIN_PARAM=-Dconfig.file=%CONFIG_FILE%"
-    set RESTVAR=
-    shift
-    :loop
-    if "%1"=="" goto skip
-        set RESTVAR=%RESTVAR% %1
-        shift
-        goto loop
+if exist %CONFIG_FILE% goto :set_chain_param
 
-:skip
+if "%1"=="" set "CHAIN_PARAM=-Dconfig.file=conf\etc.conf"
+goto :launch
+
+:set_chain_param
+set "CHAIN_PARAM=-Dconfig.file=%CONFIG_FILE%"
+set RESTVAR=
+shift
+:loop
+if "%1"=="" goto :launch
+    set RESTVAR=%RESTVAR% %1
+    shift
+    goto :loop
+
+:launch
 call bin\mantis.bat %CHAIN_PARAM% %RESTVAR%


### PR DESCRIPTION
# Description

**Note:** This is a continuation of https://github.com/input-output-hk/mantis/pull/871. Here I'm addressing the last comment made by @aakoshh in that PR.

If the launcher is executed without arguments, then the default `conf/app.conf` file is used which uses etc network. This can lead to confusions because a user would expect to make changes to `conf/etc.conf` and run them using the launcher without arguments.

# Proposed Solution

If no argument is received, the launcher will select the `conf/etc.conf` file as the default configuration. This way the user will see the impacts of changing `conf/etc.conf` when running the launcher without arguments.

# Testing

All validations from https://github.com/input-output-hk/mantis/pull/871 should still work. And:

1. Change `conf/etc.conf` by setting the network to `testnet-internal-nomad`
2. Start the client with `bin/mantis-launcher`
3. Verify that the client starts and connects to the `testnet-internal-nomad` network

