### PR TITLE
Caches implemented as ConcurrentMap

### DIFF
--- a/src/main/scala/io/iohk/ethereum/db/cache/Cache.scala
+++ b/src/main/scala/io/iohk/ethereum/db/cache/Cache.scala
@@ -2,8 +2,20 @@ package io.iohk.ethereum.db.cache
 
 import io.iohk.ethereum.common.SimpleMap
 
+
 trait Cache[K, V] extends SimpleMap[K, V, Cache[K, V]] {
   def getValues: Seq[(K, V)]
-  def clear(): Unit
+
+  /**
+    * Entries are removed from the concurrent map one by one
+    *
+    * Cache is not guaranteed to be empty after the operation
+    * As it can be updated from the other threads
+    *
+    * @return all the values that were removed from the cache
+    */
+  def drain: Seq[(K, V)]
+
+
   def shouldPersist: Boolean
 }

--- a/src/main/scala/io/iohk/ethereum/db/cache/Cache.scala
+++ b/src/main/scala/io/iohk/ethereum/db/cache/Cache.scala
@@ -2,7 +2,6 @@ package io.iohk.ethereum.db.cache
 
 import io.iohk.ethereum.common.SimpleMap
 
-
 trait Cache[K, V] extends SimpleMap[K, V, Cache[K, V]] {
   def getValues: Seq[(K, V)]
 
@@ -15,7 +14,6 @@ trait Cache[K, V] extends SimpleMap[K, V, Cache[K, V]] {
     * @return all the values that were removed from the cache
     */
   def drain: Seq[(K, V)]
-
 
   def shouldPersist: Boolean
 }

--- a/src/main/scala/io/iohk/ethereum/db/cache/LruCache.scala
+++ b/src/main/scala/io/iohk/ethereum/db/cache/LruCache.scala
@@ -6,7 +6,7 @@ import io.iohk.ethereum.utils.Config.NodeCacheConfig
 import com.google.common.cache
 import com.google.common.cache.{CacheBuilder, RemovalNotification}
 
-import scala.collection.JavaConverters.asScalaIterator
+import scala.jdk.CollectionConverters._
 import scala.concurrent.duration.FiniteDuration
 
 class LruCache[K <: AnyRef, V <: AnyRef](
@@ -27,11 +27,11 @@ class LruCache[K <: AnyRef, V <: AnyRef](
       )
       .build()
 
-  override def drain(): Seq[(K, V)] = {
+  override def drain: Seq[(K, V)] = {
     this.lastClear = System.nanoTime()
     val mapView = lruCache.asMap
     val iter = mapView.entrySet.iterator
-    val result = asScalaIterator(iter).map { e =>
+    val result = iter.asScala.map { e =>
       val key = e.getKey
       val value = mapView.remove(key)
       key -> value

--- a/src/main/scala/io/iohk/ethereum/db/cache/MapCache.scala
+++ b/src/main/scala/io/iohk/ethereum/db/cache/MapCache.scala
@@ -5,7 +5,6 @@ import io.iohk.ethereum.utils.Config.NodeCacheConfig
 import scala.collection.concurrent.{TrieMap, Map => CMap}
 import scala.concurrent.duration.FiniteDuration
 
-
 class MapCache[K, V](val cache: CMap[K, V], config: NodeCacheConfig) extends Cache[K, V] {
 
   @volatile private[this] var lastClear = System.nanoTime()
@@ -27,7 +26,7 @@ class MapCache[K, V](val cache: CMap[K, V], config: NodeCacheConfig) extends Cac
   override def drain: Seq[(K, V)] = {
     lastClear = System.nanoTime()
     cache.toList.flatMap { case (k, _) =>
-      cache.remove(k).map( v => k -> v )
+      cache.remove(k).map(v => k -> v)
     }
   }
 

--- a/src/main/scala/io/iohk/ethereum/db/cache/MapCache.scala
+++ b/src/main/scala/io/iohk/ethereum/db/cache/MapCache.scala
@@ -29,7 +29,7 @@ class MapCache[K, V](val cache: CMap[K, V], config: NodeCacheConfig) extends Cac
 
   override def drain: Seq[(K, V)] = {
     lastClear = System.nanoTime()
-    cache.toList.flatMap { case tuple @ (k, _) =>
+    cache.toList.flatMap { case (k, _) =>
       cache.remove(k).map( v => k -> v )
     }
   }

--- a/src/main/scala/io/iohk/ethereum/db/cache/MapCache.scala
+++ b/src/main/scala/io/iohk/ethereum/db/cache/MapCache.scala
@@ -1,25 +1,21 @@
 package io.iohk.ethereum.db.cache
 
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicLong
 
 import io.iohk.ethereum.utils.Config.NodeCacheConfig
-import scala.collection.mutable
+
+import scala.collection.Seq
+import scala.collection.concurrent.{TrieMap, Map => CMap}
 import scala.concurrent.duration.FiniteDuration
 
-//TODO EC-492 Investigate more carefully possibility of having read cache in front of db
-// class is not entirely thread safe
-// All updates need to be atomic and visible in respect to get, as get may be called from other threads.
-// Other methods are only called from actor context, and all updates are always visible to them
-class MapCache[K, V](val cache: mutable.Map[K, V], config: NodeCacheConfig) extends Cache[K, V] {
 
-  private val lastClear = new AtomicLong(System.nanoTime())
+class MapCache[K, V](val cache: CMap[K, V], config: NodeCacheConfig) extends Cache[K, V] {
+
+  @volatile private[this] var lastClear = System.nanoTime()
 
   override def update(toRemove: Seq[K], toUpsert: Seq[(K, V)]): Cache[K, V] = {
-    this.synchronized {
-      toRemove.foreach(key => cache -= key)
-      toUpsert.foreach(element => cache += element._1 -> element._2)
-    }
+    toRemove.foreach(key => cache -= key)
+    toUpsert.foreach(element => cache += element._1 -> element._2)
     this
   }
 
@@ -28,14 +24,15 @@ class MapCache[K, V](val cache: mutable.Map[K, V], config: NodeCacheConfig) exte
   }
 
   override def get(key: K): Option[V] = {
-    this.synchronized {
-      cache.get(key)
-    }
+    cache.get(key)
   }
 
-  override def clear(): Unit = {
-    lastClear.getAndSet(System.nanoTime())
-    cache.clear()
+  override def drain: Seq[(K, V)] = {
+    lastClear = System.nanoTime()
+    cache.toList.map { case tuple @ (k, _) =>
+      cache -= k
+      tuple
+    }
   }
 
   override def shouldPersist: Boolean = {
@@ -43,16 +40,13 @@ class MapCache[K, V](val cache: mutable.Map[K, V], config: NodeCacheConfig) exte
   }
 
   private def isTimeToClear: Boolean = {
-    FiniteDuration(System.nanoTime(), TimeUnit.NANOSECONDS) - FiniteDuration(
-      lastClear.get(),
-      TimeUnit.NANOSECONDS
-    ) >= config.maxHoldTime
+    FiniteDuration(System.nanoTime() - lastClear, TimeUnit.NANOSECONDS) >= config.maxHoldTime
   }
 }
 
 object MapCache {
 
-  def getMap[K, V]: mutable.Map[K, V] = mutable.Map.empty
+  def getMap[K, V]: CMap[K, V] = TrieMap.empty
 
   def createCache[K, V](config: NodeCacheConfig): MapCache[K, V] = {
     new MapCache[K, V](getMap[K, V], config)
@@ -67,4 +61,5 @@ object MapCache {
   ): Cache[K, V] = {
     createCache[K, V](TestCacheConfig(maxSize, maxHoldTime))
   }
+
 }

--- a/src/main/scala/io/iohk/ethereum/db/cache/MapCache.scala
+++ b/src/main/scala/io/iohk/ethereum/db/cache/MapCache.scala
@@ -1,10 +1,7 @@
 package io.iohk.ethereum.db.cache
 
 import java.util.concurrent.TimeUnit
-
 import io.iohk.ethereum.utils.Config.NodeCacheConfig
-
-import scala.collection.Seq
 import scala.collection.concurrent.{TrieMap, Map => CMap}
 import scala.concurrent.duration.FiniteDuration
 

--- a/src/main/scala/io/iohk/ethereum/db/cache/MapCache.scala
+++ b/src/main/scala/io/iohk/ethereum/db/cache/MapCache.scala
@@ -29,9 +29,8 @@ class MapCache[K, V](val cache: CMap[K, V], config: NodeCacheConfig) extends Cac
 
   override def drain: Seq[(K, V)] = {
     lastClear = System.nanoTime()
-    cache.toList.map { case tuple @ (k, _) =>
-      cache -= k
-      tuple
+    cache.toList.flatMap { case tuple @ (k, _) =>
+      cache.remove(k).map( v => k -> v )
     }
   }
 

--- a/src/main/scala/io/iohk/ethereum/db/storage/CachedKeyValueStorage.scala
+++ b/src/main/scala/io/iohk/ethereum/db/storage/CachedKeyValueStorage.scala
@@ -26,8 +26,8 @@ trait CachedKeyValueStorage[K, V, T <: CachedKeyValueStorage[K, V, T]] extends S
   }
 
   def forcePersist(): Unit = {
-    storage.update(Nil, cache.getValues)
-    cache.clear()
+    val contents = cache.drain
+    storage.update(Nil, contents)
   }
 
   // TODO EC-491 Consider other persist strategy like sliding window (save and clear only old stuff which survived long enough)

--- a/src/main/scala/io/iohk/ethereum/db/storage/CachedReferenceCountedStorage.scala
+++ b/src/main/scala/io/iohk/ethereum/db/storage/CachedReferenceCountedStorage.scala
@@ -98,10 +98,9 @@ object CachedReferenceCountedStorage {
       ser: ByteArraySerializable[V]
   ): Boolean = {
     if (cache.shouldPersist || forced) {
-      val values = cache.getValues
+      val values = cache.drain
       val serialized = values.map { case (key, value) => key -> ser.toBytes(value) }
       storage.update(Nil, serialized)
-      cache.clear()
       true
     } else {
       false

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/regular/BlockFetcherSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/regular/BlockFetcherSpec.scala
@@ -256,14 +256,24 @@ class BlockFetcherSpec
       val checkpointBlock = (new CheckpointBlockGenerator)
         .generate(
           firstBlocksBatch.last,
-          Checkpoint(CheckpointingTestHelpers.createCheckpointSignatures(Seq(crypto.generateKeyPair(secureRandom)), firstBlocksBatch.last.hash))
+          Checkpoint(
+            CheckpointingTestHelpers.createCheckpointSignatures(
+              Seq(crypto.generateKeyPair(secureRandom)),
+              firstBlocksBatch.last.hash
+            )
+          )
         )
 
       handleFirstBlockBatchHeaders()
 
       // Fetcher second request for headers
       val secondGetBlockHeadersRequest =
-        GetBlockHeaders(Left(secondBlocksBatch.head.number), syncConfig.blockHeadersPerRequest, skip = 0, reverse = false)
+        GetBlockHeaders(
+          Left(secondBlocksBatch.head.number),
+          syncConfig.blockHeadersPerRequest,
+          skip = 0,
+          reverse = false
+        )
       peersClient.expectMsgPF() { case PeersClient.Request(msg, _, _) if msg == secondGetBlockHeadersRequest => () }
 
       // Respond second headers request
@@ -281,7 +291,10 @@ class BlockFetcherSpec
       peersClient.reply(PeersClient.Response(fakePeer, secondGetBlockBodiesResponse))
 
       // send old checkpoint block
-      blockFetcher ! MessageFromPeer(PV64.NewBlock(checkpointBlock, ChainWeight(checkpointBlock.number, checkpointBlock.header.difficulty)), fakePeer.id)
+      blockFetcher ! MessageFromPeer(
+        PV64.NewBlock(checkpointBlock, ChainWeight(checkpointBlock.number, checkpointBlock.header.difficulty)),
+        fakePeer.id
+      )
 
       importer.send(blockFetcher, PickBlocks(syncConfig.blocksBatchSize * 2))
       importer.expectMsgPF() { case BlockFetcher.PickedBlocks(blocks) =>
@@ -302,7 +315,12 @@ class BlockFetcherSpec
       val checkpointBlock = (new CheckpointBlockGenerator)
         .generate(
           secondBlocksBatchFirstPart.last,
-          Checkpoint(CheckpointingTestHelpers.createCheckpointSignatures(Seq(crypto.generateKeyPair(secureRandom)), secondBlocksBatchFirstPart.last.hash))
+          Checkpoint(
+            CheckpointingTestHelpers.createCheckpointSignatures(
+              Seq(crypto.generateKeyPair(secureRandom)),
+              secondBlocksBatchFirstPart.last.hash
+            )
+          )
         )
 
       val alternativeSecondBlocksBatch = secondBlocksBatchFirstPart :+ checkpointBlock
@@ -311,7 +329,12 @@ class BlockFetcherSpec
 
       // Fetcher second request for headers
       val secondGetBlockHeadersRequest =
-        GetBlockHeaders(Left(secondBlocksBatch.head.number), syncConfig.blockHeadersPerRequest, skip = 0, reverse = false)
+        GetBlockHeaders(
+          Left(secondBlocksBatch.head.number),
+          syncConfig.blockHeadersPerRequest,
+          skip = 0,
+          reverse = false
+        )
       peersClient.expectMsgPF() { case PeersClient.Request(msg, _, _) if msg == secondGetBlockHeadersRequest => () }
 
       // Respond second headers request
@@ -325,7 +348,10 @@ class BlockFetcherSpec
       peersClient.expectMsgPF() { case PeersClient.Request(msg, _, _) if msg == secondGetBlockBodiesRequest => ()}
 
       // send old checkpoint block
-      blockFetcher ! MessageFromPeer(PV64.NewBlock(checkpointBlock, ChainWeight(checkpointBlock.number, checkpointBlock.header.difficulty)), fakePeer.id)
+      blockFetcher ! MessageFromPeer(
+        PV64.NewBlock(checkpointBlock, ChainWeight(checkpointBlock.number, checkpointBlock.header.difficulty)),
+        fakePeer.id
+      )
 
       // second bodies response
       val secondGetBlockBodiesResponse = BlockBodies(secondBlocksBatch.map(_.body))
@@ -357,11 +383,17 @@ class BlockFetcherSpec
 
       triggerFetching(10)
 
-      val alternativeBlocksBatch = BlockHelpers.generateChain(syncConfig.blockHeadersPerRequest / 2, FixtureBlocks.Genesis.block)
+      val alternativeBlocksBatch =
+        BlockHelpers.generateChain(syncConfig.blockHeadersPerRequest / 2, FixtureBlocks.Genesis.block)
       val checkpointBlock = (new CheckpointBlockGenerator)
         .generate(
           alternativeBlocksBatch.last,
-          Checkpoint(CheckpointingTestHelpers.createCheckpointSignatures(Seq(crypto.generateKeyPair(secureRandom)), alternativeBlocksBatch.last.hash))
+          Checkpoint(
+            CheckpointingTestHelpers.createCheckpointSignatures(
+              Seq(crypto.generateKeyPair(secureRandom)),
+              alternativeBlocksBatch.last.hash
+            )
+          )
         )
 
       val alternativeBlocksBatchWithCheckpoint = alternativeBlocksBatch :+ checkpointBlock
@@ -369,7 +401,10 @@ class BlockFetcherSpec
       handleFirstBlockBatch()
 
       // send checkpoint block
-      blockFetcher ! MessageFromPeer(PV64.NewBlock(checkpointBlock, ChainWeight(checkpointBlock.number, checkpointBlock.header.difficulty)), fakePeer.id)
+      blockFetcher ! MessageFromPeer(
+        PV64.NewBlock(checkpointBlock, ChainWeight(checkpointBlock.number, checkpointBlock.header.difficulty)),
+        fakePeer.id
+      )
 
       // Fetcher new request for headers
       peersClient.expectMsgPF() { case PeersClient.Request(msg, _, _) if msg == firstGetBlockHeadersRequest => () }
@@ -404,11 +439,17 @@ class BlockFetcherSpec
 
       triggerFetching(10)
 
-      val alternativeBlocksBatch = BlockHelpers.generateChain(syncConfig.blockHeadersPerRequest / 2, FixtureBlocks.Genesis.block)
+      val alternativeBlocksBatch =
+        BlockHelpers.generateChain(syncConfig.blockHeadersPerRequest / 2, FixtureBlocks.Genesis.block)
       val checkpointBlock = (new CheckpointBlockGenerator)
         .generate(
           alternativeBlocksBatch.last,
-          Checkpoint(CheckpointingTestHelpers.createCheckpointSignatures(Seq(crypto.generateKeyPair(secureRandom)), alternativeBlocksBatch.last.hash))
+          Checkpoint(
+            CheckpointingTestHelpers.createCheckpointSignatures(
+              Seq(crypto.generateKeyPair(secureRandom)),
+              alternativeBlocksBatch.last.hash
+            )
+          )
         )
 
       handleFirstBlockBatch()
@@ -421,7 +462,10 @@ class BlockFetcherSpec
       importer.expectMsg(BlockFetcher.PickedBlocks(NonEmptyList(firstBlocksBatch.head, firstBlocksBatch.tail)))
 
       // send old checkpoint block
-      blockFetcher ! MessageFromPeer(PV64.NewBlock(checkpointBlock, ChainWeight(checkpointBlock.number, checkpointBlock.header.difficulty)), fakePeer.id)
+      blockFetcher ! MessageFromPeer(
+        PV64.NewBlock(checkpointBlock, ChainWeight(checkpointBlock.number, checkpointBlock.header.difficulty)),
+        fakePeer.id
+      )
 
       importer.expectMsg(BlockImporter.OnTop)
 
@@ -495,7 +539,8 @@ class BlockFetcherSpec
     // Currently BlockFetcher only downloads first block-headers-per-request blocks without this
     def triggerFetching(startingNumber: BigInt = 1000): Unit = {
       val farAwayBlockTotalDifficulty = 100000
-      val farAwayBlock = Block(FixtureBlocks.ValidBlock.header.copy(number = startingNumber), FixtureBlocks.ValidBlock.body)
+      val farAwayBlock =
+        Block(FixtureBlocks.ValidBlock.header.copy(number = startingNumber), FixtureBlocks.ValidBlock.body)
 
       blockFetcher ! MessageFromPeer(NewBlock(farAwayBlock, farAwayBlockTotalDifficulty), fakePeer.id)
     }


### PR DESCRIPTION
# Description

Second life of my PR as a contributor before IOHK
```
val values = cache.values()
<do_something_with_values>
cache.clear()
```
Will lose everything put in cache between `values` and `clear`

# Proposed Solution

`drain()` method introduced in order to resolve concurrency issue
`ConcurrentMap` offers a fine-grained locking mode for effectively using Cache. 
