### PR TITLE
[FIX] Block fetcher failing test fix

### DIFF
--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/regular/BlockFetcherState.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/regular/BlockFetcherState.scala
@@ -100,8 +100,12 @@ case class BlockFetcherState(
         .withKnownTopAt(block.number)
       Right(newState)
     } else if (isExistInWaitingHeaders(block.header.parentHash)) {
+      // ignore already requested bodies
+      val newFetchingBodiesState =
+        if (fetchingBodiesState == AwaitingBodies) AwaitingBodiesToBeIgnored else fetchingBodiesState
       val newState = copy(
-        waitingHeaders = waitingHeaders.takeWhile(_.number < block.number).enqueue(block.header)
+        waitingHeaders = waitingHeaders.takeWhile(_.number < block.number).enqueue(block.header),
+        fetchingBodiesState = newFetchingBodiesState
       )
         .withKnownTopAt(block.number)
       Right(newState)


### PR DESCRIPTION
# Description

One of the block fetcher's test (`should process checkpoint blocks when checkpoint can fit into waiting headers queue`) was failing nondeterministically.

# Important Changes Introduced
 - added setting `AwaitingBodiesToBeIgnored` as a fetching bodies status in case of changing waiting headers queue during bodies fetching (to avoid blacklisting peers which respond to pending block bodies requests)
 - fixed test structure