### PR TITLE
Feature/etcm 533 non membership proof

### DIFF
--- a/src/it/scala/io/iohk/ethereum/txExecTest/util/DumpChainApp.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/util/DumpChainApp.scala
@@ -2,7 +2,6 @@ package io.iohk.ethereum.txExecTest.util
 
 import java.time.Clock
 import java.util.concurrent.atomic.AtomicReference
-
 import akka.actor.ActorSystem
 import akka.util.ByteString
 import com.typesafe.config.ConfigFactory
@@ -15,6 +14,7 @@ import io.iohk.ethereum.db.storage.pruning.{ArchivePruning, PruningMode}
 import io.iohk.ethereum.db.storage.{AppStateStorage, StateStorage}
 import io.iohk.ethereum.domain.BlockHeader.HeaderExtraFields.HefEmpty
 import io.iohk.ethereum.domain.{Blockchain, UInt256, _}
+import io.iohk.ethereum.jsonrpc.ProofService.{StorageProof, StorageValueProof}
 import io.iohk.ethereum.ledger.{InMemoryWorldStateProxy, InMemoryWorldStateProxyStorage}
 import io.iohk.ethereum.mpt.MptNode
 import io.iohk.ethereum.network.EtcPeerManagerActor.PeerInfo
@@ -150,7 +150,7 @@ class BlockchainMock(genesisHash: ByteString) extends Blockchain {
       rootHash: NodeHash,
       position: BigInt,
       ethCompatibleStorage: Boolean
-  ): (BigInt, Seq[MptNode]) = (BigInt(0), Seq.empty)
+  ): StorageProof = StorageValueProof(position)
 
   override protected def getHashByBlockNumber(number: BigInt): Option[ByteString] = Some(genesisHash)
 

--- a/src/it/scala/io/iohk/ethereum/txExecTest/util/DumpChainApp.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/util/DumpChainApp.scala
@@ -150,7 +150,7 @@ class BlockchainMock(genesisHash: ByteString) extends Blockchain {
       rootHash: NodeHash,
       position: BigInt,
       ethCompatibleStorage: Boolean
-  ): (BigInt, Seq[MptNode]) = (1, Seq.empty)
+  ): (BigInt, Seq[MptNode]) = (BigInt(0), Seq.empty)
 
   override protected def getHashByBlockNumber(number: BigInt): Option[ByteString] = Some(genesisHash)
 

--- a/src/it/scala/io/iohk/ethereum/txExecTest/util/DumpChainApp.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/util/DumpChainApp.scala
@@ -150,7 +150,7 @@ class BlockchainMock(genesisHash: ByteString) extends Blockchain {
       rootHash: NodeHash,
       position: BigInt,
       ethCompatibleStorage: Boolean
-  ): Option[(BigInt, Seq[MptNode])] = None
+  ): (BigInt, Seq[MptNode]) = (1, Seq.empty)
 
   override protected def getHashByBlockNumber(number: BigInt): Option[ByteString] = Some(genesisHash)
 

--- a/src/it/scala/io/iohk/ethereum/txExecTest/util/DumpChainApp.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/util/DumpChainApp.scala
@@ -14,7 +14,7 @@ import io.iohk.ethereum.db.storage.pruning.{ArchivePruning, PruningMode}
 import io.iohk.ethereum.db.storage.{AppStateStorage, StateStorage}
 import io.iohk.ethereum.domain.BlockHeader.HeaderExtraFields.HefEmpty
 import io.iohk.ethereum.domain.{Blockchain, UInt256, _}
-import io.iohk.ethereum.jsonrpc.ProofService.{StorageProof, StorageValueProof}
+import io.iohk.ethereum.jsonrpc.ProofService.{EmptyStorageValueProof, StorageProof, StorageProofKey, StorageValueProof}
 import io.iohk.ethereum.ledger.{InMemoryWorldStateProxy, InMemoryWorldStateProxyStorage}
 import io.iohk.ethereum.mpt.MptNode
 import io.iohk.ethereum.network.EtcPeerManagerActor.PeerInfo
@@ -150,7 +150,7 @@ class BlockchainMock(genesisHash: ByteString) extends Blockchain {
       rootHash: NodeHash,
       position: BigInt,
       ethCompatibleStorage: Boolean
-  ): StorageProof = StorageValueProof(position)
+  ): StorageProof = EmptyStorageValueProof(StorageProofKey(position))
 
   override protected def getHashByBlockNumber(number: BigInt): Option[ByteString] = Some(genesisHash)
 

--- a/src/main/scala/io/iohk/ethereum/domain/Blockchain.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/Blockchain.scala
@@ -12,7 +12,7 @@ import io.iohk.ethereum.db.storage._
 import io.iohk.ethereum.db.storage.pruning.PruningMode
 import io.iohk.ethereum.domain
 import io.iohk.ethereum.domain.BlockchainImpl.BestBlockLatestCheckpointNumbers
-import io.iohk.ethereum.jsonrpc.ProofService.{StorageProof, StorageValueProof}
+import io.iohk.ethereum.jsonrpc.ProofService.StorageProof
 import io.iohk.ethereum.ledger.{InMemoryWorldStateProxy, InMemoryWorldStateProxyStorage}
 import io.iohk.ethereum.mpt.{MerklePatriciaTrie, MptNode}
 import io.iohk.ethereum.utils.{ByteStringUtils, Logger}
@@ -321,7 +321,7 @@ class BlockchainImpl(
     }
     val value: Option[BigInt] = mpt.get(position)
     val proof: Option[Vector[MptNode]] = mpt.getProof(position)
-    StorageValueProof(position, value, proof)
+    StorageProof(position, value, proof)
   }
 
   private def persistBestBlocksData(): Unit = {

--- a/src/main/scala/io/iohk/ethereum/domain/Blockchain.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/Blockchain.scala
@@ -319,15 +319,9 @@ class BlockchainImpl(
       if (ethCompatibleStorage) domain.EthereumUInt256Mpt.storageMpt(rootHash, storage)
       else domain.ArbitraryIntegerMpt.storageMpt(rootHash, storage)
     }
-    val value = mpt.get(position)
-    val proof = mpt.getProof(position)
-
-    (value, proof) match {
-      case (Some(value), Some(proof)) => StorageValueProof(position, value, proof)
-      case (None, Some(proof)) => StorageValueProof(position, proof = proof)
-      case (Some(value), None) => StorageValueProof(position, value)
-      case (None, None) => StorageValueProof(position)
-    }
+    val value: Option[BigInt] = mpt.get(position)
+    val proof: Option[Vector[MptNode]] = mpt.getProof(position)
+    StorageValueProof(position, value, proof)
   }
 
   private def persistBestBlocksData(): Unit = {

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/EthProofJsonMethodsImplicits.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/EthProofJsonMethodsImplicits.scala
@@ -4,9 +4,7 @@ import io.iohk.ethereum.jsonrpc.JsonRpcError.InvalidParams
 import io.iohk.ethereum.jsonrpc.ProofService.{GetProofRequest, GetProofResponse, StorageProofKey}
 import io.iohk.ethereum.jsonrpc.serialization.JsonEncoder
 import io.iohk.ethereum.jsonrpc.serialization.JsonMethodDecoder
-import org.json4s.Extraction
 import org.json4s.JsonAST.{JArray, JString, JValue, _}
-import org.json4s.JsonDSL._
 
 object EthProofJsonMethodsImplicits extends JsonMethodsImplicits {
   def extractStorageKeys(input: JValue): Either[JsonRpcError, Seq[StorageProofKey]] = {

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/EthProofService.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/EthProofService.scala
@@ -5,7 +5,14 @@ import cats.implicits._
 import io.iohk.ethereum.consensus.blocks.BlockGenerator
 import io.iohk.ethereum.domain.{Account, Address, Block, Blockchain, UInt256}
 import io.iohk.ethereum.jsonrpc.ProofService.StorageValueProof.asRlpSerializedNode
-import io.iohk.ethereum.jsonrpc.ProofService.{GetProofRequest, GetProofResponse, ProofAccount, StorageProof, StorageProofKey, StorageValueProof}
+import io.iohk.ethereum.jsonrpc.ProofService.{
+  GetProofRequest,
+  GetProofResponse,
+  ProofAccount,
+  StorageProof,
+  StorageProofKey,
+  StorageValueProof
+}
 import io.iohk.ethereum.mpt.{MptNode, MptTraversals}
 import monix.eval.Task
 
@@ -30,6 +37,7 @@ object ProofService {
     val value: BigInt
     val proof: Seq[ByteString]
   }
+
   /**
     * Object proving a relationship of a storage value to an account's storageHash
     *
@@ -40,13 +48,16 @@ object ProofService {
   case class StorageValueProof(
       key: StorageProofKey,
       value: BigInt = BigInt(0),
-      proof: Seq[ByteString] = Seq.empty[MptNode].map(asRlpSerializedNode)) extends StorageProof
+      proof: Seq[ByteString] = Seq.empty[MptNode].map(asRlpSerializedNode)
+  ) extends StorageProof
 
   object StorageValueProof {
     def apply(position: BigInt, value: Option[BigInt], proof: Option[Vector[MptNode]]): StorageValueProof =
       (value, proof) match {
-        case (Some(value), Some(proof)) => new StorageValueProof(key = StorageProofKey(position),  value = value, proof = proof.map(asRlpSerializedNode))
-        case (None, Some(proof)) => new StorageValueProof(key = StorageProofKey(position), proof = proof.map(asRlpSerializedNode))
+        case (Some(value), Some(proof)) =>
+          new StorageValueProof(key = StorageProofKey(position), value = value, proof = proof.map(asRlpSerializedNode))
+        case (None, Some(proof)) =>
+          new StorageValueProof(key = StorageProofKey(position), proof = proof.map(asRlpSerializedNode))
         case (Some(value), None) => new StorageValueProof(key = StorageProofKey(position), value = value)
         case (None, None) => new StorageValueProof(key = StorageProofKey(position))
       }

--- a/src/main/scala/io/iohk/ethereum/mpt/MerklePatriciaTrie.scala
+++ b/src/main/scala/io/iohk/ethereum/mpt/MerklePatriciaTrie.scala
@@ -82,16 +82,14 @@ class MerklePatriciaTrie[K, V] private (private[mpt] val rootNode: Option[MptNod
     * @throws io.iohk.ethereum.mpt.MerklePatriciaTrie.MPTException if there is any inconsistency in how the trie is build.
     */
   def get(key: K): Option[V] = {
-    pathTraverse[Option[V]](None, mkKeyNibbles(key)) { case (_, node) =>
-      node match {
-        case Some(LeafNode(_, value, _, _, _)) =>
-          Some(vSerializer.fromBytes(value.toArray[Byte]))
+    pathTraverse[Option[V]](None, mkKeyNibbles(key)) {
+      case (_, Some(LeafNode(_, value, _, _, _))) =>
+        Some(vSerializer.fromBytes(value.toArray[Byte]))
 
-        case Some(BranchNode(_, terminator, _, _, _)) =>
-          terminator.map(term => vSerializer.fromBytes(term.toArray[Byte]))
+      case (_, Some(BranchNode(_, terminator, _, _, _))) =>
+        terminator.map(term => vSerializer.fromBytes(term.toArray[Byte]))
 
-        case _ => None
-      }
+      case _ => None
     }.flatten
   }
 

--- a/src/main/scala/io/iohk/ethereum/mpt/MerklePatriciaTrie.scala
+++ b/src/main/scala/io/iohk/ethereum/mpt/MerklePatriciaTrie.scala
@@ -9,7 +9,6 @@ import io.iohk.ethereum.rlp.RLPImplicits._
 import io.iohk.ethereum.rlp.{encode => encodeRLP}
 import org.bouncycastle.util.encoders.Hex
 import io.iohk.ethereum.utils.ByteUtils.matchingLength
-
 import scala.annotation.tailrec
 
 object MerklePatriciaTrie {
@@ -103,7 +102,8 @@ class MerklePatriciaTrie[K, V] private (private[mpt] val rootNode: Option[MptNod
   def getProof(key: K): Option[Vector[MptNode]] = {
     pathTraverse[Vector[MptNode]](Vector.empty, mkKeyNibbles(key)) { case (acc, node) =>
       node match {
-        case Some(nextNodeOnExt @ (_: BranchNode | _: ExtensionNode | _: LeafNode | _: HashNode)) => acc :+ nextNodeOnExt
+        case Some(nextNodeOnExt @ (_: BranchNode | _: ExtensionNode | _: LeafNode | _: HashNode)) =>
+          acc :+ nextNodeOnExt
         case _ => acc
       }
     }

--- a/src/main/scala/io/iohk/ethereum/mpt/MerklePatriciaTrie.scala
+++ b/src/main/scala/io/iohk/ethereum/mpt/MerklePatriciaTrie.scala
@@ -105,7 +105,7 @@ class MerklePatriciaTrie[K, V] private (private[mpt] val rootNode: Option[MptNod
   def getProof(key: K): Option[Vector[MptNode]] = {
     pathTraverse[Vector[MptNode]](Vector.empty, mkKeyNibbles(key)) { case (acc, node) =>
       node match {
-        case Some(nextNodeOnExt @ (_: BranchNode | _: ExtensionNode | _: LeafNode)) => acc :+ nextNodeOnExt
+        case Some(nextNodeOnExt @ (_: BranchNode | _: ExtensionNode | _: LeafNode | _: HashNode)) => acc :+ nextNodeOnExt
         case _ => acc
       }
     }
@@ -155,7 +155,7 @@ class MerklePatriciaTrie[K, V] private (private[mpt] val rootNode: Option[MptNod
 
     rootNode match {
       case Some(root) =>
-        pathTraverse(acc, root, searchKey, op)
+        pathTraverse(op(acc, Some(root)), root, searchKey, op)
       case None =>
         None
     }

--- a/src/main/scala/io/iohk/ethereum/mpt/MerklePatriciaTrie.scala
+++ b/src/main/scala/io/iohk/ethereum/mpt/MerklePatriciaTrie.scala
@@ -84,10 +84,10 @@ class MerklePatriciaTrie[K, V] private (private[mpt] val rootNode: Option[MptNod
   def get(key: K): Option[V] = {
     pathTraverse[Option[V]](None, mkKeyNibbles(key)) { case (_, node) =>
       node match {
-        case LeafNode(_, value, _, _, _) =>
+        case Some(LeafNode(_, value, _, _, _)) =>
           Some(vSerializer.fromBytes(value.toArray[Byte]))
 
-        case BranchNode(_, terminator, _, _, _) =>
+        case Some(BranchNode(_, terminator, _, _, _)) =>
           terminator.map(term => vSerializer.fromBytes(term.toArray[Byte]))
 
         case _ => None
@@ -103,9 +103,9 @@ class MerklePatriciaTrie[K, V] private (private[mpt] val rootNode: Option[MptNod
     * @throws io.iohk.ethereum.mpt.MerklePatriciaTrie.MPTException if there is any inconsistency in how the trie is build.
     */
   def getProof(key: K): Option[Vector[MptNode]] = {
-    pathTraverseWithProof[Vector[MptNode]](Vector.empty, mkKeyNibbles(key)) { case (acc, node) =>
+    pathTraverse[Vector[MptNode]](Vector.empty, mkKeyNibbles(key)) { case (acc, node) =>
       node match {
-        case nextNodeOnExt @ (_: BranchNode | _: ExtensionNode | _: LeafNode) => acc :+ nextNodeOnExt
+        case Some(nextNodeOnExt @ (_: BranchNode | _: ExtensionNode | _: LeafNode)) => acc :+ nextNodeOnExt
         case _ => acc
       }
     }
@@ -121,25 +121,25 @@ class MerklePatriciaTrie[K, V] private (private[mpt] val rootNode: Option[MptNod
     * @tparam T accumulator type
     * @return accumulated data or None if key doesn't exist
     */
-  private def pathTraverse[T](acc: T, searchKey: Array[Byte])(op: (T, MptNode) => T): Option[T] = {
+  private def pathTraverse[T](acc: T, searchKey: Array[Byte])(op: (T, Option[MptNode]) => T): Option[T] = {
 
     @tailrec
-    def pathTraverse(acc: T, node: MptNode, searchKey: Array[Byte], op: (T, MptNode) => T): Option[T] = {
+    def pathTraverse(acc: T, node: MptNode, searchKey: Array[Byte], op: (T, Option[MptNode]) => T): Option[T] = {
       node match {
         case LeafNode(key, _, _, _, _) =>
-          if (key.toArray[Byte] sameElements searchKey) Some(op(acc, node)) else None
+          if (key.toArray[Byte] sameElements searchKey) Some(op(acc, Some(node))) else Some(op(acc, None))
 
         case extNode @ ExtensionNode(sharedKey, _, _, _, _) =>
           val (commonKey, remainingKey) = searchKey.splitAt(sharedKey.length)
           if (searchKey.length >= sharedKey.length && (sharedKey.toArray[Byte] sameElements commonKey)) {
-            pathTraverse(op(acc, node), extNode.next, remainingKey, op)
-          } else None
+            pathTraverse(op(acc, Some(node)), extNode.next, remainingKey, op)
+          } else Some(op(acc, None))
 
         case branch: BranchNode =>
-          if (searchKey.isEmpty) Some(op(acc, node))
+          if (searchKey.isEmpty) Some(op(acc, Some(node)))
           else
             pathTraverse(
-              op(acc, node),
+              op(acc, Some(node)),
               branch.children(searchKey(0)),
               searchKey.slice(1, searchKey.length),
               op
@@ -149,53 +149,13 @@ class MerklePatriciaTrie[K, V] private (private[mpt] val rootNode: Option[MptNod
           pathTraverse(acc, getFromHash(bytes, nodeStorage), searchKey, op)
 
         case NullNode =>
-          None
+          Some(op(acc, None))
       }
     }
 
     rootNode match {
       case Some(root) =>
         pathTraverse(acc, root, searchKey, op)
-      case None =>
-        None
-    }
-  }
-
-  private def pathTraverseWithProof[T](acc: T, searchKey: Array[Byte])(op: (T, MptNode) => T): Option[T] = {
-
-    @tailrec
-    def pathTraverseWithProof(acc: T, node: MptNode, searchKey: Array[Byte], op: (T, MptNode) => T): Option[T] = {
-      node match {
-        case LeafNode(key, _, _, _, _) =>
-          if (key.toArray[Byte] sameElements searchKey) Some(op(acc, node)) else Some(acc)
-
-        case extNode @ ExtensionNode(sharedKey, _, _, _, _) =>
-          val (commonKey, remainingKey) = searchKey.splitAt(sharedKey.length)
-          if (searchKey.length >= sharedKey.length && (sharedKey.toArray[Byte] sameElements commonKey)) {
-            pathTraverseWithProof(op(acc, node), extNode.next, remainingKey, op)
-          } else Some(acc)
-
-        case branch: BranchNode =>
-          if (searchKey.isEmpty) Some(op(acc, node))
-          else
-            pathTraverseWithProof(
-              op(acc, node),
-              branch.children(searchKey(0)),
-              searchKey.slice(1, searchKey.length),
-              op
-            )
-
-        case HashNode(bytes) =>
-          pathTraverseWithProof(acc, getFromHash(bytes, nodeStorage), searchKey, op)
-
-        case NullNode =>
-          Some(acc)
-      }
-    }
-
-    rootNode match {
-      case Some(root) =>
-        pathTraverseWithProof(acc, root, searchKey, op)
       case None =>
         None
     }

--- a/src/test/scala/io/iohk/ethereum/ObjectGenerators.scala
+++ b/src/test/scala/io/iohk/ethereum/ObjectGenerators.scala
@@ -50,9 +50,10 @@ trait ObjectGenerators {
     } yield (aByteList.toArray, t)
   }
 
-  def keyValueListGen(): Gen[List[(Int, Int)]] = {
+  def keyValueListGen(minValue: Int = Int.MinValue, maxValue: Int = Int.MaxValue): Gen[List[(Int, Int)]] = {
     for {
-      aKeyList <- Gen.nonEmptyListOf(Arbitrary.arbitrary[Int]).map(_.distinct)
+      values <- Gen.chooseNum(minValue, maxValue)
+      aKeyList <- Gen.nonEmptyListOf(values).map(_.distinct)
     } yield aKeyList.zip(aKeyList)
   }
 

--- a/src/test/scala/io/iohk/ethereum/domain/BlockchainSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/domain/BlockchainSpec.scala
@@ -6,7 +6,7 @@ import io.iohk.ethereum.consensus.blocks.CheckpointBlockGenerator
 import io.iohk.ethereum.db.dataSource.EphemDataSource
 import io.iohk.ethereum.db.storage.StateStorage
 import io.iohk.ethereum.domain.BlockHeader.HeaderExtraFields.HefPostEcip1097
-import io.iohk.ethereum.mpt.MerklePatriciaTrie
+import io.iohk.ethereum.mpt.{HashNode, MerklePatriciaTrie}
 import io.iohk.ethereum.{BlockHelpers, Fixtures, ObjectGenerators}
 import io.iohk.ethereum.ObjectGenerators._
 import io.iohk.ethereum.proof.MptProofVerifier
@@ -177,9 +177,11 @@ class BlockchainSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyCh
 
     val wrongAddress = Address(666)
     val retrievedAccountProofWrong = blockchain.getAccountProof(wrongAddress, headerWithAcc.number)
-    //the account doesn't exist, so we can't retrieve it, but we do receive a proof of non-existence with a full path of nodes that we iterated
-    retrievedAccountProofWrong.isDefined shouldBe true
-    retrievedAccountProofWrong.size shouldBe 1
+    //the account doesn't exist, so we can't retrieve it, but we do receive a proof of non-existence with a full path of nodes(root node) that we iterated
+    (retrievedAccountProofWrong.getOrElse(Vector.empty).toList match {
+      case _ @HashNode(_) :: Nil => true
+      case _ => false
+    }) shouldBe true
     mptWithAcc.get(wrongAddress) shouldBe None
   }
 

--- a/src/test/scala/io/iohk/ethereum/domain/BlockchainSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/domain/BlockchainSpec.scala
@@ -152,7 +152,10 @@ class BlockchainSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyCh
     //unhappy path
     val wrongAddress = Address(666)
     val retrievedAccountProofWrong = blockchain.getAccountProof(wrongAddress, headerWithAcc.number)
-    retrievedAccountProofWrong.isDefined shouldBe false
+    //the account doesn't exist, so we can't retrieve it, but we do receive a proof of non-existence with a full path of nodes that we iterated
+    retrievedAccountProofWrong.isDefined shouldBe true
+    retrievedAccountProofWrong.size shouldBe 1
+    mptWithAcc.get(wrongAddress) shouldBe None
 
     //happy path
     val retrievedAccountProof = blockchain.getAccountProof(address, headerWithAcc.number)

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/EthProofServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/EthProofServiceSpec.scala
@@ -1,21 +1,18 @@
 package io.iohk.ethereum.jsonrpc
 
 import akka.actor.ActorSystem
-import akka.testkit.{TestKit, TestProbe}
+import akka.testkit.TestKit
 import akka.util.ByteString
 import com.softwaremill.diffx.scalatest.DiffMatcher
+import io.iohk.ethereum._
 import io.iohk.ethereum.blockchain.sync.EphemBlockchainTestSetup
-import io.iohk.ethereum.consensus._
 import io.iohk.ethereum.consensus.ethash.blocks.EthashBlockGenerator
-import io.iohk.ethereum.domain.{Account, Address, Block, EthereumUInt256Mpt, UInt256}
-import io.iohk.ethereum.jsonrpc.server.controllers.JsonRpcBaseController.JsonRpcConfig
-import io.iohk.ethereum.keystore.KeyStore
-import io.iohk.ethereum.ledger.{Ledger, StxLedger}
+import io.iohk.ethereum.domain._
+import io.iohk.ethereum.jsonrpc.EthUserService.{GetBalanceRequest, GetBalanceResponse, GetStorageAtRequest, GetTransactionCountRequest}
+import io.iohk.ethereum.jsonrpc.ProofService.{GetProofRequest, StorageProofKey}
+import io.iohk.ethereum.ledger.Ledger
 import io.iohk.ethereum.mpt.MerklePatriciaTrie
 import io.iohk.ethereum.nodebuilder.ApisBuilder
-import io.iohk.ethereum.utils._
-import io.iohk.ethereum._
-import io.iohk.ethereum.jsonrpc.ProofService.{GetProofRequest, StorageProofKey}
 import monix.execution.Scheduler.Implicits.global
 import org.bouncycastle.util.encoders.Hex
 import org.scalactic.TypeCheckedTripleEquals
@@ -24,11 +21,7 @@ import org.scalatest.OptionValues
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
-
-import io.iohk.ethereum.jsonrpc.EthUserService.GetBalanceResponse
-import io.iohk.ethereum.jsonrpc.EthUserService.GetBalanceRequest
-import io.iohk.ethereum.jsonrpc.EthUserService.GetTransactionCountRequest
-import io.iohk.ethereum.jsonrpc.EthUserService.GetStorageAtRequest
+import io.iohk.ethereum.mpt.MerklePatriciaTrie.defaultByteArraySerializable
 
 class EthProofServiceSpec
     extends TestKit(ActorSystem("EthGetProofSpec_ActorSystem"))
@@ -43,49 +36,9 @@ class EthProofServiceSpec
     with DiffMatcher {
 
   "EthProofService" should "handle getStorageAt request" in new TestSetup {
-    // given
-    val address = Address(ByteString(Hex.decode("abbb6bebfa05aa13e908eaa492bd7a8343760477")))
-
-    val key = 333
-    val value = 123
-
-    val storageMpt = EthereumUInt256Mpt
-      .storageMpt(
-        ByteString(MerklePatriciaTrie.EmptyRootHash),
-        storagesInstance.storages.stateStorage.getBackingStorage(0)
-      )
-      .put(UInt256(key), UInt256(value))
-
-    val account = Account(
-      nonce = 0,
-      balance = UInt256(0),
-      storageRoot = ByteString(storageMpt.getRootHash),
-      codeHash = ByteString("")
-    )
-
-    import MerklePatriciaTrie.defaultByteArraySerializable
-    val mpt =
-      MerklePatriciaTrie[Array[Byte], Account](storagesInstance.storages.stateStorage.getBackingStorage(0))
-        .put(
-          crypto.kec256(address.bytes.toArray[Byte]),
-          account
-        )
-
-    val blockToRequest = Block(Fixtures.Blocks.Block3125369.header, Fixtures.Blocks.Block3125369.body)
-    val newBlockHeader = blockToRequest.header.copy(stateRoot = ByteString(mpt.getRootHash))
-    val newblock = blockToRequest.copy(header = newBlockHeader)
-    blockchain.storeBlock(newblock).commit()
-    blockchain.saveBestKnownBlocks(newblock.header.number)
-
-    val ethGetProof = new EthProofService(blockchain, blockGenerator, blockchainConfig.ethCompatibleStorage)
-    val storageKeys = Seq(StorageProofKey(key))
-    val blockNumber = BlockParam.Latest
     val request = GetProofRequest(address, storageKeys, blockNumber)
-
-    // when
     val result = ethGetProof.getProof(request)
 
-    // then
     val balanceResponse: GetBalanceResponse = ethUserService
       .getBalance(GetBalanceRequest(address, BlockParam.Latest))
       .runSyncUnsafe()
@@ -125,18 +78,113 @@ class EthProofServiceSpec
   }
 
   "EthProofService" should "return an error when the proof is requested for non-existing account" in new TestSetup {
-    val ethGetProof = new EthProofService(blockchain, blockGenerator, blockchainConfig.ethCompatibleStorage)
-    val key = 999
-    val storageKeys = Seq(StorageProofKey(key))
-    val blockNumber = BlockParam.Latest
     val wrongAddress = Address(666)
     val request = GetProofRequest(wrongAddress, storageKeys, blockNumber)
     val retrievedAccountProofWrong: ServiceResponse[ProofService.GetProofResponse] = ethGetProof.getProof(request)
-    retrievedAccountProofWrong.runSyncUnsafe().isLeft shouldBe true
+    val result = retrievedAccountProofWrong.runSyncUnsafe()
+
+    result.isLeft shouldBe true
+    result.fold(l => l.message should include("No account found for Address"), r => r)
+  }
+
+  "EthProofService" should "return the proof with empty value for non-existing storage key" in new TestSetup {
+    val wrongStorageKey = Seq(StorageProofKey(321))
+    val request = GetProofRequest(address, wrongStorageKey, blockNumber)
+    val retrievedAccountProofWrong: ServiceResponse[ProofService.GetProofResponse] = ethGetProof.getProof(request)
+    val result = retrievedAccountProofWrong.runSyncUnsafe()
+    result.isRight shouldBe true
+    result.fold(l => l, r => r.proofAccount.storageProof.map(v => {
+      v.proof.nonEmpty shouldBe true
+      v.value shouldBe BigInt(0)
+    }))
+  }
+
+  "EthProofService" should "return the proof and value for existing storage key" in new TestSetup {
+    val storageKey = Seq(StorageProofKey(key))
+    val request = GetProofRequest(address, storageKey, blockNumber)
+    val retrievedAccountProofWrong: ServiceResponse[ProofService.GetProofResponse] = ethGetProof.getProof(request)
+    val result = retrievedAccountProofWrong.runSyncUnsafe()
+    result.isRight shouldBe true
+    result.fold(l => l, r => r.proofAccount.storageProof.map(v => {
+      v.proof.nonEmpty shouldBe true
+      v.value shouldBe BigInt(value)
+    }))
+  }
+
+  "EthProofService" should "return the proof and value for multiple existing storage keys" in new TestSetup {
+    val storageKey = Seq(StorageProofKey(key), StorageProofKey(key2))
+    val expectedValueStorageKey = Seq(BigInt(value), BigInt(value2))
+    val request = GetProofRequest(address, storageKey, blockNumber)
+    val retrievedAccountProofWrong: ServiceResponse[ProofService.GetProofResponse] = ethGetProof.getProof(request)
+    val result = retrievedAccountProofWrong.runSyncUnsafe()
+    result.isRight shouldBe true
+    result.fold(l => l, r => {
+      r.proofAccount.storageProof.size shouldBe 2
+      r.proofAccount.storageProof.map(v => {
+        v.proof.nonEmpty shouldBe true
+        expectedValueStorageKey should contain(v.value)
+      })
+    })
+  }
+
+  "EthProofService" should "return the proof for all storage keys provided, but value should be returned only for the existing ones" in new TestSetup {
+    val wrongStorageKey = StorageProofKey(321)
+    val storageKey = Seq(StorageProofKey(key), StorageProofKey(key2)) :+ wrongStorageKey
+    val expectedValueStorageKey = Seq(BigInt(value), BigInt(value2), BigInt(0))
+    val request = GetProofRequest(address, storageKey, blockNumber)
+    val retrievedAccountProofWrong: ServiceResponse[ProofService.GetProofResponse] = ethGetProof.getProof(request)
+    val result = retrievedAccountProofWrong.runSyncUnsafe()
+    result.isRight shouldBe true
+    result.fold(l => l, r => {
+      r.proofAccount.storageProof.size shouldBe 3
+      expectedValueStorageKey.forall(r.proofAccount.storageProof.map(_.value).contains) shouldBe true
+    })
   }
 
   class TestSetup(implicit system: ActorSystem) extends MockFactory with EphemBlockchainTestSetup with ApisBuilder {
+
     val blockGenerator = mock[EthashBlockGenerator]
+    val address = Address(ByteString(Hex.decode("abbb6bebfa05aa13e908eaa492bd7a8343760477")))
+
+    val key = 333
+    val value = 123
+    val key1 = 334
+    val value1 = 124
+    val key2 = 335
+    val value2 = 125
+
+    val storageMpt = EthereumUInt256Mpt
+      .storageMpt(
+        ByteString(MerklePatriciaTrie.EmptyRootHash),
+        storagesInstance.storages.stateStorage.getBackingStorage(0)
+      )
+      .put(UInt256(key), UInt256(value))
+      .put(UInt256(key1), UInt256(value1))
+      .put(UInt256(key2), UInt256(value2))
+
+    val account = Account(
+      nonce = 0,
+      balance = UInt256(0),
+      storageRoot = ByteString(storageMpt.getRootHash)
+    )
+
+    val mpt =
+      MerklePatriciaTrie[Array[Byte], Account](storagesInstance.storages.stateStorage.getBackingStorage(0))
+        .put(
+          crypto.kec256(address.bytes.toArray[Byte]),
+          account
+        )
+
+    val blockToRequest = Block(Fixtures.Blocks.Block3125369.header, Fixtures.Blocks.Block3125369.body)
+    val newBlockHeader = blockToRequest.header.copy(stateRoot = ByteString(mpt.getRootHash))
+    val newblock = blockToRequest.copy(header = newBlockHeader)
+    blockchain.storeBlock(newblock).commit()
+    blockchain.saveBestKnownBlocks(newblock.header.number)
+
+    val ethGetProof = new EthProofService(blockchain, blockGenerator, blockchainConfig.ethCompatibleStorage)
+
+    val storageKeys = Seq(StorageProofKey(key))
+    val blockNumber = BlockParam.Latest
 
     override lazy val ledger = mock[Ledger]
 

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/EthProofServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/EthProofServiceSpec.scala
@@ -25,7 +25,6 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
 
-import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import io.iohk.ethereum.jsonrpc.EthUserService.GetBalanceResponse
 import io.iohk.ethereum.jsonrpc.EthUserService.GetBalanceRequest
 import io.iohk.ethereum.jsonrpc.EthUserService.GetTransactionCountRequest

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerEthSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerEthSpec.scala
@@ -803,13 +803,15 @@ class JsonRpcControllerEthSpec
   }
 
   it should "decode and encode eth_getProof request and response" in new JsonRpcControllerFixture {
+    val address = "0x7F0d15C7FAae65896648C8273B6d7E43f58Fa842"
+
     val request: JsonRpcRequest = JsonRpcRequest(
       jsonrpc = "2.0",
       method = "eth_getProof",
       params = Some(
         JArray(
           List(
-            JString("0x7F0d15C7FAae65896648C8273B6d7E43f58Fa842"),
+            JString(address),
             JArray(List(JString("0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"))),
             JString("latest")
           )
@@ -819,14 +821,14 @@ class JsonRpcControllerEthSpec
     )
 
     val expectedDecodedRequest = GetProofRequest(
-      address = Address("0x7f0d15c7faae65896648c8273b6d7e43f58fa842"),
+      address = Address(address),
       storageKeys =
         List(StorageProofKey(BigInt("39309028074332508661983559455579427211983204215636056653337583610388178777121"))),
       blockNumber = BlockParam.Latest
     )
     val expectedEncodedResponse: GetProofResponse = GetProofResponse(
       ProofAccount(
-        address = Address("0x7f0d15c7faae65896648c8273b6d7e43f58fa842"),
+        address = Address(address),
         accountProof = Seq(ByteString(Hex.decode("1234"))),
         balance = BigInt(0x0),
         codeHash = ByteString(Hex.decode("123eeaa22a")),

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerEthSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerEthSpec.scala
@@ -18,7 +18,7 @@ import io.iohk.ethereum.jsonrpc.ProofService.{
   GetProofRequest,
   GetProofResponse,
   ProofAccount,
-  StorageProof,
+  StorageValueProof,
   StorageProofKey
 }
 import io.iohk.ethereum.jsonrpc.serialization.JsonSerializers.{
@@ -835,7 +835,7 @@ class JsonRpcControllerEthSpec
         nonce = 0,
         storageHash = ByteString(Hex.decode("1a2b3c")),
         storageProof = Seq(
-          StorageProof(
+          StorageValueProof(
             key = StorageProofKey(42),
             value = BigInt(2000),
             proof = Seq(

--- a/src/test/scala/io/iohk/ethereum/mpt/MerklePatriciaTrieSuite.scala
+++ b/src/test/scala/io/iohk/ethereum/mpt/MerklePatriciaTrieSuite.scala
@@ -573,6 +573,7 @@ class MerklePatriciaTrieSuite extends AnyFunSuite with ScalaCheckPropertyChecks 
       val proof: Option[Vector[MptNode]] = trie.getProof(key4)
       // then
       assert(proof.isDefined)
+      assert(proof.get.nonEmpty)
   }
 
   test("getProof returns valid proof for existing key") {

--- a/src/test/scala/io/iohk/ethereum/mpt/MerklePatriciaTrieSuite.scala
+++ b/src/test/scala/io/iohk/ethereum/mpt/MerklePatriciaTrieSuite.scala
@@ -573,7 +573,6 @@ class MerklePatriciaTrieSuite extends AnyFunSuite with ScalaCheckPropertyChecks 
       val proof: Option[Vector[MptNode]] = trie.getProof(key4)
       // then
       assert(proof.isDefined)
-      proof.foreach(_.foreach(MptUtils.showMptNode(_, true, " ")))
   }
 
   test("getProof returns valid proof for existing key") {
@@ -623,44 +622,4 @@ class MerklePatriciaTrieSuite extends AnyFunSuite with ScalaCheckPropertyChecks 
       val obtained = trie.get(key)
       assert(obtained.isEmpty)
     }
-}
-
-object MptUtils {
-  import io.iohk.ethereum.mpt._
-  import org.bouncycastle.util.encoders.Hex
-  def show(val1: Array[Byte]): String =
-    Hex.encode(val1).map(_.toChar).mkString
-  def showKV(key1: Array[Byte], trie: MerklePatriciaTrie[Array[Byte], Array[Byte]]): String =
-    show(key1) + " -> " + trie.get(key1).map(show)
-  def showMptNode(n: MptNode, showNull: Boolean = false, indent: String): Unit = {
-    n match {
-      case LeafNode(key, value, cachedHash, cachedRlpEncoded, parsedRlp) =>
-        if (showNull) println("\n")
-        println(s"$indent LeafNode(${show(key.toArray)} -> ${show(value.toArray)})")
-      case ExtensionNode(sharedKey, next, cachedHash, cachedRlpEncoded, parsedRlp) =>
-        if (showNull) println("\n")
-        println(s"$indent ExtensionNode(sharedKey = ${show(sharedKey.toArray)}")
-        println(s"$indent next = ")
-        showMptNode(next, false, indent + " ")
-        println(s"$indent )")
-      case BranchNode(children, terminator, cachedHash, cachedRlpEncoded, parsedRlp) =>
-        if (showNull) println("\n")
-        println(
-          s"$indent BranchNode(children = ${children.filterNot(n => n.isInstanceOf[NullNode.type]).size}, terminator = ${terminator
-            .map(e => show(e.toArray))}"
-        )
-        println(s"$indent children: ")
-        children.map(showMptNode(_, false, indent + " "))
-        println(s"$indent )")
-      case NullNode =>
-        if (showNull) println(s"$indent NullNode")
-      case other =>
-        if (showNull) println("\n")
-        println(s"$indent $other")
-    }
-  }
-  def showMptTrie[K, V](mpt: MerklePatriciaTrie[K, V]): Unit = {
-    println(s"MPT ROOT HASH ${mpt.getRootHash} rootNode: ")
-    mpt.rootNode.map(n => showMptNode(n, false, "  "))
-  }
 }


### PR DESCRIPTION
Proofs for non existent values(keys)

In case an address or storage-value does not exist, the proof needs to provide enough data to verify this fact. This means the client needs to follow the path from the root node and deliver until the last matching node. If the last matching node is a branch, the proof value in the node must be an empty one. In case of leaf-type, it must be pointing to a different relative-path in order to proof that the requested path does not exist.

Specification: https://eips.ethereum.org/EIPS/eip-1186
Jira ticket: https://jira.iohk.io/projects/ETCM/issues/ETCM-533

Proposed Solution
following similar implementation with geth client: in case of non existing account, an error should be returned. In case of non existing storage keys, the proof should be returned with default value 0

Manual tests based on other clients are welcomed

