### PR TITLE
[FIX] Align nix expression evaluation with recent changes

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,8 +1,8 @@
 steps:
   - label: ":nix::point_right::pipeline:"
     command: |
-      export NIX_PATH="nixpkgs=$(nix eval --raw '(import nix/sources.nix).nixpkgs')"
-      nix eval --json '(import ./.buildkite { pipeline = ./.buildkite/pipeline.nix; })' \
+      export NIX_PATH="nixpkgs=$(nix-instantiate --verbose ./nix/sources.nix)"
+      nix-instantiate --eval --strict --json --expr '(import ./.buildkite { pipeline = ./.buildkite/pipeline.nix; })' \
       | buildkite-agent pipeline upload --no-interpolation
     agents:
       queue: project42

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 steps:
   - label: ":nix::point_right::pipeline:"
     command: |
-      export NIX_PATH="nixpkgs=$(nix-instantiate --verbose ./nix/sources.nix)"
+      export NIX_PATH="nixpkgs=$(nix-instantiate --eval --strict --json --read-write-mode -E '(import nix/sources.nix).nixpkgs' | tr -d '"')"
       nix-instantiate --eval --strict --json --expr '(import ./.buildkite { pipeline = ./.buildkite/pipeline.nix; })' \
       | buildkite-agent pipeline upload --no-interpolation
     agents:


### PR DESCRIPTION
# Description

`nix eval '(1 + 1)'` used to evaluate but some recent changes resulted in this encoding being no longer supported.

This resulted in:
```
error: --- BadURL --- nix
'(import nix/sources.nix).nixpkgs' is not a valid URL
```

# Proposed Solution

@Infinisil proposed an alternative that should be stable:
replace the above with `nix-instantiate --eval --expr '1 + 1'` calls.

# Testing

The obvious test of buildkite working again.
