### PR TITLE
Fixed concurrency issue that allowed multiple miners instantiation.

### DIFF
--- a/src/main/scala/io/iohk/ethereum/consensus/ethash/EthashConsensus.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/ethash/EthashConsensus.scala
@@ -62,6 +62,12 @@ class EthashConsensus private (
 
   private[this] val mutex = new Object
 
+  /*
+   * guarantees one miner instance
+   * this should not use a atomic* construct as it has side-effects
+   *
+   * TODO further refactors should focus on extracting two types - one with a miner, one without - based on the config
+   */
   private[this] def startMiningProcess(node: Node): Unit = {
     if (minerRef.isEmpty) {
       mutex.synchronized {

--- a/src/main/scala/io/iohk/ethereum/consensus/ethash/EthashConsensus.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/ethash/EthashConsensus.scala
@@ -2,7 +2,6 @@ package io.iohk.ethereum
 package consensus
 package ethash
 
-import java.util.concurrent.atomic.AtomicReference
 import akka.actor.ActorRef
 import akka.util.Timeout
 import io.iohk.ethereum.consensus.Protocol._
@@ -48,34 +47,33 @@ class EthashConsensus private (
     blockchainConfig = blockchainConfig
   )
 
-  private[this] val atomicMiner = new AtomicReference[Option[ActorRef]](None)
+  @volatile private[this] var minerRef: Option[ActorRef] = None
 
   private implicit val timeout: Timeout = 5.seconds
 
-  override def sendMiner(msg: MinerProtocol): Unit = {
-    atomicMiner
-      .get()
-      .foreach(_ ! msg)
-  }
+  override def sendMiner(msg: MinerProtocol): Unit =
+    minerRef.foreach(_ ! msg)
 
   override def askMiner(msg: MinerProtocol): Task[MinerResponse] = {
-    atomicMiner
-      .get()
+    minerRef
       .map(_.askFor[MinerResponse](msg))
       .getOrElse(Task.now(MinerNotExist))
   }
 
-  private[this] def startMiningProcess(node: Node): Unit = {
-    atomicMiner.get() match {
-      case None =>
-        val miner = config.generic.protocol match {
-          case Ethash | RestrictedEthash => EthashMiner(node)
-          case MockedPow => MockedMiner(node)
-        }
-        atomicMiner.set(Some(miner))
-        sendMiner(MinerProtocol.StartMining)
+  private[this] val mutex = new Object
 
-      case _ =>
+  private[this] def startMiningProcess(node: Node): Unit = {
+    if (minerRef.isEmpty) {
+      mutex.synchronized {
+        if (minerRef.isEmpty) {
+          val miner = config.generic.protocol match {
+            case Ethash | RestrictedEthash => EthashMiner(node)
+            case MockedPow => MockedMiner(node)
+          }
+          minerRef = Some(miner)
+          sendMiner(MinerProtocol.StartMining)
+        }
+      }
     }
   }
 


### PR DESCRIPTION
This PR is a refresh of https://github.com/input-output-hk/mantis/pull/777

# Description

Concurrent `EthashConsensus.startMiningProcess()` method invocation can lead to several miner actors.
There's no thread mutual exclusion and atomicity between `AtomicReference.get()` and `AtomicReference.set()` calls.

# Proposed Solution

`synchronized` or `ReentrantReadWrite` is recommended to ensure that only one miner is created.
`AtomicReference` is redundant, since no CAS-related methods are used.
Solution assumes that no thread synchronization is needed when miner already exists.