### PR TITLE
Fix for deployment with Nix's pure evaluation mode / flakes

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -5,7 +5,11 @@ let
   # affect the fixed derivation calculation from sbt-derivation
   overlay = final: prev: let
     inherit (import sources.gitignore { inherit (prev) lib; }) gitignoreSource;
-    cleanedSrc = prev.lib.cleanSource (gitignoreSource src);
+    # If src isn't a path, it's likely a prefiltered store path, so use it directly
+    # This also makes Nix flakes work by passing the flake source as the `src` arg
+    cleanedSrc = if builtins.isPath src
+      then prev.lib.cleanSource (gitignoreSource src)
+      else src;
   in {
     inherit sources;
 


### PR DESCRIPTION
### Description

In https://github.com/input-output-hk/mantis/pull/875, `cleanSource` and `gitignoreSource` started being used for filtering the source. This doesn't work with Nix's pure evaluation mode and consequently flakes and mantis-ops. 

### Proposed Solution

This PR enables a workaround that allows pure evaluation again. Specifically, if `src` is not a path (e.g. when passing it via flakes or `fetchGit`), it isn't being filtered again. So with flakes it's now possible to build Mantis again with
```nix
{
  mantis = import mantis-source {
    inherit system;
    src = mantis-source;
  };
}
```

In addition, this is now being tested with CI to detect such problems before they are merged in the future.

### Important Changes Introduced



### Testing

This can be tested with this command, which now evaluates successfully:
```
$ nix-instantiate --pure-eval -E \
    '{ rev }: let src = fetchGit { url = ./.; inherit rev; }; in
     import src { inherit src; system = "x86_64-linux"; }' --argstr rev "$(git rev-parse @)"
warning: you did not specify '--add-root'; the result might be removed by the garbage collector
/nix/store/lap7xx0qqhs9a17pbhivr7v62szy2ikz-mantis-3.2.1.drv
```

