### PR TITLE
ETCM-147 use explicitly triggered scheduler for SyncControllerSpec

### DIFF
--- a/src/test/resources/explicit-scheduler.conf
+++ b/src/test/resources/explicit-scheduler.conf
@@ -1,0 +1,3 @@
+include "application.conf"
+
+akka.scheduler.implementation = "akka.testkit.ExplicitlyTriggeredScheduler"


### PR DESCRIPTION
The actors used by `SyncController` use the scheduler to retry various actions and its tests rely on this behavior to trigger, which involves retrying over period of up to 10 or 30 seconds. By using an explicitly triggered scheduler we can instead advance the clock artificially and only a short time.

Because of the complexity of the actors and the different timeouts I had to find the time steps (100ms and 3000ms) by trial and error, unfortunately. If they are too high or too low the specs will fail. In addition, the speed up is only about 2-4x.