### PR TITLE
Bug/etcm 636 [!pr]

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -59,7 +59,7 @@ object Dependencies {
 
   val testing: Seq[ModuleID] = Seq(
     "org.scalatest" %% "scalatest" % "3.2.2" % "it,test",
-    "org.scalamock" %% "scalamock" % "5.0.0" % "test",
+    "org.scalamock" %% "scalamock" % "5.0.0" % "it,test",
     "org.scalatestplus" %% "scalacheck-1-15" % "3.2.3.0" % "test",
     "org.scalacheck" %% "scalacheck" % "1.15.1" % "it,test",
     "com.softwaremill.diffx" %% "diffx-core" % "0.3.30" % "test",

--- a/src/it/scala/io/iohk/ethereum/ledger/BlockImporterItSpec.scala
+++ b/src/it/scala/io/iohk/ethereum/ledger/BlockImporterItSpec.scala
@@ -1,0 +1,108 @@
+package io.iohk.ethereum.ledger
+
+import akka.testkit.TestProbe
+import akka.util.ByteString
+import cats.data.NonEmptyList
+import io.iohk.ethereum.blockchain.sync.regular.{BlockFetcher, BlockImporter}
+import io.iohk.ethereum.consensus.blocks.CheckpointBlockGenerator
+import io.iohk.ethereum.domain._
+import io.iohk.ethereum.mpt.MerklePatriciaTrie
+import io.iohk.ethereum.utils.Config.SyncConfig
+import io.iohk.ethereum.utils.Config
+import io.iohk.ethereum.Fixtures
+import monix.execution.Scheduler
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AsyncFlatSpecLike
+import org.scalatest.matchers.should.Matchers
+import scala.concurrent.duration._
+
+class BlockImporterItSpec extends MockFactory with TestSetupWithVmAndValidators with AsyncFlatSpecLike with Matchers with BeforeAndAfterAll {
+
+  implicit val testScheduler = Scheduler.fixedPool("test", 32)
+
+  override def afterAll(): Unit = {
+    testScheduler.shutdown()
+    testScheduler.awaitTermination(60.second)
+  }
+
+  val bl = BlockchainImpl(storagesInstance.storages)
+
+  val blockQueue = BlockQueue(bl, SyncConfig(Config.config))
+
+  val genesis = Block(
+    Fixtures.Blocks.Genesis.header.copy(stateRoot = ByteString(MerklePatriciaTrie.EmptyRootHash)),
+    Fixtures.Blocks.Genesis.body
+  )
+  val genesisWeight = ChainWeight.zero.increase(genesis.header)
+
+  bl.save(genesis, Seq(), genesisWeight, saveAsBestBlock = true)
+
+  lazy val checkpointBlockGenerator: CheckpointBlockGenerator = new CheckpointBlockGenerator
+
+  val fetcherProbe = TestProbe()
+  val ommersPoolProbe = TestProbe()
+  val broadcasterProbe = TestProbe()
+  val pendingTransactionsManagerProbe = TestProbe()
+  val supervisor = TestProbe()
+
+  override lazy val ledger: TestLedgerImpl =  new TestLedgerImpl(validators) {
+    override private[ledger] lazy val blockExecution = mock[BlockExecution]
+  }
+
+  val blockImporter = system.actorOf(
+    BlockImporter.props(
+      fetcherProbe.ref,
+      ledger,
+      bl,
+      syncConfig,
+      ommersPoolProbe.ref,
+      broadcasterProbe.ref,
+      pendingTransactionsManagerProbe.ref,
+      checkpointBlockGenerator,
+      supervisor.ref
+    ))
+
+  "BlockImporter" should "return a correct new best block after reorganising longer chain to a shorter one" in {
+
+    val genesis = bl.getBestBlock()
+    val block1: Block = getBlock(genesis.number + 1, parent = genesis.header.hash)
+    // new chain is shorter but has a higher weight
+    val newBlock2: Block = getBlock(genesis.number + 2, difficulty = 101, parent = block1.header.hash)
+    val newBlock3: Block = getBlock(genesis.number + 3, difficulty = 333, parent = newBlock2.header.hash)
+    val oldBlock2: Block = getBlock(genesis.number + 2, difficulty = 102, parent = block1.header.hash)
+    val oldBlock3: Block = getBlock(genesis.number + 3, difficulty = 103, parent = oldBlock2.header.hash)
+    val oldBlock4: Block = getBlock(genesis.number + 4, difficulty = 104, parent = oldBlock3.header.hash)
+
+    val weight1 = ChainWeight.totalDifficultyOnly(block1.header.difficulty + 999)
+    val newWeight2 = weight1.increase(newBlock2.header)
+    val newWeight3 = newWeight2.increase(newBlock3.header)
+    val oldWeight2 = weight1.increase(oldBlock2.header)
+    val oldWeight3 = oldWeight2.increase(oldBlock3.header)
+    val oldWeight4 = oldWeight3.increase(oldBlock4.header)
+
+    //saving initial main chain
+    bl.save(block1, Nil, weight1, saveAsBestBlock = true)
+    bl.save(oldBlock2, Nil, oldWeight2, saveAsBestBlock = true)
+    bl.save(oldBlock3, Nil, oldWeight3, saveAsBestBlock = true)
+    bl.save(oldBlock4, Nil, oldWeight4, saveAsBestBlock = true)
+
+    val blockData2 = BlockData(newBlock2, Seq.empty[Receipt], newWeight2)
+    val blockData3 = BlockData(newBlock3, Seq.empty[Receipt], newWeight3)
+
+    val newBranch = List(newBlock2, newBlock3)
+
+    blockImporter ! BlockImporter.Start
+    blockImporter ! BlockFetcher.PickedBlocks(NonEmptyList.fromListUnsafe(newBranch))
+
+    (ledger.blockExecution.executeAndValidateBlocks _)
+      .expects(newBranch, *)
+      .returning((List(blockData2, blockData3), None))
+
+    // Saving new blocks, because it's part of executeBlocks method mechanism
+    bl.save(blockData2.block, blockData2.receipts, blockData2.weight, saveAsBestBlock = true)
+    bl.save(blockData3.block, blockData3.receipts, blockData3.weight, saveAsBestBlock = true)
+
+    bl.getBestBlock() shouldEqual newBlock3
+  }
+}

--- a/src/it/scala/io/iohk/ethereum/ledger/BlockImporterItSpec.scala
+++ b/src/it/scala/io/iohk/ethereum/ledger/BlockImporterItSpec.scala
@@ -104,10 +104,7 @@ class BlockImporterItSpec extends MockFactory with TestSetupWithVmAndValidators 
 
   blockImporter ! BlockImporter.Start
 
-  /** TODO: this should not behave like that, but instead return a proper error and revert reorganisation to the initial chain. Currently if we had a chain, and then
-    reorganisation started and error occurred in BlockExecution.executeAndValidateBlock() we end up with a discarded main chain to the point of the common parent**/
-
-  "BlockImporter" should "(not) discard blocks of the main chain if the reorganisation failed" in {
+  "BlockImporter" should "not discard blocks of the main chain if the reorganisation failed" in {
 
     //ledger with not mocked blockExecution
     val ledger = new TestLedgerImpl(successValidators)
@@ -129,7 +126,7 @@ class BlockImporterItSpec extends MockFactory with TestSetupWithVmAndValidators 
 
     Thread.sleep(1000)
     //because the blocks are not valid, we shouldn't reorganise, but at least stay with a current chain, and the best block of the current chain is oldBlock4
-    blockchain.getBestBlock().get shouldEqual block1
+    blockchain.getBestBlock().get shouldEqual oldBlock4
   }
 
   it should "return a correct new best block after reorganising longer chain to a shorter one" in {

--- a/src/it/scala/io/iohk/ethereum/ledger/BlockImporterItSpec.scala
+++ b/src/it/scala/io/iohk/ethereum/ledger/BlockImporterItSpec.scala
@@ -129,7 +129,7 @@ class BlockImporterItSpec extends MockFactory with TestSetupWithVmAndValidators 
     blockchain.getBestBlock().get shouldEqual oldBlock4
   }
 
-  it should "return a correct new best block after reorganising longer chain to a shorter one" in {
+  it should "return a correct new best block after reorganising longer chain to a shorter one if its weight is bigger" in {
 
     //returning discarded initial chain
     blockchain.save(oldBlock2, Nil, oldWeight2, saveAsBestBlock = true)
@@ -145,8 +145,8 @@ class BlockImporterItSpec extends MockFactory with TestSetupWithVmAndValidators 
 
   it should "switch to a branch with a checkpoint" in {
 
-    val chackpoint = ObjectGenerators.fakeCheckpointGen(3, 3).sample.get
-    val oldBlock5WithCheckpoint: Block = checkpointBlockGenerator.generate(oldBlock4, chackpoint)
+    val checkpoint = ObjectGenerators.fakeCheckpointGen(3, 3).sample.get
+    val oldBlock5WithCheckpoint: Block = checkpointBlockGenerator.generate(oldBlock4, checkpoint)
     blockchain.save(oldBlock5WithCheckpoint, Nil, oldWeight4, saveAsBestBlock = true)
 
     val newBranch = List(newBlock2, newBlock3)
@@ -158,10 +158,10 @@ class BlockImporterItSpec extends MockFactory with TestSetupWithVmAndValidators 
     blockchain.getLatestCheckpointBlockNumber() shouldEqual oldBlock5WithCheckpoint.header.number
   }
 
-  it should "return a correct checkpointed block after reorganising longer chain to a shorter one and back" in {
+  it should "switch to a branch with a newer checkpoint" in {
 
-    val chackpoint = ObjectGenerators.fakeCheckpointGen(3, 3).sample.get
-    val newBlock4WithCheckpoint: Block = checkpointBlockGenerator.generate(newBlock3, chackpoint)
+    val checkpoint = ObjectGenerators.fakeCheckpointGen(3, 3).sample.get
+    val newBlock4WithCheckpoint: Block = checkpointBlockGenerator.generate(newBlock3, checkpoint)
     blockchain.save(newBlock4WithCheckpoint, Nil, newWeight3, saveAsBestBlock = true)
 
     val newBranch = List(newBlock4WithCheckpoint)
@@ -173,7 +173,7 @@ class BlockImporterItSpec extends MockFactory with TestSetupWithVmAndValidators 
     blockchain.getLatestCheckpointBlockNumber() shouldEqual newBlock4WithCheckpoint.header.number
   }
 
-  it should "return a correct checkpointed block after receiving a new chackpoint from morpho" in {
+  it should "return a correct checkpointed block after receiving a request for generating a new checkpoint" in {
 
     val parent = blockchain.getBestBlock().get
     val newBlock5: Block = getBlock(genesisBlock.number + 5, difficulty = 104, parent = parent.header.hash)

--- a/src/it/scala/io/iohk/ethereum/ledger/BlockImporterItSpec.scala
+++ b/src/it/scala/io/iohk/ethereum/ledger/BlockImporterItSpec.scala
@@ -3,18 +3,22 @@ package io.iohk.ethereum.ledger
 import akka.testkit.TestProbe
 import akka.util.ByteString
 import cats.data.NonEmptyList
+import io.iohk.ethereum.blockchain.sync.regular.BlockImporter.NewCheckpoint
 import io.iohk.ethereum.blockchain.sync.regular.{BlockFetcher, BlockImporter}
+import io.iohk.ethereum.checkpointing.CheckpointingTestHelpers
 import io.iohk.ethereum.consensus.blocks.CheckpointBlockGenerator
 import io.iohk.ethereum.domain._
 import io.iohk.ethereum.mpt.MerklePatriciaTrie
 import io.iohk.ethereum.utils.Config.SyncConfig
 import io.iohk.ethereum.utils.Config
-import io.iohk.ethereum.Fixtures
+import io.iohk.ethereum.{Fixtures, ObjectGenerators, crypto}
+import io.iohk.ethereum.ledger.Ledger.BlockResult
 import monix.execution.Scheduler
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AsyncFlatSpecLike
 import org.scalatest.matchers.should.Matchers
+
 import scala.concurrent.duration._
 
 class BlockImporterItSpec extends MockFactory with TestSetupWithVmAndValidators with AsyncFlatSpecLike with Matchers with BeforeAndAfterAll {
@@ -26,9 +30,7 @@ class BlockImporterItSpec extends MockFactory with TestSetupWithVmAndValidators 
     testScheduler.awaitTermination(60.second)
   }
 
-  val bl = BlockchainImpl(storagesInstance.storages)
-
-  val blockQueue = BlockQueue(bl, SyncConfig(Config.config))
+  val blockQueue = BlockQueue(blockchain, SyncConfig(Config.config))
 
   val genesis = Block(
     Fixtures.Blocks.Genesis.header.copy(stateRoot = ByteString(MerklePatriciaTrie.EmptyRootHash)),
@@ -36,7 +38,7 @@ class BlockImporterItSpec extends MockFactory with TestSetupWithVmAndValidators 
   )
   val genesisWeight = ChainWeight.zero.increase(genesis.header)
 
-  bl.save(genesis, Seq(), genesisWeight, saveAsBestBlock = true)
+  blockchain.save(genesis, Seq(), genesisWeight, saveAsBestBlock = true)
 
   lazy val checkpointBlockGenerator: CheckpointBlockGenerator = new CheckpointBlockGenerator
 
@@ -46,15 +48,27 @@ class BlockImporterItSpec extends MockFactory with TestSetupWithVmAndValidators 
   val pendingTransactionsManagerProbe = TestProbe()
   val supervisor = TestProbe()
 
-  override lazy val ledger: TestLedgerImpl =  new TestLedgerImpl(validators) {
-    override private[ledger] lazy val blockExecution = mock[BlockExecution]
+  val emptyWorld: InMemoryWorldStateProxy =
+    blockchain.getWorldStateProxy(
+      -1,
+      UInt256.Zero,
+      ByteString(MerklePatriciaTrie.EmptyRootHash),
+      noEmptyAccounts = false,
+      ethCompatibleStorage = true
+    )
+
+  override lazy val ledger = new TestLedgerImpl(successValidators)  {
+    override private[ledger] lazy val blockExecution = new BlockExecution(blockchain, blockchainConfig, consensus.blockPreparator, blockValidation) {
+      override def executeAndValidateBlock(block: Block, alreadyValidated: Boolean = false): Either[BlockExecutionError, Seq[Receipt]] =
+        Right(BlockResult(emptyWorld).receipts)
+    }
   }
 
   val blockImporter = system.actorOf(
     BlockImporter.props(
       fetcherProbe.ref,
       ledger,
-      bl,
+      blockchain,
       syncConfig,
       ommersPoolProbe.ref,
       broadcasterProbe.ref,
@@ -63,46 +77,123 @@ class BlockImporterItSpec extends MockFactory with TestSetupWithVmAndValidators 
       supervisor.ref
     ))
 
-  "BlockImporter" should "return a correct new best block after reorganising longer chain to a shorter one" in {
+  val genesisBlock = blockchain.genesisBlock
+  val block1: Block = getBlock(genesisBlock.number + 1, parent = genesisBlock.header.hash)
+  // new chain is shorter but has a higher weight
+  val newBlock2: Block = getBlock(genesisBlock.number + 2, difficulty = 108, parent = block1.header.hash)
+  val newBlock3: Block = getBlock(genesisBlock.number + 3, difficulty = 300, parent = newBlock2.header.hash)
+  val oldBlock2: Block = getBlock(genesisBlock.number + 2, difficulty = 102, parent = block1.header.hash)
+  val oldBlock3: Block = getBlock(genesisBlock.number + 3, difficulty = 103, parent = oldBlock2.header.hash)
+  val oldBlock4: Block = getBlock(genesisBlock.number + 4, difficulty = 104, parent = oldBlock3.header.hash)
 
-    val genesis = bl.getBestBlock()
-    val block1: Block = getBlock(genesis.number + 1, parent = genesis.header.hash)
-    // new chain is shorter but has a higher weight
-    val newBlock2: Block = getBlock(genesis.number + 2, difficulty = 101, parent = block1.header.hash)
-    val newBlock3: Block = getBlock(genesis.number + 3, difficulty = 333, parent = newBlock2.header.hash)
-    val oldBlock2: Block = getBlock(genesis.number + 2, difficulty = 102, parent = block1.header.hash)
-    val oldBlock3: Block = getBlock(genesis.number + 3, difficulty = 103, parent = oldBlock2.header.hash)
-    val oldBlock4: Block = getBlock(genesis.number + 4, difficulty = 104, parent = oldBlock3.header.hash)
+  val weight1 = ChainWeight.totalDifficultyOnly(block1.header.difficulty)
+  val newWeight2 = weight1.increase(newBlock2.header)
+  val newWeight3 = newWeight2.increase(newBlock3.header)
+  val oldWeight2 = weight1.increase(oldBlock2.header)
+  val oldWeight3 = oldWeight2.increase(oldBlock3.header)
+  val oldWeight4 = oldWeight3.increase(oldBlock4.header)
 
-    val weight1 = ChainWeight.totalDifficultyOnly(block1.header.difficulty + 999)
-    val newWeight2 = weight1.increase(newBlock2.header)
-    val newWeight3 = newWeight2.increase(newBlock3.header)
-    val oldWeight2 = weight1.increase(oldBlock2.header)
-    val oldWeight3 = oldWeight2.increase(oldBlock3.header)
-    val oldWeight4 = oldWeight3.increase(oldBlock4.header)
+  //saving initial main chain
+  blockchain.save(block1, Nil, weight1, saveAsBestBlock = true)
+  blockchain.save(oldBlock2, Nil, oldWeight2, saveAsBestBlock = true)
+  blockchain.save(oldBlock3, Nil, oldWeight3, saveAsBestBlock = true)
+  blockchain.save(oldBlock4, Nil, oldWeight4, saveAsBestBlock = true)
 
-    //saving initial main chain
-    bl.save(block1, Nil, weight1, saveAsBestBlock = true)
-    bl.save(oldBlock2, Nil, oldWeight2, saveAsBestBlock = true)
-    bl.save(oldBlock3, Nil, oldWeight3, saveAsBestBlock = true)
-    bl.save(oldBlock4, Nil, oldWeight4, saveAsBestBlock = true)
+  val oldBranch = List(oldBlock2, oldBlock3, oldBlock4)
+  val newBranch = List(newBlock2, newBlock3)
 
-    val blockData2 = BlockData(newBlock2, Seq.empty[Receipt], newWeight2)
-    val blockData3 = BlockData(newBlock3, Seq.empty[Receipt], newWeight3)
+  blockImporter ! BlockImporter.Start
 
-    val newBranch = List(newBlock2, newBlock3)
+  /** TODO: this should not behave like that, but instead return a proper error and revert reorganisation to the initial chain. Currently if we had a chain, and then
+    reorganisation started and error occurred in BlockExecution.executeAndValidateBlock() we end up with a discarded main chain to the point of the common parent**/
+
+  "BlockImporter" should "(not) discard blocks of the main chain if the reorganisation failed" in {
+
+    //ledger with not mocked blockExecution
+    val ledger = new TestLedgerImpl(successValidators)
+    val blockImporter = system.actorOf(
+      BlockImporter.props(
+        fetcherProbe.ref,
+        ledger,
+        blockchain,
+        syncConfig,
+        ommersPoolProbe.ref,
+        broadcasterProbe.ref,
+        pendingTransactionsManagerProbe.ref,
+        checkpointBlockGenerator,
+        supervisor.ref
+      ))
 
     blockImporter ! BlockImporter.Start
     blockImporter ! BlockFetcher.PickedBlocks(NonEmptyList.fromListUnsafe(newBranch))
 
-    (ledger.blockExecution.executeAndValidateBlocks _)
-      .expects(newBranch, *)
-      .returning((List(blockData2, blockData3), None))
+    Thread.sleep(1000)
+    //because the blocks are not valid, we shouldn't reorganise, but at least stay with a current chain, and the best block of the current chain is oldBlock4
+    blockchain.getBestBlock().get shouldEqual block1
+  }
 
-    // Saving new blocks, because it's part of executeBlocks method mechanism
-    bl.save(blockData2.block, blockData2.receipts, blockData2.weight, saveAsBestBlock = true)
-    bl.save(blockData3.block, blockData3.receipts, blockData3.weight, saveAsBestBlock = true)
+  it should "return a correct new best block after reorganising longer chain to a shorter one" in {
 
-    bl.getBestBlock() shouldEqual newBlock3
+    //returning discarded initial chain
+    blockchain.save(oldBlock2, Nil, oldWeight2, saveAsBestBlock = true)
+    blockchain.save(oldBlock3, Nil, oldWeight3, saveAsBestBlock = true)
+    blockchain.save(oldBlock4, Nil, oldWeight4, saveAsBestBlock = true)
+
+    blockImporter ! BlockFetcher.PickedBlocks(NonEmptyList.fromListUnsafe(newBranch))
+
+    Thread.sleep(200)
+    blockchain.getBestBlock().get shouldEqual newBlock3
+  }
+
+
+  it should "switch to a branch with a checkpoint" in {
+
+    val chackpoint = ObjectGenerators.fakeCheckpointGen(3, 3).sample.get
+    val oldBlock5WithCheckpoint: Block = checkpointBlockGenerator.generate(oldBlock4, chackpoint)
+    blockchain.save(oldBlock5WithCheckpoint, Nil, oldWeight4, saveAsBestBlock = true)
+
+    val newBranch = List(newBlock2, newBlock3)
+
+    blockImporter ! BlockFetcher.PickedBlocks(NonEmptyList.fromListUnsafe(newBranch))
+
+    Thread.sleep(200)
+    blockchain.getBestBlock().get shouldEqual oldBlock5WithCheckpoint
+    blockchain.getLatestCheckpointBlockNumber() shouldEqual oldBlock5WithCheckpoint.header.number
+  }
+
+  it should "return a correct checkpointed block after reorganising longer chain to a shorter one and back" in {
+
+    val chackpoint = ObjectGenerators.fakeCheckpointGen(3, 3).sample.get
+    val newBlock4WithCheckpoint: Block = checkpointBlockGenerator.generate(newBlock3, chackpoint)
+    blockchain.save(newBlock4WithCheckpoint, Nil, newWeight3, saveAsBestBlock = true)
+
+    val newBranch = List(newBlock4WithCheckpoint)
+
+    blockImporter ! BlockFetcher.PickedBlocks(NonEmptyList.fromListUnsafe(newBranch))
+
+    Thread.sleep(200)
+    blockchain.getBestBlock().get shouldEqual newBlock4WithCheckpoint
+    blockchain.getLatestCheckpointBlockNumber() shouldEqual newBlock4WithCheckpoint.header.number
+  }
+
+  it should "return a correct checkpointed block after receiving a new chackpoint from morpho" in {
+
+    val parent = blockchain.getBestBlock().get
+    val newBlock5: Block = getBlock(genesisBlock.number + 5, difficulty = 104, parent = parent.header.hash)
+    val newWeight5 = newWeight3.increase(newBlock5.header)
+
+    blockchain.save(newBlock5, Nil, newWeight5, saveAsBestBlock = true)
+
+    val signatures = CheckpointingTestHelpers.createCheckpointSignatures(
+      Seq(crypto.generateKeyPair(secureRandom)),
+      newBlock5.hash
+    )
+    blockImporter ! NewCheckpoint(newBlock5.hash, signatures)
+
+    val checkpointBlock = checkpointBlockGenerator.generate(newBlock5, Checkpoint(signatures))
+
+    Thread.sleep(1000)
+    blockchain.getBestBlock().get shouldEqual checkpointBlock
+    blockchain.getLatestCheckpointBlockNumber() shouldEqual newBlock5.header.number + 1
   }
 }

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/fast/FastSync.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/fast/FastSync.scala
@@ -823,8 +823,8 @@ class FastSync(
         val bestReceivedBlock = fullBlocks.maxBy(_.number)
         val lastStoredBestBlockNumber = appStateStorage.getBestBlockNumber()
         if (lastStoredBestBlockNumber < bestReceivedBlock.number) {
-          appStateStorage.putBestBlockNumber(bestReceivedBlock.number).commit()
           blockchain.saveBestKnownBlocks(bestReceivedBlock.number)
+          appStateStorage.putBestBlockNumber(bestReceivedBlock.number).commit()
         }
         syncState = syncState.copy(lastFullBlockNumber = bestReceivedBlock.number.max(lastStoredBestBlockNumber))
       }

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/fast/FastSync.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/fast/FastSync.scala
@@ -823,8 +823,8 @@ class FastSync(
         val bestReceivedBlock = fullBlocks.maxBy(_.number)
         val lastStoredBestBlockNumber = appStateStorage.getBestBlockNumber()
         if (lastStoredBestBlockNumber < bestReceivedBlock.number) {
-          blockchain.saveBestKnownBlocks(bestReceivedBlock.number)
           appStateStorage.putBestBlockNumber(bestReceivedBlock.number).commit()
+          blockchain.saveBestKnownBlocks(bestReceivedBlock.number)
         }
         syncState = syncState.copy(lastFullBlockNumber = bestReceivedBlock.number.max(lastStoredBestBlockNumber))
       }

--- a/src/main/scala/io/iohk/ethereum/domain/Blockchain.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/Blockchain.scala
@@ -341,12 +341,6 @@ class BlockchainImpl(
   }
 
   def save(block: Block, receipts: Seq[Receipt], weight: ChainWeight, saveAsBestBlock: Boolean): Unit = {
-    log.debug("Saving new block block {} to database", block.idTag)
-    storeBlock(block)
-      .and(storeReceipts(block.header.hash, receipts))
-      .and(storeChainWeight(block.header.hash, weight))
-      .commit()
-
     if (saveAsBestBlock && block.hasCheckpoint) {
       log.debug(
         "New best known block block number - {}, new best checkpoint number - {}",
@@ -361,6 +355,12 @@ class BlockchainImpl(
       )
       saveBestKnownBlock(block.header.number)
     }
+
+    log.debug("Saving new block block {} to database", block.idTag)
+    storeBlock(block)
+      .and(storeReceipts(block.header.hash, receipts))
+      .and(storeChainWeight(block.header.hash, weight))
+      .commit()
 
     // not transactional part
     // the best blocks data will be persisted only when the cache will be persisted
@@ -397,20 +397,17 @@ class BlockchainImpl(
     }
   }
 
-  private def saveBestKnownBlock(bestBlockNumber: BigInt): Unit = {
+  private def saveBestKnownBlock(bestBlockNumber: BigInt): Unit =
     bestKnownBlockAndLatestCheckpoint.updateAndGet(_.copy(bestBlockNumber = bestBlockNumber))
-  }
 
-  private def saveBestKnownBlockAndLatestCheckpointNumber(number: BigInt, latestCheckpointNumber: BigInt): Unit = {
+  private def saveBestKnownBlockAndLatestCheckpointNumber(number: BigInt, latestCheckpointNumber: BigInt): Unit =
     bestKnownBlockAndLatestCheckpoint.set(BestBlockLatestCheckpointNumbers(number, latestCheckpointNumber))
-  }
 
   def storeChainWeight(blockhash: ByteString, weight: ChainWeight): DataSourceBatchUpdate =
     chainWeightStorage.put(blockhash, weight)
 
-  def saveNode(nodeHash: NodeHash, nodeEncoded: NodeEncoded, blockNumber: BigInt): Unit = {
+  def saveNode(nodeHash: NodeHash, nodeEncoded: NodeEncoded, blockNumber: BigInt): Unit =
     stateStorage.saveNode(nodeHash, nodeEncoded, blockNumber)
-  }
 
   override protected def getHashByBlockNumber(number: BigInt): Option[ByteString] =
     blockNumberMappingStorage.get(number)

--- a/src/main/scala/io/iohk/ethereum/ledger/BlockExecution.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/BlockExecution.scala
@@ -60,8 +60,9 @@ class BlockExecution(
         .getBlockHeaderByHash(block.header.parentHash)
         .toRight(MissingParentError) // Should not never occur because validated earlier
       execResult <- executeBlockTransactions(block, parent)
-      worldToPersist <- Either.catchOnly[Throwable](blockPreparator.payBlockReward(block, execResult.worldState))
-      .leftMap(BlockExecutionError.MPTError.apply)
+      worldToPersist <- Either
+        .catchOnly[Throwable](blockPreparator.payBlockReward(block, execResult.worldState))
+        .leftMap(BlockExecutionError.MPTError.apply)
       // State root hash needs to be up-to-date for validateBlockAfterExecution
       worldPersisted = InMemoryWorldStateProxy.persistState(worldToPersist)
     } yield execResult.copy(worldState = worldPersisted)

--- a/src/main/scala/io/iohk/ethereum/ledger/BlockExecution.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/BlockExecution.scala
@@ -6,9 +6,7 @@ import io.iohk.ethereum.ledger.Ledger.BlockResult
 import io.iohk.ethereum.utils.{BlockchainConfig, DaoForkConfig, Logger}
 import io.iohk.ethereum.vm.EvmConfig
 import scala.annotation.tailrec
-import scala.util.Try
-import akka.util.ByteString
-import io.iohk.ethereum.mpt.MerklePatriciaTrie.MissingNodeException
+import cats.implicits._
 
 class BlockExecution(
     blockchain: BlockchainImpl,
@@ -62,9 +60,8 @@ class BlockExecution(
         .getBlockHeaderByHash(block.header.parentHash)
         .toRight(MissingParentError) // Should not never occur because validated earlier
       execResult <- executeBlockTransactions(block, parent)
-      worldToPersist <- Try {
-        blockPreparator.payBlockReward(block, execResult.worldState)
-      }.toEither.left.map(BlockExecutionError.MPTError(_))
+      worldToPersist <- Either.catchOnly[Throwable](blockPreparator.payBlockReward(block, execResult.worldState))
+      .leftMap(BlockExecutionError.MPTError.apply)
       // State root hash needs to be up-to-date for validateBlockAfterExecution
       worldPersisted = InMemoryWorldStateProxy.persistState(worldToPersist)
     } yield execResult.copy(worldState = worldPersisted)
@@ -174,21 +171,21 @@ sealed trait BlockExecutionError {
 
 sealed trait BlockExecutionSuccess
 
-case object BlockExecutionSuccess extends BlockExecutionSuccess
+final case object BlockExecutionSuccess extends BlockExecutionSuccess
 
 object BlockExecutionError {
-  case class ValidationBeforeExecError(reason: Any) extends BlockExecutionError
+  final case class ValidationBeforeExecError(reason: Any) extends BlockExecutionError
 
-  case class StateBeforeFailure(worldState: InMemoryWorldStateProxy, acumGas: BigInt, acumReceipts: Seq[Receipt])
+  final case class StateBeforeFailure(worldState: InMemoryWorldStateProxy, acumGas: BigInt, acumReceipts: Seq[Receipt])
 
-  case class TxsExecutionError(stx: SignedTransaction, stateBeforeError: StateBeforeFailure, reason: String)
+  final case class TxsExecutionError(stx: SignedTransaction, stateBeforeError: StateBeforeFailure, reason: String)
       extends BlockExecutionError
 
-  case class ValidationAfterExecError(reason: String) extends BlockExecutionError
+  final case class ValidationAfterExecError(reason: String) extends BlockExecutionError
 
-  case object MissingParentError extends BlockExecutionError {
+  final case object MissingParentError extends BlockExecutionError {
     override val reason: Any = "Cannot find parent"
   }
 
-  case class MPTError(reason: Throwable) extends BlockExecutionError
+  final case class MPTError(reason: Throwable) extends BlockExecutionError
 }

--- a/src/main/scala/io/iohk/ethereum/ledger/BlockValidation.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/BlockValidation.scala
@@ -43,13 +43,13 @@ class BlockValidation(consensus: Consensus, blockchain: Blockchain, blockQueue: 
 
   def validateBlockAfterExecution(
       block: Block,
-      hash: ByteString,
+      stateRootHash: ByteString,
       receipts: Seq[Receipt],
       gasUsed: BigInt
   ): Either[BlockExecutionError, BlockExecutionSuccess] = {
     consensus.validators.validateBlockAfterExecution(
       block = block,
-      stateRootHash = hash,
+      stateRootHash = stateRootHash,
       receipts = receipts,
       gasUsed = gasUsed
     )

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/ScenarioSetup.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/ScenarioSetup.scala
@@ -21,8 +21,8 @@ import scala.concurrent.ExecutionContext
   * [[io.iohk.ethereum.nodebuilder.Node Node]].
   */
 trait ScenarioSetup extends StdTestConsensusBuilder with SyncConfigBuilder with StdLedgerBuilder {
-  protected lazy val executionContext = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(4))
-  protected lazy val monixScheduler = Scheduler(executionContext)
+  protected lazy val executionContextExecutor = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(4))
+  protected lazy val monixScheduler = Scheduler(executionContextExecutor)
   protected lazy val successValidators: Validators = Mocks.MockValidatorsAlwaysSucceed
   protected lazy val failureValidators: Validators = Mocks.MockValidatorsAlwaysFail
   protected lazy val ethashValidators: ValidatorsExecutor = ValidatorsExecutor(blockchainConfig, Protocol.Ethash)

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/regular/BlockFetcherSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/regular/BlockFetcherSpec.scala
@@ -102,7 +102,7 @@ class BlockFetcherSpec
       peersClient.expectMsgPF() { case PeersClient.Request(msg, _, _) if msg == firstGetBlockHeadersRequest => () }
     }
 
-    "should not enqueue requested blocks if the received bodies does not match" in new TestSetup {
+    "should not enqueue requested blocks if the received bodies do not match" in new TestSetup {
 
       // Important: Here we are forcing the mismatch between request headers and received bodies
       override lazy val validators = new MockValidatorsFailingOnBlockBodies

--- a/src/test/scala/io/iohk/ethereum/db/dataSource/DataSourceTestBehavior.scala
+++ b/src/test/scala/io/iohk/ethereum/db/dataSource/DataSourceTestBehavior.scala
@@ -2,9 +2,9 @@ package io.iohk.ethereum.db.dataSource
 
 import java.io.File
 import java.nio.file.Files
-
 import io.iohk.ethereum.ObjectGenerators
 import io.iohk.ethereum.db.dataSource.DataSource.{Key, Namespace, Value}
+import io.iohk.ethereum.db.dataSource.RocksDbDataSource.RocksDbDataSourceClosedException
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
@@ -45,6 +45,15 @@ trait DataSourceTestBehavior extends ScalaCheckPropertyChecks with ObjectGenerat
         }
 
         dataSource.destroy()
+      }
+    }
+
+    it should "throw an exception if the rocksdb storage is unavailable" in {
+      withDir { path =>
+        val dataSource = createDataSource(path)
+        val someByteString = byteStringOfLengthNGen(KeySizeWithoutPrefix).sample.get
+        dataSource.destroy()
+        assertThrows[RocksDbDataSourceClosedException](dataSource.update(prepareUpdate(toUpsert = Seq(someByteString -> someByteString))))
       }
     }
 
@@ -111,5 +120,4 @@ trait DataSourceTestBehavior extends ScalaCheckPropertyChecks with ObjectGenerat
     }
   }
   // scalastyle:on
-
 }

--- a/src/test/scala/io/iohk/ethereum/ledger/BlockImportSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/BlockImportSpec.scala
@@ -146,6 +146,57 @@ class BlockImportSpec extends AnyFlatSpec with Matchers with ScalaFutures {
     blockQueue.isQueued(oldBlock3.header.hash) shouldBe true
   }
 
+  it should "fail to get bestblock after reorganisation of the longer chain to a shorter one if desync state happened between cache and db" in new EphemBlockchain {
+    val block1: Block = getBlock(bestNum - 2)
+    // new chain is shorter but has a higher weight
+    val newBlock2: Block = getBlock(bestNum - 1, difficulty = 101, parent = block1.header.hash)
+    val newBlock3: Block = getBlock(bestNum, difficulty = 333, parent = newBlock2.header.hash)
+    val oldBlock2: Block = getBlock(bestNum - 1, difficulty = 102, parent = block1.header.hash)
+    val oldBlock3: Block = getBlock(bestNum, difficulty = 103, parent = oldBlock2.header.hash)
+    val oldBlock4: Block = getBlock(bestNum + 1, difficulty = 104, parent = oldBlock3.header.hash)
+
+    val weight1 = ChainWeight.totalDifficultyOnly(block1.header.difficulty + 999)
+    val newWeight2 = weight1.increase(newBlock2.header)
+    val newWeight3 = newWeight2.increase(newBlock3.header)
+    val oldWeight2 = weight1.increase(oldBlock2.header)
+    val oldWeight3 = oldWeight2.increase(oldBlock3.header)
+    val oldWeight4 = oldWeight3.increase(oldBlock4.header)
+
+    blockchain.save(block1, Nil, weight1, saveAsBestBlock = true)
+    blockchain.save(oldBlock2, receipts, oldWeight2, saveAsBestBlock = true)
+    blockchain.save(oldBlock3, Nil, oldWeight3, saveAsBestBlock = true)
+    blockchain.save(oldBlock4, Nil, oldWeight4, saveAsBestBlock = true)
+
+    val ancestorForValidation: Block = getBlock(0, difficulty = 1)
+    blockchain.save(ancestorForValidation, Nil, ChainWeight.totalDifficultyOnly(1), saveAsBestBlock = false)
+
+    val oldBranch = List(oldBlock2, oldBlock3, oldBlock4)
+    val newBranch = List(newBlock2, newBlock3)
+    val blockData2 = BlockData(newBlock2, Seq.empty[Receipt], newWeight2)
+    val blockData3 = BlockData(newBlock3, Seq.empty[Receipt], newWeight3)
+
+    (ledgerWithMockedBlockExecution.blockExecution.executeAndValidateBlocks _)
+      .expects(newBranch, *)
+      .returning((List(blockData2, blockData3), None))
+
+    whenReady(ledgerWithMockedBlockExecution.importBlock(newBlock3).runToFuture) { _ shouldEqual BlockEnqueued }
+    whenReady(ledgerWithMockedBlockExecution.importBlock(newBlock2).runToFuture) { result =>
+      result shouldEqual ChainReorganised(oldBranch, newBranch, List(newWeight2, newWeight3))
+    }
+
+    // Saving new blocks, because it's part of executeBlocks method mechanism
+    blockchain.save(blockData2.block, blockData2.receipts, blockData2.weight, saveAsBestBlock = true)
+    blockchain.save(blockData3.block, blockData3.receipts, blockData3.weight, saveAsBestBlock = true)
+
+    //saving to cache the value of the best block from the initial chain. This recreates the bug ETCM-626, where (possiby) because of the thread of execution
+    // dying before updating the storage but after updating the cache, inconsistency is created
+    blockchain.saveBestKnownBlocks(oldBlock4.number)
+
+    assertThrows[NoSuchElementException] {
+      blockchain.getBestBlock()
+    }
+  }
+
   it should "handle error when trying to reorganise chain" in new EphemBlockchain {
     val block1: Block = getBlock(bestNum - 2)
     val newBlock2: Block = getBlock(bestNum - 1, difficulty = 101, parent = block1.header.hash)
@@ -166,11 +217,8 @@ class BlockImportSpec extends AnyFlatSpec with Matchers with ScalaFutures {
     val ancestorForValidation: Block = getBlock(0, difficulty = 1)
     blockchain.save(ancestorForValidation, Nil, ChainWeight.totalDifficultyOnly(1), saveAsBestBlock = false)
 
-    //FIXME: unused vals???
-    val oldBranch = List(oldBlock2, oldBlock3)
     val newBranch = List(newBlock2, newBlock3)
     val blockData2 = BlockData(newBlock2, Seq.empty[Receipt], newWeight2)
-    val blockData3 = BlockData(newBlock3, Seq.empty[Receipt], newWeight3)
 
     (ledgerWithMockedBlockExecution.blockExecution.executeAndValidateBlocks _)
       .expects(newBranch, *)

--- a/src/test/scala/io/iohk/ethereum/ledger/BlockImportSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/BlockImportSpec.scala
@@ -188,13 +188,11 @@ class BlockImportSpec extends AnyFlatSpec with Matchers with ScalaFutures {
     blockchain.save(blockData2.block, blockData2.receipts, blockData2.weight, saveAsBestBlock = true)
     blockchain.save(blockData3.block, blockData3.receipts, blockData3.weight, saveAsBestBlock = true)
 
-    //saving to cache the value of the best block from the initial chain. This recreates the bug ETCM-626, where (possiby) because of the thread of execution
+    //saving to cache the value of the best block from the initial chain. This recreates the bug ETCM-626, where (possibly) because of the thread of execution
     // dying before updating the storage but after updating the cache, inconsistency is created
     blockchain.saveBestKnownBlocks(oldBlock4.number)
 
-    assertThrows[NoSuchElementException] {
-      blockchain.getBestBlock()
-    }
+    blockchain.getBestBlock() shouldBe None
   }
 
   it should "handle error when trying to reorganise chain" in new EphemBlockchain {


### PR DESCRIPTION
# Description

None.get on bestBlock happened because of the inconsistency between cache and db. This PR introduces uni and integration tests that try to reproduce the issue. In case of it test - it's not possible to reproduce as probable cause is the thread of execution dying in the middle of updates.

Also updating one method with preferred order of execution - first saving to cache, after to db.

