### PR TITLE
[ETCM-689] Update state sync and pivot block selector to use new blacklist

### DIFF
--- a/src/it/scala/io/iohk/ethereum/ledger/BlockImporterItSpec.scala
+++ b/src/it/scala/io/iohk/ethereum/ledger/BlockImporterItSpec.scala
@@ -21,7 +21,12 @@ import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.duration._
 
-class BlockImporterItSpec extends MockFactory with TestSetupWithVmAndValidators with AsyncFlatSpecLike with Matchers with BeforeAndAfterAll {
+class BlockImporterItSpec
+    extends MockFactory
+    with TestSetupWithVmAndValidators
+    with AsyncFlatSpecLike
+    with Matchers
+    with BeforeAndAfterAll {
 
   implicit val testScheduler = Scheduler.fixedPool("test", 32)
 
@@ -57,11 +62,15 @@ class BlockImporterItSpec extends MockFactory with TestSetupWithVmAndValidators 
       ethCompatibleStorage = true
     )
 
-  override lazy val ledger = new TestLedgerImpl(successValidators)  {
-    override private[ledger] lazy val blockExecution = new BlockExecution(blockchain, blockchainConfig, consensus.blockPreparator, blockValidation) {
-      override def executeAndValidateBlock(block: Block, alreadyValidated: Boolean = false): Either[BlockExecutionError, Seq[Receipt]] =
-        Right(BlockResult(emptyWorld).receipts)
-    }
+  override lazy val ledger = new TestLedgerImpl(successValidators) {
+    override private[ledger] lazy val blockExecution =
+      new BlockExecution(blockchain, blockchainConfig, consensus.blockPreparator, blockValidation) {
+        override def executeAndValidateBlock(
+            block: Block,
+            alreadyValidated: Boolean = false
+        ): Either[BlockExecutionError, Seq[Receipt]] =
+          Right(BlockResult(emptyWorld).receipts)
+      }
   }
 
   val blockImporter = system.actorOf(
@@ -75,7 +84,8 @@ class BlockImporterItSpec extends MockFactory with TestSetupWithVmAndValidators 
       pendingTransactionsManagerProbe.ref,
       checkpointBlockGenerator,
       supervisor.ref
-    ))
+    )
+  )
 
   val genesisBlock = blockchain.genesisBlock
   val block1: Block = getBlock(genesisBlock.number + 1, parent = genesisBlock.header.hash)
@@ -119,7 +129,8 @@ class BlockImporterItSpec extends MockFactory with TestSetupWithVmAndValidators 
         pendingTransactionsManagerProbe.ref,
         checkpointBlockGenerator,
         supervisor.ref
-      ))
+      )
+    )
 
     blockImporter ! BlockImporter.Start
     blockImporter ! BlockFetcher.PickedBlocks(NonEmptyList.fromListUnsafe(newBranch))
@@ -141,7 +152,6 @@ class BlockImporterItSpec extends MockFactory with TestSetupWithVmAndValidators 
     Thread.sleep(200)
     blockchain.getBestBlock().get shouldEqual newBlock3
   }
-
 
   it should "switch to a branch with a checkpoint" in {
 

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/Blacklist.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/Blacklist.scala
@@ -77,6 +77,10 @@ object Blacklist {
         val code: Int = 9
         val name: String = "PeerActorTerminated"
       }
+      case object InvalidStateResponseType extends BlacklistReasonType {
+        val code: Int = 10
+        val name: String = "InvalidStateResponse"
+      }
     }
 
     case object WrongBlockHeaders extends BlacklistReason {
@@ -113,6 +117,10 @@ object Blacklist {
     }
     case object PeerActorTerminated extends BlacklistReason {
       val reasonType: BlacklistReasonType = PeerActorTerminatedType
+      val description: String = "Peer actor terminated"
+    }
+    final case class InvalidStateResponse(details: String) extends BlacklistReason {
+      val reasonType: BlacklistReasonType = InvalidStateResponseType
       val description: String = "Peer actor terminated"
     }
   }

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/Blacklist.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/Blacklist.scala
@@ -81,6 +81,14 @@ object Blacklist {
         val code: Int = 10
         val name: String = "InvalidStateResponse"
       }
+      case object InvalidPivotBlockElectionResponseType extends BlacklistReasonType {
+        val code: Int = 11
+        val name: String = "InvalidPivotElectionResponse"
+      }
+      case object PivotBlockElectionTimeoutType extends BlacklistReasonType {
+        val code: Int = 12
+        val name: String = "PivotBlockElectionTimeout"
+      }
     }
 
     case object WrongBlockHeaders extends BlacklistReason {
@@ -121,7 +129,15 @@ object Blacklist {
     }
     final case class InvalidStateResponse(details: String) extends BlacklistReason {
       val reasonType: BlacklistReasonType = InvalidStateResponseType
-      val description: String = "Peer actor terminated"
+      val description: String = s"Invalid response while syncing state trie: $details"
+    }
+    case object InvalidPivotBlockElectionResponse extends BlacklistReason {
+      val reasonType: BlacklistReasonType = InvalidStateResponseType
+      val description: String = "Invalid response while selecting pivot block"
+    }
+    case object PivotBlockElectionTimeout extends BlacklistReason {
+      val reasonType: BlacklistReasonType = InvalidStateResponseType
+      val description: String = "Peer didn't respond with requested pivot block candidate in a timely manner"
     }
   }
 }

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/SyncController.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/SyncController.scala
@@ -21,13 +21,11 @@ class SyncController(
     checkpointBlockGenerator: CheckpointBlockGenerator,
     ommersPool: ActorRef,
     etcPeerManager: ActorRef,
+    blacklist: Blacklist,
     syncConfig: SyncConfig,
     externalSchedulerOpt: Option[Scheduler] = None
 ) extends Actor
     with ActorLogging {
-
-  private val blacklistSize: Int = 1000 // TODO ETCM-642 move to config
-  private val blacklist: Blacklist = CacheBasedBlacklist.empty(blacklistSize)
 
   def scheduler: Scheduler = externalSchedulerOpt getOrElse context.system.scheduler
 
@@ -132,6 +130,7 @@ object SyncController {
       checkpointBlockGenerator: CheckpointBlockGenerator,
       ommersPool: ActorRef,
       etcPeerManager: ActorRef,
+      blacklist: Blacklist,
       syncConfig: SyncConfig
   ): Props =
     Props(
@@ -146,6 +145,7 @@ object SyncController {
         checkpointBlockGenerator,
         ommersPool,
         etcPeerManager,
+        blacklist,
         syncConfig
       )
     )

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/fast/FastSync.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/fast/FastSync.scala
@@ -83,7 +83,7 @@ class FastSync(
   def startFromScratch(): Unit = {
     log.info("Starting fast sync from scratch")
     val pivotBlockSelector = context.actorOf(
-      PivotBlockSelector.props(etcPeerManager, peerEventBus, syncConfig, scheduler, context.self),
+      PivotBlockSelector.props(etcPeerManager, peerEventBus, syncConfig, scheduler, context.self, blacklist),
       "pivot-block-selector"
     )
     pivotBlockSelector ! PivotBlockSelector.SelectPivotBlock
@@ -219,7 +219,7 @@ class FastSync(
       log.info("Asking for new pivot block")
       val pivotBlockSelector = {
         context.actorOf(
-          PivotBlockSelector.props(etcPeerManager, peerEventBus, syncConfig, scheduler, context.self)
+          PivotBlockSelector.props(etcPeerManager, peerEventBus, syncConfig, scheduler, context.self, blacklist)
         )
       }
       pivotBlockSelector ! PivotBlockSelector.SelectPivotBlock

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/fast/FastSync.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/fast/FastSync.scala
@@ -138,6 +138,7 @@ class FastSync(
           syncConfig,
           etcPeerManager,
           peerEventBus,
+          blacklist,
           scheduler
         ),
       "state-scheduler"

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/fast/PivotBlockSelector.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/fast/PivotBlockSelector.scala
@@ -45,7 +45,7 @@ class PivotBlockSelector(
       val (peersToAsk, waitingPeers) = correctPeers.splitAt(minPeersToChoosePivotBlock + peersToChoosePivotBlockMargin)
 
       log.info(
-        "Trying to choose fast sync pivot block using {} peers ({} correct ones). Ask {} peers for block nr {}",
+        "Trying to choose fast sync pivot block using {} peers ({} ones with high enough block). Ask {} peers for block nr {}",
         peersToDownloadFrom.size,
         correctPeers.size,
         peersToAsk.size,

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/PivotBlockSelectorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/PivotBlockSelectorSpec.scala
@@ -420,6 +420,8 @@ class PivotBlockSelectorSpec
 
   class TestSetup extends TestSyncConfig {
 
+    val blacklist: Blacklist = CacheBasedBlacklist.empty(100)
+
     private def isNewBlock(msg: Message): Boolean = msg match {
       case _: NewBlock => true
       case _ => false
@@ -467,7 +469,8 @@ class PivotBlockSelectorSpec
         peerMessageBus.ref,
         defaultSyncConfig,
         time.scheduler,
-        fastSync.ref
+        fastSync.ref,
+        blacklist
       )
     )
 

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/StateSyncSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/StateSyncSpec.scala
@@ -171,12 +171,11 @@ class StateSyncSpec
       )
     }.toMap
 
+    val blacklist: Blacklist = CacheBasedBlacklist.empty(100)
+
     sealed trait PeerAction
-
     case object FullResponse extends PeerAction
-
     case object PartialResponse extends PeerAction
-
     case object NoResponse extends PeerAction
 
     val defaultPeerConfig: PeerConfig = peersMap.map { case (peer, _) =>
@@ -264,6 +263,7 @@ class StateSyncSpec
         syncConfig,
         etcPeerManager.ref,
         peerEventBus.ref,
+        blacklist,
         system.scheduler
       )
     )

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/SyncControllerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/SyncControllerSpec.scala
@@ -2,15 +2,15 @@ package io.iohk.ethereum.blockchain.sync
 
 import akka.actor.{ActorRef, ActorSystem, Props}
 import akka.testkit.TestActor.AutoPilot
-import akka.testkit.{TestActorRef, TestProbe}
+import akka.testkit.{ExplicitlyTriggeredScheduler, TestActorRef, TestProbe}
 import akka.util.ByteString
-import io.iohk.ethereum.blockchain.sync.fast.FastSync
+import com.typesafe.config.ConfigFactory
 import io.iohk.ethereum.blockchain.sync.fast.FastSync.SyncState
 import io.iohk.ethereum.consensus.TestConsensus
 import io.iohk.ethereum.consensus.blocks.CheckpointBlockGenerator
 import io.iohk.ethereum.consensus.validators.BlockHeaderError.HeaderPoWError
 import io.iohk.ethereum.consensus.validators.{BlockHeaderValid, BlockHeaderValidator, Validators}
-import io.iohk.ethereum.domain.{Account, BlockBody, BlockHeader, ChainWeight, Receipt}
+import io.iohk.ethereum.domain._
 import io.iohk.ethereum.ledger.Ledger
 import io.iohk.ethereum.ledger.Ledger.VMImpl
 import io.iohk.ethereum.network.EtcPeerManagerActor
@@ -23,21 +23,16 @@ import io.iohk.ethereum.network.p2p.messages.PV63.GetNodeData.GetNodeDataEnc
 import io.iohk.ethereum.network.p2p.messages.PV63.GetReceipts.GetReceiptsEnc
 import io.iohk.ethereum.network.p2p.messages.PV63.{NodeData, Receipts}
 import io.iohk.ethereum.utils.Config.SyncConfig
-import io.iohk.ethereum.{Fixtures, Mocks}
+import io.iohk.ethereum.{Fixtures, Mocks, NormalPatience}
 import org.bouncycastle.util.encoders.Hex
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.BeforeAndAfter
 import org.scalatest.concurrent.Eventually
-import org.scalatest.concurrent.PatienceConfiguration.Timeout
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import org.scalatest.time.{Seconds, Span}
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
-import com.typesafe.config.ConfigFactory
-import akka.testkit.ExplicitlyTriggeredScheduler
-import io.iohk.ethereum.NormalPatience
 
 // scalastyle:off file.size.limit
 class SyncControllerSpec

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/SyncControllerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/SyncControllerSpec.scala
@@ -224,7 +224,7 @@ class SyncControllerSpec
   }
 
   it should "update pivot block if pivot fail" in withTestSetup(new Mocks.MockValidatorsAlwaysSucceed {
-    override val blockHeaderValidator: BlockHeaderValidator = { (blockHeader, getBlockHeaderByHash) =>
+    override val blockHeaderValidator: BlockHeaderValidator = { (blockHeader, _) =>
       {
         if (blockHeader.number != 399500 + 10) {
           Right(BlockHeaderValid)
@@ -239,11 +239,11 @@ class SyncControllerSpec
 
     syncController ! SyncProtocol.Start
 
-    val handshakedPeers = HandshakedPeers(singlePeer)
+    val handshakedPeers = HandshakedPeers(twoAcceptedPeers)
 
     val newPivot = defaultPivotBlockHeader.copy(number = defaultPivotBlockHeader.number + 20)
     val peerWithNewPivot = defaultPeer1Info.copy(maxBlockNumber = bestBlock + 20)
-    val newHanshaked = HandshakedPeers(Map(peer1 -> peerWithNewPivot))
+    val newHandshaked = HandshakedPeers(Map(peer2 -> peerWithNewPivot))
 
     val newBest = 399500 + 9
 
@@ -257,7 +257,7 @@ class SyncControllerSpec
       storagesInstance.storages.fastSyncStateStorage.getSyncState().get.pivotBlock shouldBe defaultPivotBlockHeader
     }
 
-    autopilot.updateAutoPilot(newHanshaked, newPivot, BlockchainData(newBlocks))
+    autopilot.updateAutoPilot(newHandshaked, newPivot, BlockchainData(newBlocks))
 
     val watcher = TestProbe()
     watcher.watch(syncController)

--- a/src/test/scala/io/iohk/ethereum/db/dataSource/DataSourceTestBehavior.scala
+++ b/src/test/scala/io/iohk/ethereum/db/dataSource/DataSourceTestBehavior.scala
@@ -53,7 +53,9 @@ trait DataSourceTestBehavior extends ScalaCheckPropertyChecks with ObjectGenerat
         val dataSource = createDataSource(path)
         val someByteString = byteStringOfLengthNGen(KeySizeWithoutPrefix).sample.get
         dataSource.destroy()
-        assertThrows[RocksDbDataSourceClosedException](dataSource.update(prepareUpdate(toUpsert = Seq(someByteString -> someByteString))))
+        assertThrows[RocksDbDataSourceClosedException](
+          dataSource.update(prepareUpdate(toUpsert = Seq(someByteString -> someByteString)))
+        )
       }
     }
 


### PR DESCRIPTION
# Description

Updates all remaining fast-sync components to use the new cache-based blacklist.

# Testing

* since the blacklist is now shared between fast-sync and pivot block selector, one test had to be updated because otherwise `peer1` wouldn't be considered for pivot block selection because it had previously sent us an invalid response

