### PR TITLE
[ETCM-594] Improve peer discovery algorithm

### DIFF
--- a/src/it/scala/io/iohk/ethereum/sync/util/CommonFakePeer.scala
+++ b/src/it/scala/io/iohk/ethereum/sync/util/CommonFakePeer.scala
@@ -24,7 +24,15 @@ import io.iohk.ethereum.network.p2p.Message.Version
 import io.iohk.ethereum.network.p2p.messages.ProtocolNegotiator
 import io.iohk.ethereum.network.rlpx.AuthHandshaker
 import io.iohk.ethereum.network.rlpx.RLPxConnectionHandler.RLPxConfiguration
-import io.iohk.ethereum.network.{EtcPeerManagerActor, ForkResolver, KnownNodesManager, PeerEventBusActor, PeerManagerActor, PeerStatisticsActor, ServerActor}
+import io.iohk.ethereum.network.{
+  EtcPeerManagerActor,
+  ForkResolver,
+  KnownNodesManager,
+  PeerEventBusActor,
+  PeerManagerActor,
+  PeerStatisticsActor,
+  ServerActor
+}
 import io.iohk.ethereum.nodebuilder.PruningConfigBuilder
 import io.iohk.ethereum.security.SecureRandomBuilder
 import io.iohk.ethereum.sync.util.SyncCommonItSpec._

--- a/src/main/scala/io/iohk/ethereum/network/discovery/PeerDiscoveryManager.scala
+++ b/src/main/scala/io/iohk/ethereum/network/discovery/PeerDiscoveryManager.scala
@@ -190,7 +190,6 @@ class PeerDiscoveryManager(
 
     maybeDiscoveredNodes
       .map(_ ++ alreadyDiscoveredNodes)
-      .map(_.filterNot(isLocalNode))
       .map(DiscoveredNodesInfo(_))
   }
 

--- a/src/test/scala/io/iohk/ethereum/network/handshaker/EtcHandshakerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/network/handshaker/EtcHandshakerSpec.scala
@@ -269,7 +269,8 @@ class EtcHandshakerSpec extends AnyFlatSpec with Matchers {
     )
     lazy val nodeStatusHolder = new AtomicReference(nodeStatus)
 
-    class MockEtcHandshakerConfiguration(pv: Int = Config.blockchains.blockchainConfig.protocolVersion) extends EtcHandshakerConfiguration {
+    class MockEtcHandshakerConfiguration(pv: Int = Config.blockchains.blockchainConfig.protocolVersion)
+        extends EtcHandshakerConfiguration {
       override val forkResolverOpt: Option[ForkResolver] = None
       override val nodeStatusHolder: AtomicReference[NodeStatus] = TestSetup.this.nodeStatusHolder
       override val peerConfiguration: PeerConfiguration = Config.Network.peer


### PR DESCRIPTION
# Description
Improves peer discovery algorithm by triggering the discovery of new nodes only after finishing processing the current list of new known nodes

# Proposed Solution
Instead of having a fixed and recurrent schedule triggering the discovery of new nodes, the discovery is triggered at specific moments:
- If no bootstrap / saved nodes are found
- If no new discovery nodes are found
- After processing all current new discovery nodes