### PR TITLE
etcm-678 etcm-660 fix for removing chain after the node restart

### DIFF
--- a/src/it/scala/io/iohk/ethereum/ledger/BlockImporterItSpec.scala
+++ b/src/it/scala/io/iohk/ethereum/ledger/BlockImporterItSpec.scala
@@ -168,7 +168,7 @@ class BlockImporterItSpec
     blockchain.getBestBlock().get shouldEqual newBlock3
   }
 
-  it should "return Unknown branch, don't start reorganisation(therefore no block/ommer validation) in case of PickedBlocks with block that has a parent who is not present in the chain(or ommer not in  chain)" in {
+  it should "return Unknown branch, in case of PickedBlocks with block that has a parent that's not in the chain" in {
     val newcomerBlock4: Block =
       getBlock(genesisBlock.number + 4, difficulty = 104, parent = oldBlock3.header.hash)
     val newcomerWeight4Duplicate = oldWeight3.increase(newcomerBlock4.header)

--- a/src/main/scala/io/iohk/ethereum/domain/Blockchain.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/Blockchain.scala
@@ -215,6 +215,19 @@ trait Blockchain {
   def getStateStorage: StateStorage
 
   def mptStateSavedKeys(): Observable[Either[IterationError, ByteString]]
+
+  /**
+    * Strict check if given block hash is in chain
+    * Using any of getXXXByHash is not always accurate - after restart the best block is often lower than before restart
+    * The result of that is returning data of blocks which we don't consider as a part of the chain anymore
+    * @param hash block hash
+    */
+  def isInChain(hash: ByteString): Boolean = {
+    (for {
+      header <- getBlockHeaderByHash(hash) if header.number <= getBestBlockNumber()
+      hash <- getHashByBlockNumber(header.number)
+    } yield header.hash == hash).getOrElse(false)
+  }
 }
 // scalastyle:on
 

--- a/src/main/scala/io/iohk/ethereum/ledger/BranchResolution.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/BranchResolution.scala
@@ -11,8 +11,7 @@ class BranchResolution(blockchain: Blockchain) extends Logger {
       InvalidBranch
     } else {
       val knownParentOrGenesis = blockchain
-        .getBlockHeaderByHash(headers.head.parentHash)
-        .isDefined || headers.head.hash == blockchain.genesisHeader.hash
+        .isInChain(headers.head.parentHash) || headers.head.hash == blockchain.genesisHeader.hash
 
       if (!knownParentOrGenesis)
         UnknownBranch

--- a/src/test/scala/io/iohk/ethereum/domain/BlockchainSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/domain/BlockchainSpec.scala
@@ -44,6 +44,15 @@ class BlockchainSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyCh
     assert(validBlock == block.get)
   }
 
+  it should "be able to do strict check of block existence in the chain" in new EphemBlockchainTestSetup {
+    val validBlock = Fixtures.Blocks.ValidBlock.block
+    blockchain.save(validBlock, Seq.empty, ChainWeight(100, 100), saveAsBestBlock = true)
+    assert(blockchain.isInChain(validBlock.hash))
+    // simulation of node restart
+    blockchain.saveBestKnownBlocks(validBlock.header.number - 1)
+    assert(!blockchain.isInChain(validBlock.hash))
+  }
+
   it should "be able to query a stored blockHeader by it's number" in new EphemBlockchainTestSetup {
     val validHeader = Fixtures.Blocks.ValidBlock.header
     blockchain.storeBlockHeader(validHeader).commit()

--- a/src/test/scala/io/iohk/ethereum/domain/BlockchainSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/domain/BlockchainSpec.scala
@@ -26,44 +26,44 @@ class BlockchainSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyCh
     val validBlock = Fixtures.Blocks.ValidBlock.block
     blockchain.storeBlock(validBlock).commit()
     val block = blockchain.getBlockByHash(validBlock.header.hash)
-    assert(block.isDefined)
-    assert(validBlock == block.get)
+    block.isDefined should ===(true)
+    validBlock should ===(block.get)
     val blockHeader = blockchain.getBlockHeaderByHash(validBlock.header.hash)
-    assert(blockHeader.isDefined)
-    assert(validBlock.header == blockHeader.get)
+    blockHeader.isDefined should ===(true)
+    validBlock.header should ===(blockHeader.get)
     val blockBody = blockchain.getBlockBodyByHash(validBlock.header.hash)
-    assert(blockBody.isDefined)
-    assert(validBlock.body == blockBody.get)
+    blockBody.isDefined should ===(true)
+    validBlock.body should ===(blockBody.get)
   }
 
   it should "be able to store a block and retrieve it by number" in new EphemBlockchainTestSetup {
     val validBlock = Fixtures.Blocks.ValidBlock.block
     blockchain.storeBlock(validBlock).commit()
     val block = blockchain.getBlockByNumber(validBlock.header.number)
-    assert(block.isDefined)
-    assert(validBlock == block.get)
+    block.isDefined should ===(true)
+    validBlock should ===(block.get)
   }
 
   it should "be able to do strict check of block existence in the chain" in new EphemBlockchainTestSetup {
     val validBlock = Fixtures.Blocks.ValidBlock.block
     blockchain.save(validBlock, Seq.empty, ChainWeight(100, 100), saveAsBestBlock = true)
-    assert(blockchain.isInChain(validBlock.hash))
+    blockchain.isInChain(validBlock.hash) === (false)
     // simulation of node restart
     blockchain.saveBestKnownBlocks(validBlock.header.number - 1)
-    assert(!blockchain.isInChain(validBlock.hash))
+    blockchain.isInChain(validBlock.hash) should ===(false)
   }
 
   it should "be able to query a stored blockHeader by it's number" in new EphemBlockchainTestSetup {
     val validHeader = Fixtures.Blocks.ValidBlock.header
     blockchain.storeBlockHeader(validHeader).commit()
     val header = blockchain.getBlockHeaderByNumber(validHeader.number)
-    assert(header.isDefined)
-    assert(validHeader == header.get)
+    header.isDefined should ===(true)
+    validHeader should ===(header.get)
   }
 
   it should "not return a value if not stored" in new EphemBlockchainTestSetup {
-    assert(blockchain.getBlockByNumber(Fixtures.Blocks.ValidBlock.header.number).isEmpty)
-    assert(blockchain.getBlockByHash(Fixtures.Blocks.ValidBlock.header.hash).isEmpty)
+    blockchain.getBlockByNumber(Fixtures.Blocks.ValidBlock.header.number).isEmpty should ===(true)
+    blockchain.getBlockByHash(Fixtures.Blocks.ValidBlock.header.hash).isEmpty should ===(true)
   }
 
   it should "be able to store a block with checkpoint and retrieve it and checkpoint" in new EphemBlockchainTestSetup {
@@ -75,8 +75,8 @@ class BlockchainSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyCh
     blockchain.save(validBlock, Seq.empty, ChainWeight(0, 0), saveAsBestBlock = true)
 
     val retrievedBlock = blockchain.getBlockByHash(validBlock.header.hash)
-    assert(retrievedBlock.isDefined)
-    assert(validBlock == retrievedBlock.get)
+    retrievedBlock.isDefined should ===(true)
+    validBlock should ===(retrievedBlock.get)
 
     blockchain.getLatestCheckpointBlockNumber() should ===(validBlock.number)
     blockchain.getBestBlockNumber() should ===(validBlock.number)

--- a/src/test/scala/io/iohk/ethereum/ledger/LedgerTestSetup.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/LedgerTestSetup.scala
@@ -400,16 +400,14 @@ trait MockBlockchain extends MockFactory { self: TestSetupWithVmAndValidators =>
       .once()
   }
 
-  def setHeaderInChain(hash: ByteString, result: Boolean = true): CallHandler1[ByteString, Boolean] = {
+  def setHeaderInChain(hash: ByteString, result: Boolean = true): CallHandler1[ByteString, Boolean] =
     (blockchain.isInChain _).expects(hash).returning(result)
-  }
 
   def setBlockByNumber(number: BigInt, block: Option[Block]): CallHandler1[BigInt, Option[Block]] =
     (blockchain.getBlockByNumber _).expects(number).returning(block)
 
-  def setGenesisHeader(header: BlockHeader): Unit = {
+  def setGenesisHeader(header: BlockHeader): Unit =
     (() => blockchain.genesisHeader).expects().returning(header)
-  }
 }
 
 trait EphemBlockchain extends TestSetupWithVmAndValidators with MockFactory {

--- a/src/test/scala/io/iohk/ethereum/ledger/LedgerTestSetup.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/LedgerTestSetup.scala
@@ -400,15 +400,15 @@ trait MockBlockchain extends MockFactory { self: TestSetupWithVmAndValidators =>
       .once()
   }
 
-  def setHeaderByHash(hash: ByteString, header: Option[BlockHeader]): CallHandler1[ByteString, Option[BlockHeader]] =
-    (blockchain.getBlockHeaderByHash _).expects(hash).returning(header)
+  def setHeaderInChain(hash: ByteString, result: Boolean = true): CallHandler1[ByteString, Boolean] = {
+    (blockchain.isInChain _).expects(hash).returning(result)
+  }
 
   def setBlockByNumber(number: BigInt, block: Option[Block]): CallHandler1[BigInt, Option[Block]] =
     (blockchain.getBlockByNumber _).expects(number).returning(block)
 
   def setGenesisHeader(header: BlockHeader): Unit = {
     (() => blockchain.genesisHeader).expects().returning(header)
-    setHeaderByHash(header.parentHash, None)
   }
 }
 


### PR DESCRIPTION
# Description
Adding check validating if the block exists in chain - Using any of getXXXByHash is not always accurate - after restart the best block is often lower than before restart. This change is trying to resolve the branch and checking the existence of the block when trying to import blocks



