### PR TITLE
[bugfix] Fixes a bug that caused miners to assume new epoch too early

### DIFF
--- a/src/main/scala/io/iohk/ethereum/consensus/ethash/EthashMiner.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/ethash/EthashMiner.scala
@@ -62,7 +62,7 @@ class EthashMiner(
           .getBlockForMining(blockValue)
           .map {
             case PendingBlockAndState(PendingBlock(block, _), _) => {
-              val blockNumber = block.header.number.toLong + 1
+              val blockNumber = block.header.number.toLong
               val epoch = EthashUtils.epoch(blockNumber, blockCreator.blockchainConfig.ecip1099BlockNumber.toLong)
               val (dag, dagSize) = calculateDagSize(blockNumber, epoch)
               val headerHash = crypto.kec256(BlockHeader.getEncodedWithoutNonce(block.header))


### PR DESCRIPTION
# Description

A recent refactoring introduced a small but critical bug in `EthashMiner` that caused miners to assume a new epoch one block too early and as a consequence they were unable to mine the final block of the previous epoch and got stuck forever.

# Proposed Solution / Important Changes Introduced

Removed the `+ 1` added to the pending block. It was previously required because it was added to the parent block, but the header number in the pending block is already incremented.

