### PR TITLE
Feature/etcm 655

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -410,17 +410,15 @@ mantis {
     # we found a fork. To resolve it, we need to query the same peer for previous headers, to find a common ancestor.
     branch-resolution-request-size = 30
 
-    # TODO investigate proper value to handle ETC reorgs correctly
     # threshold for storing non-main-chain blocks in queue.
     # if: current_best_block_number - block_number > max-queued-block-number-behind
     # then: the block will not be queued (such already queued blocks will be removed)
-    max-queued-block-number-behind = 100
+    max-queued-block-number-behind = 1000
 
-    # TODO investigate proper value to handle ETC reorgs correctly
     # threshold for storing non-main-chain blocks in queue.
     # if: block_number - current_best_block_number > max-queued-block-number-ahead
     # then: the block will not be queued (such already queued blocks will be removed)
-    max-queued-block-number-ahead = 100
+    max-queued-block-number-ahead = 1000
 
     # Maximum number of blocks, after which block hash from NewBlockHashes packet is considered ancient
     # and peer sending it is blacklisted

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -621,7 +621,8 @@ akka {
   loglevel = "INFO"
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
   logger-startup-timeout = 30s
-  log-dead-letters = off
+  log-dead-letters-during-shutdown = off
+  log-dead-letters = 5
 
   coordinated-shutdown.phases {
     actor-system-terminate {

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/regular/BlockFetcher.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/regular/BlockFetcher.scala
@@ -267,7 +267,7 @@ class BlockFetcher(
   }
 
   private def handlePossibleTopUpdate(state: BlockFetcherState): Receive = {
-    //by handling these type of messages, fetcher can received from network, fresh info about blocks on top
+    //by handling these type of messages, fetcher can receive from network, fresh info about blocks on top
     //ex. After a successful handshake, fetcher will receive the info about the header of the peer best block
     case MessageFromPeer(BlockHeaders(headers), _) =>
       headers.lastOption.map { bh =>
@@ -275,12 +275,21 @@ class BlockFetcher(
         val newState = state.withPossibleNewTopAt(bh.number)
         fetchBlocks(newState)
       }
-    //keep fetcher state updated in case new checkpoint block or mined block was imported
+    //keep fetcher state updated in case new mined block was imported
     case InternalLastBlockImport(blockNr) =>
-      log.debug(s"New last block $blockNr imported from the inside")
+      log.debug(s"New mined block $blockNr imported from the inside")
       val newState = state.withLastBlock(blockNr).withPossibleNewTopAt(blockNr)
 
       fetchBlocks(newState)
+
+    //keep fetcher state updated in case new checkpoint block was imported
+    case InternalCheckpointImport(blockNr) =>
+      log.debug(s"New checkpoint block $blockNr imported from the inside")
+
+      val newState = state
+        .clearQueues()
+        .withLastBlock(blockNr)
+        .withPossibleNewTopAt(blockNr)
   }
 
   private def handlePickedBlocks(
@@ -403,13 +412,13 @@ object BlockFetcher {
     Props(new BlockFetcher(peersClient, peerEventBus, supervisor, syncConfig, blockValidator))
 
   sealed trait FetchMsg
-  case class Start(importer: ActorRef, fromBlock: BigInt) extends FetchMsg
-  case class FetchStateNode(hash: ByteString) extends FetchMsg
-  case object RetryFetchStateNode extends FetchMsg
-  case class PickBlocks(amount: Int) extends FetchMsg
-  case class StrictPickBlocks(from: BigInt, atLEastWith: BigInt) extends FetchMsg
-  case object PrintStatus extends FetchMsg
-  case class InvalidateBlocksFrom(fromBlock: BigInt, reason: String, toBlacklist: Option[BigInt]) extends FetchMsg
+  final case class Start(importer: ActorRef, fromBlock: BigInt) extends FetchMsg
+  final case class FetchStateNode(hash: ByteString) extends FetchMsg
+  final case object RetryFetchStateNode extends FetchMsg
+  final case class PickBlocks(amount: Int) extends FetchMsg
+  final case class StrictPickBlocks(from: BigInt, atLEastWith: BigInt) extends FetchMsg
+  final case object PrintStatus extends FetchMsg
+  final case class InvalidateBlocksFrom(fromBlock: BigInt, reason: String, toBlacklist: Option[BigInt]) extends FetchMsg
 
   object InvalidateBlocksFrom {
 
@@ -419,12 +428,13 @@ object BlockFetcher {
     def apply(from: BigInt, reason: String, toBlacklist: Option[BigInt]): InvalidateBlocksFrom =
       new InvalidateBlocksFrom(from, reason, toBlacklist)
   }
-  case class BlockImportFailed(blockNr: BigInt, reason: String) extends FetchMsg
-  case class InternalLastBlockImport(blockNr: BigInt) extends FetchMsg
-  case object RetryBodiesRequest extends FetchMsg
-  case object RetryHeadersRequest extends FetchMsg
+  final case class BlockImportFailed(blockNr: BigInt, reason: String) extends FetchMsg
+  final case class InternalLastBlockImport(blockNr: BigInt) extends FetchMsg
+  final case class InternalCheckpointImport(blockNr: BigInt) extends FetchMsg
+  final case object RetryBodiesRequest extends FetchMsg
+  final case object RetryHeadersRequest extends FetchMsg
 
   sealed trait FetchResponse
-  case class PickedBlocks(blocks: NonEmptyList[Block]) extends FetchResponse
-  case class FetchedStateNode(stateNode: NodeData) extends FetchResponse
+  final case class PickedBlocks(blocks: NonEmptyList[Block]) extends FetchResponse
+  final case class FetchedStateNode(stateNode: NodeData) extends FetchResponse
 }

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/regular/BlockFetcherState.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/regular/BlockFetcherState.scala
@@ -41,6 +41,7 @@ case class BlockFetcherState(
     waitingHeaders: Queue[BlockHeader],
     fetchingHeadersState: FetchingHeadersState,
     fetchingBodiesState: FetchingBodiesState,
+    pausedFetching: Boolean = false,
     stateNodeFetcher: Option[StateNodeFetcher],
     lastBlock: BigInt,
     knownTop: BigInt,
@@ -294,6 +295,9 @@ case class BlockFetcherState(
   def isFetchingBodies: Boolean = fetchingBodiesState != NotFetchingBodies
   def withNewBodiesFetch: BlockFetcherState = copy(fetchingBodiesState = AwaitingBodies)
   def withBodiesFetchReceived: BlockFetcherState = copy(fetchingBodiesState = NotFetchingBodies)
+
+  def withPausedFetching: BlockFetcherState = copy(pausedFetching = true)
+  def withResumedFetching: BlockFetcherState = copy(pausedFetching = false)
 
   def fetchingStateNode(hash: ByteString, requestor: ActorRef): BlockFetcherState =
     copy(stateNodeFetcher = Some(StateNodeFetcher(hash, requestor)))

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/regular/BlockImporter.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/regular/BlockImporter.scala
@@ -184,7 +184,8 @@ class BlockImporter(
   ): Task[(List[Block], Option[Any])] =
     if (blocks.isEmpty) {
       importedBlocks.headOption match {
-        case Some(block) => supervisor ! ProgressProtocol.ImportedBlock(block.number, internally = false)
+        case Some(block) =>
+          supervisor ! ProgressProtocol.ImportedBlock(block.number, block.hasCheckpoint, internally = false)
         case None => ()
       }
 
@@ -258,7 +259,7 @@ class BlockImporter(
               val (blocks, weights) = importedBlocksData.map(data => (data.block, data.weight)).unzip
               broadcastBlocks(blocks, weights)
               updateTxPool(importedBlocksData.map(_.block), Seq.empty)
-              supervisor ! ProgressProtocol.ImportedBlock(block.number, internally)
+              supervisor ! ProgressProtocol.ImportedBlock(block.number, block.hasCheckpoint, internally)
             case BlockEnqueued => ()
             case DuplicateBlock => ()
             case UnknownParent => () // This is normal when receiving broadcast blocks
@@ -266,7 +267,8 @@ class BlockImporter(
               updateTxPool(newBranch, oldBranch)
               broadcastBlocks(newBranch, weights)
               newBranch.lastOption match {
-                case Some(newBlock) => supervisor ! ProgressProtocol.ImportedBlock(newBlock.number, internally)
+                case Some(newBlock) =>
+                  supervisor ! ProgressProtocol.ImportedBlock(newBlock.number, block.hasCheckpoint, internally)
                 case None => ()
               }
             case BlockImportFailed(error) =>

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/regular/RegularSync.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/regular/RegularSync.scala
@@ -5,7 +5,7 @@ import akka.util.ByteString
 import io.iohk.ethereum.blockchain.sync.SyncProtocol
 import io.iohk.ethereum.blockchain.sync.SyncProtocol.Status
 import io.iohk.ethereum.blockchain.sync.SyncProtocol.Status.Progress
-import io.iohk.ethereum.blockchain.sync.regular.BlockFetcher.InternalLastBlockImport
+import io.iohk.ethereum.blockchain.sync.regular.BlockFetcher.{InternalCheckpointImport, InternalLastBlockImport}
 import io.iohk.ethereum.blockchain.sync.regular.RegularSync.{NewCheckpoint, ProgressProtocol, ProgressState}
 import io.iohk.ethereum.consensus.blocks.CheckpointBlockGenerator
 import io.iohk.ethereum.consensus.validators.BlockValidator
@@ -100,10 +100,14 @@ class RegularSync(
       log.info(s"Got information about new block [number = $blockNumber]")
       val newState = progressState.copy(bestKnownNetworkBlock = blockNumber)
       context become running(newState)
-    case ProgressProtocol.ImportedBlock(blockNumber, internally) =>
+    case ProgressProtocol.ImportedBlock(blockNumber, isCheckpoint, internally) =>
       log.info(s"Imported new block [number = $blockNumber, internally = $internally]")
-      val newState = progressState.copy(currentBlock = blockNumber)
-      if (internally) {
+      val newState =
+        if (isCheckpoint) progressState.copy(currentBlock = blockNumber, bestKnownNetworkBlock = blockNumber)
+        else progressState.copy(currentBlock = blockNumber)
+      if (internally && isCheckpoint) {
+        fetcher ! InternalCheckpointImport(blockNumber)
+      } else if (internally) {
         fetcher ! InternalLastBlockImport(blockNumber)
       }
       context become running(newState)
@@ -171,6 +175,6 @@ object RegularSync {
     case object StartedFetching extends ProgressProtocol
     case class StartingFrom(blockNumber: BigInt) extends ProgressProtocol
     case class GotNewBlock(blockNumber: BigInt) extends ProgressProtocol
-    case class ImportedBlock(blockNumber: BigInt, internally: Boolean) extends ProgressProtocol
+    case class ImportedBlock(blockNumber: BigInt, isCheckpoint: Boolean, internally: Boolean) extends ProgressProtocol
   }
 }

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/CheckpointingServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/CheckpointingServiceSpec.scala
@@ -37,10 +37,66 @@ class CheckpointingServiceSpec
 
       val block = Block(Fixtures.Blocks.ValidBlock.header.copy(number = checkpointedBlockNum), BlockBody.empty)
 
-      val request = GetLatestBlockRequest(k)
-      val expectedResponse = GetLatestBlockResponse(block.hash, block.number)
+      val request = GetLatestBlockRequest(k, None)
+      val expectedResponse = GetLatestBlockResponse(Some(BlockInfo(block.hash, block.number)))
 
       (blockchain.getBestBlockNumber _).expects().returning(bestBlockNum)
+      (blockchain.getBlockByNumber _).expects(checkpointedBlockNum).returning(Some(block))
+      val result = service.getLatestBlock(request)
+
+      result.runSyncUnsafe() shouldEqual Right(expectedResponse)
+    }
+  }
+
+  it should "get latest block that is a descendant of the passed parent checkpoint block" in new TestSetup {
+    val nums = for {
+      k <- Gen.choose[Int](1, 10) // checkpointing interval
+      m <- Gen.choose(0, 1000) // number of checkpoints in the chain
+      n <- Gen.choose(0, k - 1) // distance from best block to checkpointed block
+    } yield (k, m, n)
+
+    val previousCheckpoint = Fixtures.Blocks.ValidBlock.block
+    val hash = previousCheckpoint.hash
+
+    forAll(nums) { case (k, m, n) =>
+      val checkpointedBlockNum: BigInt = k * m
+      val bestBlockNum: BigInt = checkpointedBlockNum + n
+
+      val block = Block(Fixtures.Blocks.ValidBlock.header.copy(number = checkpointedBlockNum), BlockBody.empty)
+
+      val request = GetLatestBlockRequest(k, Some(hash))
+      val expectedResponse = GetLatestBlockResponse(Some(BlockInfo(block.hash, block.number)))
+
+      (blockchain.getBestBlockNumber _).expects().returning(bestBlockNum)
+      (blockchain.getBlockHeaderByHash _).expects(hash).returning(Some(previousCheckpoint.header))
+      (blockchain.getBlockByNumber _).expects(checkpointedBlockNum).returning(Some(block))
+      val result = service.getLatestBlock(request)
+
+      result.runSyncUnsafe() shouldEqual Right(expectedResponse)
+    }
+  }
+
+  it should "return an empty response if the descendant is not a part of a local blockchain" in new TestSetup {
+    val nums = for {
+      k <- Gen.choose[Int](1, 10) // checkpointing interval
+      m <- Gen.choose(0, 1000) // number of checkpoints in the chain
+      n <- Gen.choose(0, k - 1) // distance from best block to checkpointed block
+    } yield (k, m, n)
+
+    val previousCheckpoint = Fixtures.Blocks.ValidBlock.block
+    val hash = previousCheckpoint.hash
+
+    forAll(nums) { case (k, m, n) =>
+      val checkpointedBlockNum: BigInt = k * m
+      val bestBlockNum: BigInt = checkpointedBlockNum + n
+
+      val block = Block(Fixtures.Blocks.ValidBlock.header.copy(number = checkpointedBlockNum), BlockBody.empty)
+
+      val request = GetLatestBlockRequest(k, Some(hash))
+      val expectedResponse = GetLatestBlockResponse(None)
+
+      (blockchain.getBestBlockNumber _).expects().returning(bestBlockNum)
+      (blockchain.getBlockHeaderByHash _).expects(hash).returning(None)
       (blockchain.getBlockByNumber _).expects(checkpointedBlockNum).returning(Some(block))
       val result = service.getLatestBlock(request)
 
@@ -62,7 +118,7 @@ class CheckpointingServiceSpec
 
   it should "get latest block in case of blockchain re-org" in new TestSetup {
     val block = Fixtures.Blocks.ValidBlock.block
-    val expectedResponse = GetLatestBlockResponse(block.hash, block.number)
+    val expectedResponse = GetLatestBlockResponse(Some(BlockInfo(block.hash, block.number)))
     (blockchain.getBestBlockNumber _)
       .expects()
       .returning(7)
@@ -76,7 +132,7 @@ class CheckpointingServiceSpec
       .expects(BigInt(4))
       .returning(Some(block))
 
-    val result = service.getLatestBlock(GetLatestBlockRequest(4))
+    val result = service.getLatestBlock(GetLatestBlockRequest(4, None))
 
     result.runSyncUnsafe() shouldEqual Right(expectedResponse)
   }


### PR DESCRIPTION
# Description

Stable changes from checkpointing:
- delayed fetching of new blocks from peers after the checkpoint was received internally, to give it time to get propagated without starting reorganisations right away
- Extend `checkpointing_getLatestBlock` RPC call with the parentBlock hash to only return the descendants of the previous checkpoint, update response type to exclude the situation when the hash returned without bockNumber of vice versa
- Update the size of the block queue where fetcher keeps all known forks in case those forks become main chain
- Enable logging of dead letters