### PR TITLE
ETCM-286: fixed some rpc test issues

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -113,7 +113,7 @@ object Dependencies {
     "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.2",
     "org.scala-sbt.ipcsocket" % "ipcsocket" % "1.1.0",
     "org.xerial.snappy" % "snappy-java" % "1.1.7.7",
-    "org.web3j" % "core" % "5.0.0" % Test,
+    "org.web3j" % "core" % "4.5.11" % Test,
     "io.vavr" % "vavr" % "1.0.0-alpha-3",
     "org.jupnp" % "org.jupnp" % "2.5.2",
     "org.jupnp" % "org.jupnp.support" % "2.5.2",

--- a/src/rpcTest/README.md
+++ b/src/rpcTest/README.md
@@ -9,11 +9,11 @@ Private keys for pre-funded accounts are located in `mantis/src/rpcTest/resource
 
 1. Build `mantis` client via `sbt dist`.
 2. Unzip built client to some directory i.e `~/mantis_build`
-3. Run script `patch-mantis` (it's in resources dir) with path to your mantis instance. Example invocation assuming that mantis is in `~/mantis_build` looks as follows:
+3. Run script `patch-mantis` (it's in resources dir) with path to your mantis instance. Example invocation assuming that mantis is in `~/mantis_build/mantis-X.Y.Z` looks as follows:
     
-        ./resources/patch-mantis ~/mantis_build
+        ./resources/patch-mantis ~/mantis_build/mantis-3.2.1
 
-4. Go to `~/mantis_build` directory and run mantis on ETC mainnet with command:
+4. Go to `~/mantis_build/mantis-3.2.1` directory and run mantis on ETC mainnet with command:
 
         ./bin/mantis-launcher etc -Dmantis.sync.do-fast-sync=false -Dmantis.network.discovery.discovery-enabled=true -Dmantis.network.rpc.http.mode=http
         
@@ -22,8 +22,8 @@ Private keys for pre-funded accounts are located in `mantis/src/rpcTest/resource
 
         sbt "rpcTest:testOnly -- -n MainNet"
         
-7. Turn off Mantis client in `~/mantis_build`
-8. Go to `~/mantis_build` directory and run mantis using command below (mantis will be run with miner so you need to wait till DAG is loaded):
+7. Turn off Mantis client in `~/mantis_build/mantis-3.2.1`
+8. Go to `~/mantis_build/mantis-3.2.1` directory and run mantis using command below (mantis will be run with miner so you need to wait till DAG is loaded):
 
         ./bin/mantis -Dmantis.consensus.mining-enabled=true
 9. Go to `mantis` source dir and run 
@@ -31,7 +31,7 @@ Private keys for pre-funded accounts are located in `mantis/src/rpcTest/resource
         sbt "rpcTest:testOnly -- -n PrivNet"
         
 10. Turn off Mantis client
-11. Go to `~/mantis_build` directory and run Mantis with mining disabled using command
+11. Go to `~/mantis_build/mantis-3.2.1` directory and run Mantis with mining disabled using command
 
         ./bin/mantis
         

--- a/src/rpcTest/resources/patch-mantis
+++ b/src/rpcTest/resources/patch-mantis
@@ -2,7 +2,7 @@
 
 MANTIS_DIR=$1
 SCRIPT_DIR="$( cd "$(dirname "$0")" ; pwd -P )"
-KEYSTORE_PATH=~/.mantis-rpc-test/rpc-test-private/keystore
+KEYSTORE_PATH=~/.mantis-rpc-test/rpc-test-private/keystore/
 
 if [[ -z "$MANTIS_DIR" ]]; then
   echo "Path to Mantis dir must be passed as the first argument"
@@ -16,7 +16,7 @@ fi
 
 echo "Patching Mantis at $MANTIS_DIR with configuration for JSON-RPC tests"
 
-cp -R ${SCRIPT_DIR}/privateNetConfig/conf/ ${MANTIS_DIR}/conf
+cp -R ${SCRIPT_DIR}/privateNetConfig/conf/* ${MANTIS_DIR}/conf/
 
 mkdir -p ${KEYSTORE_PATH}
-cp -R ${SCRIPT_DIR}/privateNetConfig/keystore/ ${KEYSTORE_PATH}
+cp -R ${SCRIPT_DIR}/privateNetConfig/keystore/* ${KEYSTORE_PATH}

--- a/src/rpcTest/scala/io/iohk/ethereum/rpcTest/RpcApiTests.scala
+++ b/src/rpcTest/scala/io/iohk/ethereum/rpcTest/RpcApiTests.scala
@@ -2,7 +2,6 @@ package io.iohk.ethereum.rpcTest
 
 import java.math.BigInteger
 import java.security.SecureRandom
-
 import akka.util.ByteString
 import com.typesafe.config.ConfigFactory
 import io.iohk.ethereum.domain.Address
@@ -24,6 +23,7 @@ import io.iohk.ethereum.rpcTest.TestData._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.web3j.protocol.core.methods.response.EthLog
+import org.web3j.protocol.exceptions.ClientConnectionException
 
 import scala.jdk.CollectionConverters._
 import scala.language.implicitConversions
@@ -68,9 +68,7 @@ class RpcApiTests extends AnyFlatSpec with Matchers with Logger {
     val response1 = service.ethGetBlockTransactionCountByNumber(twoTransactionBlock.blockNumber).send()
     response1.getTransactionCount.asBigInt shouldEqual twoTransactionBlock.transactions.size
 
-    val response2 = service.ethGetBlockTransactionCountByNumber(futureBlock).send()
-    response2.getResult shouldBe null
-    response2.getError.getCode shouldEqual generalErrorCode
+    assertThrows[ClientConnectionException](service.ethGetBlockTransactionCountByNumber(futureBlock).send())
   }
 
   it should "eth_getUncleCountByBlockHash" taggedAs (MainNet) in new ScenarioSetup {
@@ -80,9 +78,7 @@ class RpcApiTests extends AnyFlatSpec with Matchers with Logger {
     val response1 = service.ethGetUncleCountByBlockHash(oneUncleTestBlock.hash).send()
     response1.getUncleCount.asBigInt shouldEqual oneUncleTestBlock.uncles.size
 
-    val response2 = service.ethGetUncleCountByBlockHash(unexisitingBlockHash).send()
-    response2.getResult shouldBe null
-    response2.getError.getCode shouldEqual generalErrorCode
+    assertThrows[ClientConnectionException](service.ethGetUncleCountByBlockHash(unexisitingBlockHash).send())
   }
 
   it should "eth_getUncleCountByBlockNumber" taggedAs (MainNet) in new ScenarioSetup {
@@ -92,9 +88,7 @@ class RpcApiTests extends AnyFlatSpec with Matchers with Logger {
     val response1 = service.ethGetUncleCountByBlockNumber(oneUncleTestBlock.blockNumber).send()
     response1.getUncleCount.asBigInt shouldEqual oneUncleTestBlock.uncles.size
 
-    val response2 = service.ethGetUncleCountByBlockNumber(futureBlock).send()
-    response2.getResult shouldBe null
-    response2.getError.getCode shouldEqual generalErrorCode
+    assertThrows[ClientConnectionException](service.ethGetUncleCountByBlockNumber(futureBlock).send())
   }
 
   it should "eth_getBlockByHash" taggedAs (MainNet) in new ScenarioSetup {
@@ -105,9 +99,7 @@ class RpcApiTests extends AnyFlatSpec with Matchers with Logger {
     response1.getBlock shouldEqual null
     response1.getError shouldEqual null
 
-    val response2 = service.ethGetBlockByHash(badHash, false).send()
-    response2.getBlock shouldEqual null
-    response2.getError.getCode shouldEqual generalErrorCode
+    assertThrows[ClientConnectionException](service.ethGetBlockByHash(badHash, false).send())
   }
 
   it should "eth_getTransactionByBlockHashAndIndex" taggedAs (MainNet) in new ScenarioSetup {
@@ -1094,7 +1086,12 @@ class RpcApiTests extends AnyFlatSpec with Matchers with Logger {
     val response = service.personalListAccounts().send()
     val personalAccounts = response.getAccountIds.asScala
 
-    personalAccounts should contain.allOf(firstAccount.address, secondAccount.address, thirdAccount.address, gethAccount.address)
+    personalAccounts should contain.allOf(
+      firstAccount.address,
+      secondAccount.address,
+      thirdAccount.address,
+      gethAccount.address
+    )
 
     val response1 = service.ethAccounts().send()
     val ethAccounts = response1.getAccounts.asScala


### PR DESCRIPTION
# Description

Part of fixes introduced for Mantis RPC tests

# Important Changes Introduced

Changed test assertions when requesting future/non-existing blocks. Updated patch script to bring config and keystore files to appropriate mantis client path. Lowered web3j lib to be able to run tests from Intellij (transient dependency issue with Kamon)

# Testing
Follow existing README guide

