### PR TITLE
[ETCM-709] Improve ommers validations.

### DIFF
--- a/src/ets/scala/io/iohk/ethereum/ets/blockchain/BlockchainTestConfig.scala
+++ b/src/ets/scala/io/iohk/ethereum/ets/blockchain/BlockchainTestConfig.scala
@@ -2,7 +2,7 @@ package io.iohk.ethereum.ets.blockchain
 
 import akka.util.ByteString
 import io.iohk.ethereum.consensus.Protocol
-import io.iohk.ethereum.consensus.ethash.validators.ValidatorsExecutor
+import io.iohk.ethereum.consensus.validators.std.ValidatorsExecutor
 import io.iohk.ethereum.domain.{Address, UInt256}
 import io.iohk.ethereum.utils.{BlockchainConfig, DaoForkConfig, MonetaryPolicyConfig}
 import org.bouncycastle.util.encoders.Hex

--- a/src/ets/scala/io/iohk/ethereum/ets/blockchain/ScenarioSetup.scala
+++ b/src/ets/scala/io/iohk/ethereum/ets/blockchain/ScenarioSetup.scala
@@ -3,7 +3,7 @@ package io.iohk.ethereum.ets.blockchain
 import akka.util.ByteString
 import io.iohk.ethereum.consensus.Protocol.NoAdditionalEthashData
 import io.iohk.ethereum.consensus.ethash.EthashConsensus
-import io.iohk.ethereum.consensus.ethash.validators.ValidatorsExecutor
+import io.iohk.ethereum.consensus.validators.std.ValidatorsExecutor
 import io.iohk.ethereum.consensus.{ConsensusConfig, FullConsensusConfig, TestConsensus, ethash}
 import io.iohk.ethereum.db.components.Storages.PruningModeComponent
 import io.iohk.ethereum.db.components.{EphemDataSourceComponent, Storages}
@@ -18,6 +18,7 @@ import io.iohk.ethereum.utils.BigIntExtensionMethods._
 import io.iohk.ethereum.utils.{BlockchainConfig, Config}
 import monix.execution.Scheduler
 import org.bouncycastle.util.encoders.Hex
+
 import scala.util.{Failure, Success, Try}
 
 object ScenarioSetup {

--- a/src/it/scala/io/iohk/ethereum/ledger/BlockImporterItSpec.scala
+++ b/src/it/scala/io/iohk/ethereum/ledger/BlockImporterItSpec.scala
@@ -8,8 +8,9 @@ import io.iohk.ethereum.blockchain.sync.regular.{BlockFetcher, BlockImporter}
 import io.iohk.ethereum.checkpointing.CheckpointingTestHelpers
 import io.iohk.ethereum.consensus.{GetBlockHeaderByHash, GetNBlocksBack}
 import io.iohk.ethereum.consensus.blocks.CheckpointBlockGenerator
-import io.iohk.ethereum.consensus.ethash.validators.{OmmersValidator, StdOmmersValidator}
+import io.iohk.ethereum.consensus.ethash.validators.OmmersValidator
 import io.iohk.ethereum.consensus.validators.Validators
+import io.iohk.ethereum.consensus.validators.std.StdOmmersValidator
 import io.iohk.ethereum.domain._
 import io.iohk.ethereum.mpt.MerklePatriciaTrie
 import io.iohk.ethereum.utils.Config.SyncConfig
@@ -74,7 +75,7 @@ class BlockImporterItSpec
         getBlockHeaderByHash: GetBlockHeaderByHash,
         getNBlocksBack: GetNBlocksBack
     ) =>
-      new StdOmmersValidator(blockchainConfig, blockHeaderValidator)
+      new StdOmmersValidator(blockHeaderValidator)
         .validate(parentHash, blockNumber, ommers, getBlockHeaderByHash, getNBlocksBack)
   }
 

--- a/src/it/scala/io/iohk/ethereum/sync/RegularSyncItSpec.scala
+++ b/src/it/scala/io/iohk/ethereum/sync/RegularSyncItSpec.scala
@@ -152,7 +152,12 @@ class RegularSyncItSpec extends FreeSpecBase with Matchers with BeforeAndAfterAl
       _ <- peer1.waitForRegularSyncLoadLastBlock(length)
     } yield {
       assert(peer1.bl.getBestBlock().get.hash == peer2.bl.getBestBlock().get.hash)
-      assert(peer1.bl.getBestBlock().get.number == peer2.bl.getBestBlock().get.number && peer1.bl.getBestBlock().get.number == length)
+      assert(
+        peer1.bl.getBestBlock().get.number == peer2.bl.getBestBlock().get.number && peer1.bl
+          .getBestBlock()
+          .get
+          .number == length
+      )
       assert(peer1.bl.getLatestCheckpointBlockNumber() == peer2.bl.getLatestCheckpointBlockNumber())
     }
   }

--- a/src/it/scala/io/iohk/ethereum/sync/util/RegularSyncItSpecUtils.scala
+++ b/src/it/scala/io/iohk/ethereum/sync/util/RegularSyncItSpecUtils.scala
@@ -7,7 +7,13 @@ import io.iohk.ethereum.Mocks.MockValidatorsAlwaysSucceed
 import io.iohk.ethereum.blockchain.sync.regular.BlockBroadcast.BlockToBroadcast
 import io.iohk.ethereum.blockchain.sync.regular.BlockBroadcasterActor.BroadcastBlock
 import io.iohk.ethereum.blockchain.sync.regular.BlockImporter.Start
-import io.iohk.ethereum.blockchain.sync.regular.{BlockBroadcast, BlockBroadcasterActor, BlockFetcher, BlockImporter, RegularSync}
+import io.iohk.ethereum.blockchain.sync.regular.{
+  BlockBroadcast,
+  BlockBroadcasterActor,
+  BlockFetcher,
+  BlockImporter,
+  RegularSync
+}
 import io.iohk.ethereum.blockchain.sync.regular.RegularSync.NewCheckpoint
 import io.iohk.ethereum.blockchain.sync.{PeersClient, SyncProtocol}
 import io.iohk.ethereum.checkpointing.CheckpointingTestHelpers
@@ -96,7 +102,8 @@ object RegularSyncItSpecUtils {
         broadcasterRef,
         pendingTransactionsManager,
         regularSync
-      ))
+      )
+    )
 
     lazy val regularSync = system.actorOf(
       RegularSync.props(

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/regular/BlockImporter.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/regular/BlockImporter.scala
@@ -15,10 +15,12 @@ import io.iohk.ethereum.network.PeerId
 import io.iohk.ethereum.ommers.OmmersPool.AddOmmers
 import io.iohk.ethereum.transactions.PendingTransactionsManager
 import io.iohk.ethereum.transactions.PendingTransactionsManager.{AddUncheckedTransactions, RemoveTransactions}
+import io.iohk.ethereum.utils.ByteStringUtils
 import io.iohk.ethereum.utils.Config.SyncConfig
 import io.iohk.ethereum.utils.FunctorOps._
 import monix.eval.Task
 import monix.execution.Scheduler
+import org.bouncycastle.util.encoders.Hex
 
 import scala.concurrent.duration._
 
@@ -207,7 +209,12 @@ class BlockImporter(
             tryImportBlocks(restOfBlocks, importedBlocks)
 
           case err @ (UnknownParent | BlockImportFailed(_)) =>
-            log.error("Block {} import failed", blocks.head.number)
+            log.error(
+              "Block {} import failed, with hash {} and parent hash {}",
+              blocks.head.number,
+              blocks.head.header.hashAsHexString,
+              ByteStringUtils.hash2string(blocks.head.header.parentHash)
+            )
             Task.now((importedBlocks, Some(err)))
         }
         .onErrorHandle {

--- a/src/main/scala/io/iohk/ethereum/consensus/ConsensusBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/ConsensusBuilder.scala
@@ -2,7 +2,7 @@ package io.iohk.ethereum.consensus
 
 import io.iohk.ethereum.consensus.Protocol.{NoAdditionalEthashData, RestrictedEthashMinerData}
 import io.iohk.ethereum.consensus.ethash.EthashConsensus
-import io.iohk.ethereum.consensus.ethash.validators.ValidatorsExecutor
+import io.iohk.ethereum.consensus.validators.std.ValidatorsExecutor
 import io.iohk.ethereum.nodebuilder._
 import io.iohk.ethereum.utils.{Config, Logger}
 

--- a/src/main/scala/io/iohk/ethereum/consensus/ethash/EthashConsensus.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/ethash/EthashConsensus.scala
@@ -13,8 +13,8 @@ import io.iohk.ethereum.consensus.ethash.blocks.{
   EthashBlockGeneratorImpl,
   RestrictedEthashBlockGeneratorImpl
 }
-import io.iohk.ethereum.consensus.ethash.validators.ValidatorsExecutor
 import io.iohk.ethereum.consensus.validators.Validators
+import io.iohk.ethereum.consensus.validators.std.ValidatorsExecutor
 import io.iohk.ethereum.domain.BlockchainImpl
 import io.iohk.ethereum.jsonrpc.AkkaTaskOps.TaskActorOps
 import io.iohk.ethereum.ledger.BlockPreparator
@@ -22,6 +22,7 @@ import io.iohk.ethereum.ledger.Ledger.VMImpl
 import io.iohk.ethereum.nodebuilder.Node
 import io.iohk.ethereum.utils.{BlockchainConfig, Logger}
 import monix.eval.Task
+
 import scala.concurrent.duration._
 
 /**

--- a/src/main/scala/io/iohk/ethereum/consensus/ethash/blocks/EthashBlockGenerator.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/ethash/blocks/EthashBlockGenerator.scala
@@ -5,12 +5,12 @@ import akka.util.ByteString
 import io.iohk.ethereum.consensus.ConsensusConfig
 import io.iohk.ethereum.consensus.blocks._
 import io.iohk.ethereum.consensus.difficulty.DifficultyCalculator
-import io.iohk.ethereum.consensus.ethash.validators.ValidatorsExecutor
 import io.iohk.ethereum.crypto.kec256
 import io.iohk.ethereum.domain._
 import io.iohk.ethereum.ledger.{BlockPreparator, InMemoryWorldStateProxy}
 import io.iohk.ethereum.utils.BlockchainConfig
 import io.iohk.ethereum.consensus.ConsensusMetrics
+import io.iohk.ethereum.consensus.validators.std.ValidatorsExecutor
 
 /** Internal API, used for testing (especially mocks) */
 trait EthashBlockGenerator extends TestBlockGenerator {

--- a/src/main/scala/io/iohk/ethereum/consensus/ethash/blocks/RestrictedEthashBlockGeneratorImpl.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/ethash/blocks/RestrictedEthashBlockGeneratorImpl.scala
@@ -4,12 +4,12 @@ import io.iohk.ethereum.consensus.ConsensusConfig
 import io.iohk.ethereum.consensus.blocks.{BlockTimestampProvider, DefaultBlockTimestampProvider, PendingBlockAndState}
 import io.iohk.ethereum.consensus.difficulty.DifficultyCalculator
 import io.iohk.ethereum.consensus.ethash.RestrictedEthashSigner
-import io.iohk.ethereum.consensus.ethash.validators.ValidatorsExecutor
 import io.iohk.ethereum.domain.{Address, Block, Blockchain, SignedTransaction}
 import io.iohk.ethereum.ledger.{BlockPreparator, InMemoryWorldStateProxy}
 import io.iohk.ethereum.utils.BlockchainConfig
 import org.bouncycastle.crypto.AsymmetricCipherKeyPair
 import io.iohk.ethereum.consensus.ConsensusMetrics
+import io.iohk.ethereum.consensus.validators.std.ValidatorsExecutor
 
 class RestrictedEthashBlockGeneratorImpl(
     validators: ValidatorsExecutor,

--- a/src/main/scala/io/iohk/ethereum/consensus/ethash/validators/OmmersValidator.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/ethash/validators/OmmersValidator.scala
@@ -2,6 +2,7 @@ package io.iohk.ethereum.consensus.ethash.validators
 
 import akka.util.ByteString
 import io.iohk.ethereum.consensus.ethash.validators.OmmersValidator.{OmmersError, OmmersValid}
+import io.iohk.ethereum.consensus.validators.BlockHeaderError
 import io.iohk.ethereum.consensus.{GetBlockHeaderByHash, GetNBlocksBack}
 import io.iohk.ethereum.domain.{Block, BlockHeader, Blockchain}
 
@@ -36,9 +37,10 @@ object OmmersValidator {
 
   object OmmersError {
     case object OmmersLengthError extends OmmersError
-    case object OmmersNotValidError extends OmmersError
+    case class OmmersHeaderError(errors: List[BlockHeaderError]) extends OmmersError
     case object OmmersUsedBeforeError extends OmmersError
-    case object OmmersAncestorsError extends OmmersError
+    case object OmmerIsAncestorError extends OmmersError
+    case object OmmerParentIsNotAncestorError extends OmmersError
     case object OmmersDuplicatedError extends OmmersError
   }
 

--- a/src/main/scala/io/iohk/ethereum/consensus/validators/std/StdValidators.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/validators/std/StdValidators.scala
@@ -12,7 +12,7 @@ import org.bouncycastle.util.encoders.Hex
   * Implements validators that adhere to the original [[io.iohk.ethereum.consensus.validators.Validators Validators]]
   * interface.
   *
-  * @see [[io.iohk.ethereum.consensus.ethash.validators.StdValidatorsExecutor StdEthashValidators]]
+  * @see [[StdValidatorsExecutor StdEthashValidators]]
   *      for the PoW-specific counterpart.
   */
 final class StdValidators(

--- a/src/main/scala/io/iohk/ethereum/consensus/validators/std/StdValidatorsExecutor.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/validators/std/StdValidatorsExecutor.scala
@@ -1,13 +1,14 @@
-package io.iohk.ethereum.consensus.ethash.validators
+package io.iohk.ethereum.consensus.validators.std
 
+import io.iohk.ethereum.consensus.ethash.validators.OmmersValidator
 import io.iohk.ethereum.consensus.validators.{BlockHeaderValidator, BlockValidator, SignedTransactionValidator}
 
 /**
   * Implements validators that adhere to the PoW-specific
-  * [[io.iohk.ethereum.consensus.ethash.validators.ValidatorsExecutor]]
+  * [[ValidatorsExecutor]]
   * interface.
   */
-final class StdValidatorsExecutor private[validators] (
+final class StdValidatorsExecutor private[std] (
     val blockValidator: BlockValidator,
     val blockHeaderValidator: BlockHeaderValidator,
     val signedTransactionValidator: SignedTransactionValidator,

--- a/src/main/scala/io/iohk/ethereum/consensus/validators/std/ValidatorsExecutor.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/validators/std/ValidatorsExecutor.scala
@@ -1,9 +1,14 @@
-package io.iohk.ethereum.consensus
-package ethash.validators
+package io.iohk.ethereum.consensus.validators.std
 
 import akka.util.ByteString
-import io.iohk.ethereum.consensus.validators.std.{StdBlockValidator, StdSignedTransactionValidator, StdValidators}
+import io.iohk.ethereum.consensus.ethash.validators.{
+  EthashBlockHeaderValidator,
+  MockedPowBlockHeaderValidator,
+  OmmersValidator,
+  RestrictedEthashBlockHeaderValidator
+}
 import io.iohk.ethereum.consensus.validators.{BlockHeaderValidator, Validators}
+import io.iohk.ethereum.consensus.{GetBlockHeaderByHash, GetNBlocksBack, Protocol}
 import io.iohk.ethereum.domain.{Block, Receipt}
 import io.iohk.ethereum.ledger.BlockExecutionError.ValidationBeforeExecError
 import io.iohk.ethereum.ledger.{BlockExecutionError, BlockExecutionSuccess}
@@ -55,7 +60,7 @@ object ValidatorsExecutor {
       StdBlockValidator,
       blockHeaderValidator,
       new StdSignedTransactionValidator(blockchainConfig),
-      new StdOmmersValidator(blockchainConfig, blockHeaderValidator)
+      new StdOmmersValidator(blockHeaderValidator)
     )
   }
 
@@ -66,7 +71,7 @@ object ValidatorsExecutor {
       StdBlockValidator,
       blockHeaderValidator,
       new StdSignedTransactionValidator(blockchainConfig),
-      new StdOmmersValidator(blockchainConfig, blockHeaderValidator)
+      new StdOmmersValidator(blockHeaderValidator)
     )
   }
 

--- a/src/main/scala/io/iohk/ethereum/domain/Blockchain.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/Blockchain.scala
@@ -446,7 +446,7 @@ class BlockchainImpl(
   private def removeBlock(block: Block, withState: Boolean): Unit = {
     val blockHash = block.hash
 
-    log.debug(s"Trying to remove block block ${block.idTag}")
+    log.debug(s"Trying to remove block ${block.idTag}")
 
     val txList = block.body.transactionList
     val bestBlockNumber = getBestBlockNumber()

--- a/src/main/scala/io/iohk/ethereum/ledger/BlockImport.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/BlockImport.scala
@@ -35,7 +35,10 @@ class BlockImport(
 
     Task.parMap2(validationResult, importResult) { case (validationResult, importResult) =>
       validationResult.fold(
-        error => handleImportTopValidationError(error, block, importResult),
+        error => {
+          log.error("Error while validation block before execution: {}", error.reason)
+          handleImportTopValidationError(error, block, importResult)
+        },
         _ => importResult
       )
     }

--- a/src/main/scala/io/iohk/ethereum/ledger/Ledger.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/Ledger.scala
@@ -137,13 +137,20 @@ class LedgerImpl(
               importResult.foreach(measureBlockMetrics)
               importResult
             case None =>
-              log.error(s"Getting total difficulty for current best block with hash: $hash failed")
-              Task.now(BlockImportFailed(s"Couldn't get total difficulty for current best block with hash: $hash"))
+              log.error(
+                "Getting total difficulty for current best block with hash: {} failed",
+                bestBlock.header.hashAsHexString
+              )
+              Task.now(
+                BlockImportFailed(
+                  "Couldn't get total difficulty for current best block with hash: ${bestBlock.header.hashAsHexString}"
+                )
+              )
           }
         }
       case None =>
         log.error("Getting current best block failed")
-        Task.now(BlockImportFailed(s"Couldn't find the current best block"))
+        Task.now(BlockImportFailed("Couldn't find the current best block"))
     }
 
   private def isBlockADuplicate(block: BlockHeader, currentBestBlockNumber: BigInt): Boolean = {

--- a/src/test/scala/io/iohk/ethereum/Mocks.scala
+++ b/src/test/scala/io/iohk/ethereum/Mocks.scala
@@ -2,12 +2,13 @@ package io.iohk.ethereum
 
 import akka.util.ByteString
 import cats.data.NonEmptyList
-import io.iohk.ethereum.consensus.ethash.validators.OmmersValidator.OmmersError.OmmersNotValidError
+import io.iohk.ethereum.consensus.ethash.validators.OmmersValidator.OmmersError.OmmersHeaderError
 import io.iohk.ethereum.consensus.ethash.validators.OmmersValidator.OmmersValid
-import io.iohk.ethereum.consensus.ethash.validators.{OmmersValidator, ValidatorsExecutor}
-import io.iohk.ethereum.consensus.validators.BlockHeaderError.HeaderNumberError
+import io.iohk.ethereum.consensus.ethash.validators.OmmersValidator
+import io.iohk.ethereum.consensus.validators.BlockHeaderError.{HeaderDifficultyError, HeaderNumberError}
 import io.iohk.ethereum.consensus.validators._
 import io.iohk.ethereum.consensus.validators.std.StdBlockValidator.{BlockError, BlockTransactionsHashError, BlockValid}
+import io.iohk.ethereum.consensus.validators.std.ValidatorsExecutor
 import io.iohk.ethereum.consensus.{Consensus, GetBlockHeaderByHash, GetNBlocksBack}
 import io.iohk.ethereum.domain._
 import io.iohk.ethereum.ledger.BlockExecutionError.ValidationAfterExecError
@@ -103,7 +104,7 @@ object Mocks {
 
     override val ommersValidator: OmmersValidator =
       (_: ByteString, _: BigInt, _: Seq[BlockHeader], _: GetBlockHeaderByHash, _: GetNBlocksBack) =>
-        Left(OmmersNotValidError)
+        Left(OmmersHeaderError(List(HeaderDifficultyError)))
 
     override val blockValidator: BlockValidator = new BlockValidator {
       override def validateHeaderAndBody(blockHeader: BlockHeader, blockBody: BlockBody) = Left(

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/ScenarioSetup.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/ScenarioSetup.scala
@@ -2,16 +2,18 @@ package io.iohk.ethereum.blockchain.sync
 
 import io.iohk.ethereum.Mocks
 import io.iohk.ethereum.Mocks.MockVM
-import io.iohk.ethereum.consensus.ethash.validators.ValidatorsExecutor
 import io.iohk.ethereum.consensus.validators.Validators
+import io.iohk.ethereum.consensus.validators.std.ValidatorsExecutor
 import io.iohk.ethereum.consensus.{Consensus, Protocol, StdTestConsensusBuilder, TestConsensus}
 import io.iohk.ethereum.domain.BlockchainImpl
 import io.iohk.ethereum.ledger.Ledger.VMImpl
 import io.iohk.ethereum.ledger.LedgerImpl
 import io.iohk.ethereum.nodebuilder._
 import io.iohk.ethereum.utils.BlockchainConfig
+
 import java.util.concurrent.Executors
 import monix.execution.Scheduler
+
 import scala.concurrent.ExecutionContext
 
 /**

--- a/src/test/scala/io/iohk/ethereum/consensus/blocks/BlockGeneratorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/blocks/BlockGeneratorSpec.scala
@@ -1,11 +1,10 @@
-package io.iohk.ethereum.consensus
+package io.iohk.ethereum.consensus.blocks
 
 import akka.util.ByteString
 import io.iohk.ethereum.blockchain.data.GenesisDataLoader
 import io.iohk.ethereum.blockchain.sync.EphemBlockchainTestSetup
-import io.iohk.ethereum.consensus.blocks.BlockTimestampProvider
-import io.iohk.ethereum.consensus.ethash.validators.ValidatorsExecutor
 import io.iohk.ethereum.consensus.validators._
+import io.iohk.ethereum.consensus.validators.std.ValidatorsExecutor
 import io.iohk.ethereum.crypto
 import io.iohk.ethereum.crypto._
 import io.iohk.ethereum.domain.BlockHeader.HeaderExtraFields
@@ -15,7 +14,6 @@ import io.iohk.ethereum.domain._
 import io.iohk.ethereum.ledger.{BlockExecution, BlockQueue, BlockValidation}
 import io.iohk.ethereum.mpt.MerklePatriciaTrie.MPTException
 import io.iohk.ethereum.utils._
-import java.time.Instant
 import monix.execution.Scheduler
 import org.bouncycastle.crypto.AsymmetricCipherKeyPair
 import org.bouncycastle.crypto.params.ECPublicKeyParameters
@@ -23,6 +21,8 @@ import org.bouncycastle.util.encoders.Hex
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+
+import java.time.Instant
 
 class BlockGeneratorSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyChecks with Logger {
   implicit val testContext = Scheduler.fixedPool("block-generator-spec-pool", 4)

--- a/src/test/scala/io/iohk/ethereum/consensus/ethash/EthashMinerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/ethash/EthashMinerSpec.scala
@@ -49,7 +49,8 @@ class EthashMinerSpec
 
   it should "mine valid blocks on the end of the epoch" taggedAs EthashMinerSpecTag in new TestSetup {
     val epochLength: Int = EthashUtils.EPOCH_LENGTH_BEFORE_ECIP_1099
-    val parentBlockNumber: Int = 2 * epochLength - 2 // 59998, mined block will be 59999 (last block of the current epoch)
+    val parentBlockNumber: Int =
+      2 * epochLength - 2 // 59998, mined block will be 59999 (last block of the current epoch)
     val parentBlock: Block = origin.copy(header = origin.header.copy(number = parentBlockNumber))
     val bfm: Block = blockForMining(parentBlock.header)
 
@@ -84,8 +85,9 @@ class EthashMinerSpec
       ommersPool = ommersPool.ref
     )
 
-    val miner: TestActorRef[Nothing] = TestActorRef(EthashMiner.props(blockchain, blockCreator, sync.ref, ethService, ethMiningService))
-
+    val miner: TestActorRef[Nothing] = TestActorRef(
+      EthashMiner.props(blockchain, blockCreator, sync.ref, ethService, ethMiningService)
+    )
 
     protected def executeTest(parentBlock: Block, blockForMining: Block): Unit = {
       prepareMocks(parentBlock, blockForMining)

--- a/src/test/scala/io/iohk/ethereum/consensus/ethash/validators/EthashBlockHeaderValidatorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/ethash/validators/EthashBlockHeaderValidatorSpec.scala
@@ -1,26 +1,25 @@
-package io.iohk.ethereum.consensus.validators
+package io.iohk.ethereum.consensus.ethash.validators
 
 import akka.util.ByteString
 import io.iohk.ethereum.blockchain.sync.EphemBlockchainTestSetup
 import io.iohk.ethereum.consensus.difficulty.DifficultyCalculator
 import io.iohk.ethereum.consensus.ethash.difficulty.EthashDifficultyCalculator
-import io.iohk.ethereum.consensus.ethash.validators.EthashBlockHeaderValidator
 import io.iohk.ethereum.consensus.validators.BlockHeaderError._
 import io.iohk.ethereum.consensus.validators.BlockHeaderValidator._
+import io.iohk.ethereum.consensus.validators.{BlockHeaderError, BlockHeaderValid, BlockHeaderValidatorSkeleton}
+import io.iohk.ethereum.domain.BlockHeader.HeaderExtraFields._
 import io.iohk.ethereum.domain.{UInt256, _}
 import io.iohk.ethereum.utils.{BlockchainConfig, DaoForkConfig}
-import io.iohk.ethereum.{Fixtures, ObjectGenerators}
+import io.iohk.ethereum.{Fixtures, ObjectGenerators, SuperSlow}
 import org.bouncycastle.util.encoders.Hex
 import org.scalamock.scalatest.MockFactory
-import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import io.iohk.ethereum.domain.BlockHeader.HeaderExtraFields._
-import io.iohk.ethereum.SuperSlow
 import org.scalatest.prop.TableFor4
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
 // scalastyle:off magic.number
-class BlockHeaderValidatorSpec
+class EthashBlockHeaderValidatorSpec
     extends AnyFlatSpec
     with Matchers
     with ScalaCheckPropertyChecks

--- a/src/test/scala/io/iohk/ethereum/consensus/ethash/validators/RestrictedEthashBlockHeaderValidatorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/ethash/validators/RestrictedEthashBlockHeaderValidatorSpec.scala
@@ -1,9 +1,9 @@
-package io.iohk.ethereum.consensus.validators
+package io.iohk.ethereum.consensus.ethash.validators
 
 import akka.util.ByteString
 import io.iohk.ethereum.consensus.ethash.RestrictedEthashSigner
-import io.iohk.ethereum.consensus.ethash.validators.RestrictedEthashBlockHeaderValidator
 import io.iohk.ethereum.consensus.validators.BlockHeaderError.{HeaderPoWError, RestrictedEthashHeaderExtraDataError}
+import io.iohk.ethereum.consensus.validators.BlockHeaderValid
 import io.iohk.ethereum.crypto
 import io.iohk.ethereum.crypto.ECDSASignature
 import io.iohk.ethereum.domain.{Address, BlockHeader, UInt256}

--- a/src/test/scala/io/iohk/ethereum/consensus/validators/std/StdBlockValidatorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/validators/std/StdBlockValidatorSpec.scala
@@ -1,19 +1,18 @@
-package io.iohk.ethereum.consensus.validators
+package io.iohk.ethereum.consensus.validators.std
 
 import akka.util.ByteString
 import io.iohk.ethereum.checkpointing.CheckpointingTestHelpers
 import io.iohk.ethereum.consensus.blocks.CheckpointBlockGenerator
-import io.iohk.ethereum.consensus.validators.std.StdBlockValidator
 import io.iohk.ethereum.consensus.validators.std.StdBlockValidator._
 import io.iohk.ethereum.crypto
 import io.iohk.ethereum.domain._
-import io.iohk.ethereum.security.SecureRandomBuilder
 import io.iohk.ethereum.ledger.BloomFilter
+import io.iohk.ethereum.security.SecureRandomBuilder
 import org.bouncycastle.util.encoders.Hex
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-class BlockValidatorSpec extends AnyFlatSpec with Matchers with SecureRandomBuilder {
+class StdBlockValidatorSpec extends AnyFlatSpec with Matchers with SecureRandomBuilder {
 
   "Block" should "created based on valid data" in {
     val block = Block(validBlockHeader, validBlockBody)

--- a/src/test/scala/io/iohk/ethereum/consensus/validators/std/StdSignedTransactionValidatorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/validators/std/StdSignedTransactionValidatorSpec.scala
@@ -1,11 +1,8 @@
-package io.iohk.ethereum.consensus.validators
-
-import java.math.BigInteger
-import java.security.SecureRandom
+package io.iohk.ethereum.consensus.validators.std
 
 import akka.util.ByteString
 import io.iohk.ethereum.consensus.validators.SignedTransactionError.{TransactionSignatureError, _}
-import io.iohk.ethereum.consensus.validators.std.StdSignedTransactionValidator
+import io.iohk.ethereum.consensus.validators.{SignedTransactionError, SignedTransactionValid}
 import io.iohk.ethereum.crypto.ECDSASignature
 import io.iohk.ethereum.domain._
 import io.iohk.ethereum.utils.Config
@@ -15,7 +12,10 @@ import org.bouncycastle.util.encoders.Hex
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-class SignedTransactionValidatorSpec extends AnyFlatSpec with Matchers {
+import java.math.BigInteger
+import java.security.SecureRandom
+
+class StdSignedTransactionValidatorSpec extends AnyFlatSpec with Matchers {
 
   val blockchainConfig = Config.blockchains.blockchainConfig
 

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/CheckpointingJRCSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/CheckpointingJRCSpec.scala
@@ -41,7 +41,8 @@ class CheckpointingJRCSpec
       "block" -> JObject(
         "hash" -> JString("0x" + ByteStringUtils.hash2string(block.hash)),
         "number" -> JInt(block.number)
-    ))
+      )
+    )
 
     val response = jsonRpcController.handleRequest(request).runSyncUnsafe()
     response should haveResult(expectedResult)

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/CheckpointingServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/CheckpointingServiceSpec.scala
@@ -96,7 +96,9 @@ class CheckpointingServiceSpec
       val expectedResponse = GetLatestBlockResponse(None)
 
       (blockchain.getBestBlockNumber _).expects().returning(bestBlockNum)
-      (blockchain.getBlockHeaderByHash _).expects(hash).returning(Some(previousCheckpoint.header.copy(number = bestBlockNum)))
+      (blockchain.getBlockHeaderByHash _)
+        .expects(hash)
+        .returning(Some(previousCheckpoint.header.copy(number = bestBlockNum)))
       (blockchain.getBlockByNumber _).expects(*).returning(Some(previousCheckpoint))
       val result = service.getLatestBlock(request)
 

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerFixture.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerFixture.scala
@@ -6,7 +6,7 @@ import akka.util.ByteString
 import io.iohk.ethereum.blockchain.sync.EphemBlockchainTestSetup
 import io.iohk.ethereum.consensus.blocks.CheckpointBlockGenerator
 import io.iohk.ethereum.consensus.ethash.blocks.EthashBlockGenerator
-import io.iohk.ethereum.consensus.ethash.validators.ValidatorsExecutor
+import io.iohk.ethereum.consensus.validators.std.ValidatorsExecutor
 import io.iohk.ethereum.consensus.{ConsensusConfigs, TestConsensus}
 import io.iohk.ethereum.crypto.ECDSASignature
 import io.iohk.ethereum.db.storage.AppStateStorage

--- a/src/test/scala/io/iohk/ethereum/ledger/LedgerTestSetup.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/LedgerTestSetup.scala
@@ -5,8 +5,9 @@ import akka.util.ByteString.{empty => bEmpty}
 import cats.data.NonEmptyList
 import io.iohk.ethereum.blockchain.sync.EphemBlockchainTestSetup
 import io.iohk.ethereum.consensus.blocks.CheckpointBlockGenerator
-import io.iohk.ethereum.consensus.ethash.validators.{OmmersValidator, StdOmmersValidator}
+import io.iohk.ethereum.consensus.ethash.validators.OmmersValidator
 import io.iohk.ethereum.consensus.validators.BlockHeaderError.HeaderParentNotFoundError
+import io.iohk.ethereum.consensus.validators.std.StdOmmersValidator
 import io.iohk.ethereum.consensus.validators.{BlockHeaderError, BlockHeaderValid, BlockHeaderValidator, Validators}
 import io.iohk.ethereum.consensus.{GetBlockHeaderByHash, GetNBlocksBack, TestConsensus}
 import io.iohk.ethereum.crypto.{generateKeyPair, kec256}
@@ -434,7 +435,7 @@ trait OmmersTestSetup extends EphemBlockchain {
         getBlockHeaderByHash: GetBlockHeaderByHash,
         getNBlocksBack: GetNBlocksBack
     ) =>
-      new StdOmmersValidator(blockchainConfig, blockHeaderValidator)
+      new StdOmmersValidator(blockHeaderValidator)
         .validate(parentHash, blockNumber, ommers, getBlockHeaderByHash, getNBlocksBack)
   }
 

--- a/src/test/scala/io/iohk/ethereum/network/handshaker/EtcHandshakerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/network/handshaker/EtcHandshakerSpec.scala
@@ -269,8 +269,7 @@ class EtcHandshakerSpec extends AnyFlatSpec with Matchers {
     )
     lazy val nodeStatusHolder = new AtomicReference(nodeStatus)
 
-    class MockEtcHandshakerConfiguration(pv: Int = Config.Network.protocolVersion)
-        extends EtcHandshakerConfiguration {
+    class MockEtcHandshakerConfiguration(pv: Int = Config.Network.protocolVersion) extends EtcHandshakerConfiguration {
       override val forkResolverOpt: Option[ForkResolver] = None
       override val nodeStatusHolder: AtomicReference[NodeStatus] = TestSetup.this.nodeStatusHolder
       override val peerConfiguration: PeerConfiguration = Config.Network.peer


### PR DESCRIPTION
# Description
In testnet we observed the following error message `Block import error BlockImportFailed(OmmersAncestorsError)`, but looking at the code it was not possible to know exactly why the validation failed.
The goal of this PR is to allow for better debugging in case we observe the same error message again.

# Proposed Solution

Replaced OmmersAncestorsError by more specific OmmerIsAncestorError and OmmerParentIsNotAncestorError.
Renamed OmmersNotValidError to OmmersHeaderError and added the underlying reason for failure 
Refactored validateOmmersAncestors method.
Refactored validateOmmersHeaders method to not hide the underlying failing reason.
Reorganized some packages because some classes were not in the correct package and/or the Spec was not in the correct package. Renamed some specs to better reflect the class being tested
Raised the log level of some logs in BlockFetcher because there are barely any logs this actor when debug logs are disabled

# Testing
Connected to Sagano with FastSync off and RegularSync is importing blocks properly
