### PR TITLE
[ETCM-685] Improve pivot block selection

### DIFF
--- a/src/main/resources/conf/base.conf
+++ b/src/main/resources/conf/base.conf
@@ -473,6 +473,13 @@ mantis {
     # Maximum number of retries performed by fast sync when the master peer sends invalid block headers.
     # On reaching this limit, it will perform branch resolving.
     fast-sync-max-batch-retries = 5
+
+    # If the expected pivot block cannot be confirmed from `min-peers-to-choose-pivot-block`,
+    # the pivot block number is pushed back by the follwing number of blocks and the confirmation process repeats.
+    pivot-block-number-reset-delta = 50
+
+    # Max number of times a pivot block is checked against available best peers before the whole process is restarted.
+    max-pivot-block-failures-count = 5
   }
 
   pruning {

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/fast/PivotBlockSelector.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/fast/PivotBlockSelector.scala
@@ -35,13 +35,23 @@ class PivotBlockSelector(
   import PivotBlockSelector._
   import syncConfig._
 
+  private var pivotBlockRetryCount = 0
+
+  //TODO make these config params
+  private val pivotBlockNumberResetDelta: BigInt = 50
+  private val maxPivotBlockFailuresCount = 3
+
   override def receive: Receive = idle
 
   private def idle: Receive = handlePeerListMessages orElse { case SelectPivotBlock =>
-    val election @ ElectionDetails(correctPeers, expectedPivotBlock) = collectVoters
+    val electionDetails = collectVoters()
+    startPivotBlockSelection(electionDetails)
+  }
 
-    if (election.isEnoughVoters(minPeersToChoosePivotBlock)) {
+  private def startPivotBlockSelection(election: ElectionDetails): Unit = {
+    val ElectionDetails(correctPeers, currentBestBlockNumber, expectedPivotBlock) = election
 
+    if (election.hasEnoughVoters(minPeersToChoosePivotBlock)) {
       val (peersToAsk, waitingPeers) = correctPeers.splitAt(minPeersToChoosePivotBlock + peersToChoosePivotBlockMargin)
 
       log.info(
@@ -64,17 +74,28 @@ class PivotBlockSelector(
       )
     } else {
       log.info(
-        "Cannot pick pivot block. Need at least {} peers, but there are only {} which meet the criteria ({} all available at the moment). Retrying in {}",
+        "Cannot pick pivot block. Need at least {} peers, but there are only {} which meet the criteria " +
+          "({} all available at the moment). Retrying with current best block number [{}]",
         minPeersToChoosePivotBlock,
         correctPeers.size,
         peersToDownloadFrom.size,
-        startRetryInterval
+        currentBestBlockNumber
       )
+      retryPivotBlockSelection(currentBestBlockNumber)
+    }
+  }
+
+  private def retryPivotBlockSelection(pivotBlockNumber: BigInt): Unit = {
+    pivotBlockRetryCount += 1
+    if (pivotBlockRetryCount <= maxPivotBlockFailuresCount) {
+      val electionDetails = collectVoters(Some(pivotBlockNumber))
+      startPivotBlockSelection(electionDetails)
+    } else {
       scheduleRetry(startRetryInterval)
     }
   }
 
-  def runningPivotBlockElection(
+  private def runningPivotBlockElection(
       peersToAsk: Set[PeerId],
       waitingPeers: List[PeerId],
       pivotBlockNumber: BigInt,
@@ -85,10 +106,7 @@ class PivotBlockSelector(
       case MessageFromPeer(blockHeaders: BlockHeaders, peerId) =>
         peerEventBus ! Unsubscribe(MessageClassifier(Set(Codes.BlockHeadersCode), PeerSelector.WithId(peerId)))
         val updatedPeersToAsk = peersToAsk - peerId
-        val targetBlockHeaderOpt =
-          if (blockHeaders.headers.size != 1) None
-          else
-            blockHeaders.headers.find(header => header.number == pivotBlockNumber)
+        val targetBlockHeaderOpt = blockHeaders.headers.find(header => header.number == pivotBlockNumber)
         targetBlockHeaderOpt match {
           case Some(targetBlockHeader) =>
             val newValue =
@@ -159,6 +177,7 @@ class PivotBlockSelector(
     peersLeft + bestHeaderVotes >= minPeersToChoosePivotBlock
 
   private def scheduleRetry(interval: FiniteDuration): Unit = {
+    pivotBlockRetryCount = 0
     scheduler.scheduleOnce(interval, self, SelectPivotBlock)
     context become idle
   }
@@ -178,7 +197,7 @@ class PivotBlockSelector(
     )
   }
 
-  private def collectVoters: ElectionDetails = {
+  private def collectVoters(previousBestBlockNumber: Option[BigInt] = None): ElectionDetails = {
     val peersUsedToChooseTarget = peersToDownloadFrom.collect {
       case (_, PeerWithInfo(peer, PeerInfo(_, _, true, maxBlockNumber, _))) =>
         (peer, maxBlockNumber)
@@ -188,12 +207,18 @@ class PivotBlockSelector(
     val bestPeerBestBlockNumber = peersSortedByBestNumber.headOption
       .map { case (_, bestPeerBestBlockNumber) => bestPeerBestBlockNumber }
       .getOrElse(BigInt(0))
-    val expectedPivotBlock = (bestPeerBestBlockNumber - syncConfig.pivotBlockOffset).max(0)
+
+    val currentBestBlockNumber: BigInt =
+      previousBestBlockNumber
+        .map(_ - pivotBlockNumberResetDelta)
+        .getOrElse(bestPeerBestBlockNumber)
+
+    val expectedPivotBlock = (currentBestBlockNumber - syncConfig.pivotBlockOffset).max(0)
     val correctPeers = peersSortedByBestNumber
       .takeWhile { case (_, number) => number >= expectedPivotBlock }
       .map { case (peer, _) => peer }
 
-    ElectionDetails(correctPeers, expectedPivotBlock)
+    ElectionDetails(correctPeers, currentBestBlockNumber, expectedPivotBlock)
   }
 }
 
@@ -209,7 +234,7 @@ object PivotBlockSelector {
     Props(new PivotBlockSelector(etcPeerManager: ActorRef, peerEventBus, syncConfig, scheduler, fastSync, blacklist))
 
   case object SelectPivotBlock
-  case class Result(targetBlockHeader: BlockHeader)
+  final case class Result(targetBlockHeader: BlockHeader)
 
   case object ElectionPivotBlockTimeout
 
@@ -223,7 +248,11 @@ object PivotBlockSelector {
     }
   }
 
-  case class ElectionDetails(participants: List[Peer], expectedPivotBlock: BigInt) {
-    def isEnoughVoters(minNumberOfVoters: Int): Boolean = participants.size >= minNumberOfVoters
+  final case class ElectionDetails(
+      participants: List[Peer],
+      currentBestBlockNumber: BigInt,
+      expectedPivotBlock: BigInt
+  ) {
+    def hasEnoughVoters(minNumberOfVoters: Int): Boolean = participants.size >= minNumberOfVoters
   }
 }

--- a/src/main/scala/io/iohk/ethereum/utils/Config.scala
+++ b/src/main/scala/io/iohk/ethereum/utils/Config.scala
@@ -135,7 +135,9 @@ object Config {
       stateSyncPersistBatchSize: Int,
       pivotBlockReScheduleInterval: FiniteDuration,
       maxPivotBlockAge: Int,
-      fastSyncMaxBatchRetries: Int
+      fastSyncMaxBatchRetries: Int,
+      pivotBlockNumberResetDelta: Int,
+      maxPivotBlockFailuresCount: Int
   )
 
   object SyncConfig {
@@ -179,7 +181,9 @@ object Config {
         stateSyncPersistBatchSize = syncConfig.getInt("state-sync-persist-batch-size"),
         pivotBlockReScheduleInterval = syncConfig.getDuration("pivot-block-reschedule-interval").toMillis.millis,
         maxPivotBlockAge = syncConfig.getInt("max-pivot-block-age"),
-        fastSyncMaxBatchRetries = syncConfig.getInt("fast-sync-max-batch-retries")
+        fastSyncMaxBatchRetries = syncConfig.getInt("fast-sync-max-batch-retries"),
+        pivotBlockNumberResetDelta = syncConfig.getInt("pivot-block-number-reset-delta"),
+        maxPivotBlockFailuresCount = syncConfig.getInt("max-pivot-block-failures-count")
       )
     }
   }

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/PivotBlockSelectorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/PivotBlockSelectorSpec.scala
@@ -418,6 +418,48 @@ class PivotBlockSelectorSpec
     peerMessageBus.expectMsg(Unsubscribe())
   }
 
+  it should "retry pivot block election with fallback to lower peer numbers" in new TestSetup {
+
+    override val minPeersToChoosePivotBlock = 2
+    override val peersToChoosePivotBlockMargin = 1
+
+    updateHandshakedPeers(
+      HandshakedPeers(
+        allPeers
+          .updated(peer1, allPeers(peer1).copy(maxBlockNumber = 2000))
+          .updated(peer2, allPeers(peer2).copy(maxBlockNumber = 800))
+          .updated(peer3, allPeers(peer3).copy(maxBlockNumber = 900))
+          .updated(peer4, allPeers(peer4).copy(maxBlockNumber = 1400))
+      )
+    )
+
+    pivotBlockSelector ! SelectPivotBlock
+
+    peerMessageBus.expectMsgAllOf(
+      Subscribe(MessageClassifier(Set(Codes.BlockHeadersCode), PeerSelector.WithId(peer1.id))),
+      Subscribe(MessageClassifier(Set(Codes.BlockHeadersCode), PeerSelector.WithId(peer4.id)))
+    )
+
+    etcPeerManager.expectMsgAllOf(
+      EtcPeerManagerActor.SendMessage(GetBlockHeaders(Left(1400), 1, 0, reverse = false), peer1.id),
+      EtcPeerManagerActor.SendMessage(GetBlockHeaders(Left(1400), 1, 0, reverse = false), peer4.id)
+    )
+    etcPeerManager.expectNoMessage()
+
+    // Collecting pivot block (for voting)
+    pivotBlockSelector ! MessageFromPeer(BlockHeaders(Seq(baseBlockHeader.copy(number = 1400))), peer1.id)
+    pivotBlockSelector ! MessageFromPeer(BlockHeaders(Seq(baseBlockHeader.copy(number = 1400))), peer4.id)
+
+    peerMessageBus.expectMsgAllOf(
+      Unsubscribe(MessageClassifier(Set(Codes.BlockHeadersCode), PeerSelector.WithId(peer1.id))),
+      Unsubscribe(MessageClassifier(Set(Codes.BlockHeadersCode), PeerSelector.WithId(peer4.id))),
+      Unsubscribe()
+    )
+    peerMessageBus.expectNoMessage()
+
+    fastSync.expectMsg(Result(baseBlockHeader.copy(number = 1400)))
+  }
+
   class TestSetup extends TestSyncConfig {
 
     val blacklist: Blacklist = CacheBasedBlacklist.empty(100)

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/TestSyncConfig.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/TestSyncConfig.scala
@@ -44,7 +44,9 @@ trait TestSyncConfig extends SyncConfigBuilder {
     stateSyncPersistBatchSize = 1000,
     pivotBlockReScheduleInterval = 1.second,
     maxPivotBlockAge = 96,
-    fastSyncMaxBatchRetries = 3
+    fastSyncMaxBatchRetries = 3,
+    pivotBlockNumberResetDelta = 50,
+    maxPivotBlockFailuresCount = 3
   )
 
   override lazy val syncConfig: SyncConfig = defaultSyncConfig


### PR DESCRIPTION
# Description

If Mantis connects with a peer with the best block number bigger than other nodes (the difference bigger than `pivotBlockOffset`) it will wait for a minimum number of voters infinitely and never choose pivot block and will never start to sync.

# Proposed Solution

If a particular pivot block cannot be confirmed,
 * the pivot block number is pushed back by a configured amount of blocks and the confirmation process repeats.
 * if a maximum number of retries is reached, the task fails and the whole process is restarted.

# Important Changes Introduced

`PivotBlockSelector.scala`

# Testing

Unit tests were added.

