### PR TITLE
ETCM-720: Added tests for mining block on beginning or end of epoch

### DIFF
--- a/src/test/scala/io/iohk/ethereum/consensus/ethash/MinerSpecSetup.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/ethash/MinerSpecSetup.scala
@@ -80,7 +80,7 @@ abstract class MinerSpecSetup(implicit system: ActorSystem) extends ScenarioSetu
         receiptsRoot = parentHeader.receiptsRoot,
         logsBloom = parentHeader.logsBloom,
         difficulty = difficultyCalc.calculateDifficulty(1, blockForMiningTimestamp, parentHeader),
-        number = BigInt(1),
+        number = parentHeader.number + 1,
         gasLimit = calculateGasLimit(UInt256(parentHeader.gasLimit)),
         gasUsed = BigInt(0),
         unixTimestamp = blockForMiningTimestamp,


### PR DESCRIPTION
# Description

Added tests for mining first and last block of an epoch.

# Testing

In order to validate my changes, I have temporarily reverted @pbvie's changes and the test were failing when generating the last block of the epoch. With the new changes mining tests are passing.

Additional note: I noticed that in the `build.sbt` miner tests (`EthashMinerSpec` ) are excluded. I have changed this during development, but didn't include it in the PR.



