### PR TITLE
ETCM-389 Move checkpoint creation to the checkpoint service

### DIFF
--- a/src/it/scala/io/iohk/ethereum/ledger/BlockImporterItSpec.scala
+++ b/src/it/scala/io/iohk/ethereum/ledger/BlockImporterItSpec.scala
@@ -98,7 +98,6 @@ class BlockImporterItSpec
       ommersPoolProbe.ref,
       broadcasterProbe.ref,
       pendingTransactionsManagerProbe.ref,
-      checkpointBlockGenerator,
       supervisor.ref
     )
   )
@@ -143,7 +142,6 @@ class BlockImporterItSpec
         ommersPoolProbe.ref,
         broadcasterProbe.ref,
         pendingTransactionsManagerProbe.ref,
-        checkpointBlockGenerator,
         supervisor.ref
       )
     )
@@ -234,9 +232,8 @@ class BlockImporterItSpec
       Seq(crypto.generateKeyPair(secureRandom)),
       newBlock5.hash
     )
-    blockImporter ! NewCheckpoint(newBlock5.hash, signatures)
-
     val checkpointBlock = checkpointBlockGenerator.generate(newBlock5, Checkpoint(signatures))
+    blockImporter ! NewCheckpoint(checkpointBlock)
 
     eventually { Thread.sleep(1000); blockchain.getBestBlock().get shouldEqual checkpointBlock }
     eventually {

--- a/src/it/scala/io/iohk/ethereum/sync/util/RegularSyncItSpecUtils.scala
+++ b/src/it/scala/io/iohk/ethereum/sync/util/RegularSyncItSpecUtils.scala
@@ -95,7 +95,6 @@ object RegularSyncItSpecUtils {
         ommersPool,
         broadcasterRef,
         pendingTransactionsManager,
-        checkpointBlockGenerator,
         regularSync
       ))
 
@@ -110,7 +109,6 @@ object RegularSyncItSpecUtils {
         testSyncConfig,
         ommersPool,
         pendingTransactionsManager,
-        checkpointBlockGenerator,
         system.scheduler
       )
     )
@@ -170,7 +168,8 @@ object RegularSyncItSpecUtils {
         Seq(crypto.generateKeyPair(secureRandom)),
         parent.hash
       )
-      regularSync ! NewCheckpoint(parent.header.hash, signatures)
+      val checkpoint = checkpointBlockGenerator.generate(parent, Checkpoint(signatures))
+      regularSync ! NewCheckpoint(checkpoint)
     }
 
     def getCheckpointFromPeer(checkpoint: Block, peerId: PeerId): Task[Unit] = Task {

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/SyncController.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/SyncController.scala
@@ -3,7 +3,6 @@ package io.iohk.ethereum.blockchain.sync
 import akka.actor.{Actor, ActorLogging, ActorRef, PoisonPill, Props, Scheduler}
 import io.iohk.ethereum.blockchain.sync.fast.FastSync
 import io.iohk.ethereum.blockchain.sync.regular.RegularSync
-import io.iohk.ethereum.consensus.blocks.CheckpointBlockGenerator
 import io.iohk.ethereum.consensus.validators.Validators
 import io.iohk.ethereum.db.storage.{AppStateStorage, FastSyncStateStorage}
 import io.iohk.ethereum.domain.Blockchain
@@ -18,7 +17,6 @@ class SyncController(
     validators: Validators,
     peerEventBus: ActorRef,
     pendingTransactionsManager: ActorRef,
-    checkpointBlockGenerator: CheckpointBlockGenerator,
     ommersPool: ActorRef,
     etcPeerManager: ActorRef,
     blacklist: Blacklist,
@@ -106,7 +104,6 @@ class SyncController(
         syncConfig,
         ommersPool,
         pendingTransactionsManager,
-        checkpointBlockGenerator,
         scheduler
       ),
       "regular-sync"
@@ -127,7 +124,6 @@ object SyncController {
       validators: Validators,
       peerEventBus: ActorRef,
       pendingTransactionsManager: ActorRef,
-      checkpointBlockGenerator: CheckpointBlockGenerator,
       ommersPool: ActorRef,
       etcPeerManager: ActorRef,
       blacklist: Blacklist,
@@ -142,7 +138,6 @@ object SyncController {
         validators,
         peerEventBus,
         pendingTransactionsManager,
-        checkpointBlockGenerator,
         ommersPool,
         etcPeerManager,
         blacklist,

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/regular/BlockFetcher.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/regular/BlockFetcher.scala
@@ -268,7 +268,7 @@ class BlockFetcher(
         fetchBlocks(newState)
       case Left(_) if block.number <= state.knownTop =>
         log.debug(
-          s"Checkpoint block ${ByteStringUtils.hash2string(blockHash)} not fit into queues - clearing the queues and setting possible new top"
+          s"Checkpoint block ${ByteStringUtils.hash2string(blockHash)} not fit into queues - clearing the queues and setting new top"
         )
         val newState = state
           .clearQueues()

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/regular/BlockImporter.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/regular/BlockImporter.scala
@@ -66,14 +66,26 @@ class BlockImporter(
       importBlocks(blocks, DefaultBlockImport)(state)
 
     case MinedBlock(block) if !state.importing =>
-      importBlock(block, new MinedBlockImportMessages(block), MinedBlockImport, false, true)(state)
+      importBlock(
+        block,
+        new MinedBlockImportMessages(block),
+        MinedBlockImport,
+        informFetcherOnFail = false,
+        internally = true
+      )(state)
 
     //We don't want to lose a checkpoint
     case nc @ NewCheckpoint(_) if state.importing =>
       context.system.scheduler.scheduleOnce(1.second, self, nc)
 
     case NewCheckpoint(block) if !state.importing =>
-      importBlock(block, new CheckpointBlockImportMessages(block), CheckpointBlockImport, false, true)(state)
+      importBlock(
+        block,
+        new CheckpointBlockImportMessages(block),
+        CheckpointBlockImport,
+        informFetcherOnFail = false,
+        internally = true
+      )(state)
 
     case ImportNewBlock(block, peerId) if state.isOnTop && !state.importing =>
       importBlock(

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/regular/BlockImporter.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/regular/BlockImporter.scala
@@ -73,18 +73,17 @@ class BlockImporter(
           false,
           true)(state)
 
-    case nc @ NewCheckpoint(block) =>
-      if (state.importing) {
-        //We don't want to lose a checkpoint
+    //We don't want to lose a checkpoint
+    case nc @ NewCheckpoint(_) if state.importing =>
         context.system.scheduler.scheduleOnce(1.second, self, nc)
-      } else {
-        importBlock(
-          block,
-          new CheckpointBlockImportMessages(block),
-          CheckpointBlockImport,
-          false,
-          true)(state)
-      }
+
+    case NewCheckpoint(block) if !state.importing =>
+      importBlock(
+        block,
+        new CheckpointBlockImportMessages(block),
+        CheckpointBlockImport,
+        false,
+        true)(state)
 
     case ImportNewBlock(block, peerId) if state.isOnTop && !state.importing =>
       importBlock(

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/regular/BlockImporter.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/regular/BlockImporter.scala
@@ -66,24 +66,14 @@ class BlockImporter(
       importBlocks(blocks, DefaultBlockImport)(state)
 
     case MinedBlock(block) if !state.importing =>
-        importBlock(
-          block,
-          new MinedBlockImportMessages(block),
-          MinedBlockImport,
-          false,
-          true)(state)
+      importBlock(block, new MinedBlockImportMessages(block), MinedBlockImport, false, true)(state)
 
     //We don't want to lose a checkpoint
     case nc @ NewCheckpoint(_) if state.importing =>
-        context.system.scheduler.scheduleOnce(1.second, self, nc)
+      context.system.scheduler.scheduleOnce(1.second, self, nc)
 
     case NewCheckpoint(block) if !state.importing =>
-      importBlock(
-        block,
-        new CheckpointBlockImportMessages(block),
-        CheckpointBlockImport,
-        false,
-        true)(state)
+      importBlock(block, new CheckpointBlockImportMessages(block), CheckpointBlockImport, false, true)(state)
 
     case ImportNewBlock(block, peerId) if state.isOnTop && !state.importing =>
       importBlock(

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/CheckpointingService.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/CheckpointingService.scala
@@ -3,13 +3,17 @@ package io.iohk.ethereum.jsonrpc
 import akka.actor.ActorRef
 import akka.util.ByteString
 import io.iohk.ethereum.blockchain.sync.regular.RegularSync.NewCheckpoint
+import io.iohk.ethereum.consensus.blocks.CheckpointBlockGenerator
 import io.iohk.ethereum.crypto.ECDSASignature
-import io.iohk.ethereum.domain.Blockchain
-import io.iohk.ethereum.utils.Logger
+import io.iohk.ethereum.domain.{Block, Blockchain, Checkpoint}
+import io.iohk.ethereum.ledger.Ledger
+import io.iohk.ethereum.utils.{ByteStringUtils, Logger}
 import monix.eval.Task
 
 class CheckpointingService(
     blockchain: Blockchain,
+    ledger: Ledger,
+    checkpointBlockGenerator: CheckpointBlockGenerator,
     syncController: ActorRef
 ) extends Logger {
 
@@ -40,7 +44,16 @@ class CheckpointingService(
   }
 
   def pushCheckpoint(req: PushCheckpointRequest): ServiceResponse[PushCheckpointResponse] = Task {
-    syncController ! NewCheckpoint(req.hash, req.signatures)
+    val parentHash = req.hash
+
+    ledger.getBlockByHash(parentHash) match {
+      case Some(parent) =>
+        val checkpointBlock: Block = checkpointBlockGenerator.generate(parent, Checkpoint(req.signatures))
+        syncController ! NewCheckpoint(checkpointBlock)
+
+      case None =>
+        log.error(s"Could not find parent (${ByteStringUtils.hash2string(parentHash)}) for new checkpoint block")
+    }
     Right(PushCheckpointResponse())
   }
 }

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/QAService.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/QAService.scala
@@ -50,7 +50,8 @@ class QAService(
     hash match {
       case Some(hashValue) =>
         Task {
-          val parent = blockchain.getBlockByHash(hashValue).orElse(blockchain.getBestBlock()).getOrElse(blockchain.genesisBlock)
+          val parent =
+            blockchain.getBlockByHash(hashValue).orElse(blockchain.getBestBlock()).getOrElse(blockchain.genesisBlock)
           val checkpoint = generateCheckpoint(hashValue, req.privateKeys)
           val checkpointBlock: Block = checkpointBlockGenerator.generate(parent, checkpoint)
           syncController ! NewCheckpoint(checkpointBlock)

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/QAService.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/QAService.scala
@@ -6,12 +6,13 @@ import cats.implicits._
 import enumeratum._
 import io.iohk.ethereum.blockchain.sync.regular.RegularSync.NewCheckpoint
 import io.iohk.ethereum.consensus._
+import io.iohk.ethereum.consensus.blocks.CheckpointBlockGenerator
 import io.iohk.ethereum.consensus.ethash.MinerResponses._
 import io.iohk.ethereum.consensus.ethash.MockedMinerProtocol.MineBlocks
 import io.iohk.ethereum.consensus.ethash.{MinerResponse, MinerResponses}
 import io.iohk.ethereum.crypto
 import io.iohk.ethereum.crypto.ECDSASignature
-import io.iohk.ethereum.domain.{Blockchain, Checkpoint}
+import io.iohk.ethereum.domain.{Block, Blockchain, Checkpoint}
 import io.iohk.ethereum.jsonrpc.QAService.MineBlocksResponse.MinerResponseType
 import io.iohk.ethereum.jsonrpc.QAService._
 import io.iohk.ethereum.utils.{BlockchainConfig, Logger}
@@ -21,6 +22,7 @@ import mouse.all._
 class QAService(
     consensus: Consensus,
     blockchain: Blockchain,
+    checkpointBlockGenerator: CheckpointBlockGenerator,
     blockchainConfig: BlockchainConfig,
     syncController: ActorRef
 ) extends Logger {
@@ -48,8 +50,10 @@ class QAService(
     hash match {
       case Some(hashValue) =>
         Task {
+          val parent = blockchain.getBlockByHash(hashValue).orElse(blockchain.getBestBlock()).getOrElse(blockchain.genesisBlock)
           val checkpoint = generateCheckpoint(hashValue, req.privateKeys)
-          syncController ! NewCheckpoint(hashValue, checkpoint.signatures)
+          val checkpointBlock: Block = checkpointBlockGenerator.generate(parent, checkpoint)
+          syncController ! NewCheckpoint(checkpointBlock)
           Right(GenerateCheckpointResponse(checkpoint))
         }
       case None => Task.now(Left(JsonRpcError.BlockNotFound))

--- a/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
@@ -472,23 +472,30 @@ trait PersonalServiceBuilder {
 }
 
 trait QaServiceBuilder {
-  self: ConsensusBuilder with SyncControllerBuilder with BlockchainBuilder with BlockchainConfigBuilder =>
+  self: ConsensusBuilder
+    with SyncControllerBuilder
+    with BlockchainBuilder
+    with BlockchainConfigBuilder
+    with CheckpointBlockGeneratorBuilder =>
 
   lazy val qaService =
     new QAService(
       consensus,
       blockchain,
+      checkpointBlockGenerator,
       blockchainConfig,
       syncController
     )
 }
 
 trait CheckpointingServiceBuilder {
-  self: BlockchainBuilder with SyncControllerBuilder =>
+  self: BlockchainBuilder with SyncControllerBuilder with LedgerBuilder with CheckpointBlockGeneratorBuilder =>
 
   lazy val checkpointingService =
     new CheckpointingService(
       blockchain,
+      ledger,
+      checkpointBlockGenerator,
       syncController
     )
 }
@@ -657,7 +664,6 @@ trait SyncControllerBuilder {
     with LedgerBuilder
     with PeerEventBusBuilder
     with PendingTransactionsManagerBuilder
-    with CheckpointBlockGeneratorBuilder
     with OmmersPoolBuilder
     with EtcPeerManagerActorBuilder
     with SyncConfigBuilder
@@ -674,7 +680,6 @@ trait SyncControllerBuilder {
       consensus.validators,
       peerEventBus,
       pendingTransactionsManager,
-      checkpointBlockGenerator,
       ommersPool,
       etcPeerManager,
       blacklist,

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/SyncControllerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/SyncControllerSpec.scala
@@ -6,7 +6,6 @@ import akka.testkit.{ExplicitlyTriggeredScheduler, TestActorRef, TestProbe}
 import akka.util.ByteString
 import com.typesafe.config.ConfigFactory
 import io.iohk.ethereum.blockchain.sync.fast.FastSync.SyncState
-import io.iohk.ethereum.consensus.blocks.CheckpointBlockGenerator
 import io.iohk.ethereum.consensus.validators.BlockHeaderError.{HeaderParentNotFoundError, HeaderPoWError}
 import io.iohk.ethereum.consensus.validators.{BlockHeaderError, BlockHeaderValid, BlockHeaderValidator, Validators}
 import io.iohk.ethereum.consensus.{GetBlockHeaderByHash, TestConsensus}
@@ -508,8 +507,6 @@ class SyncControllerSpec
     val peerMessageBus = TestProbe()
     val pendingTransactionsManager = TestProbe()
 
-    val checkpointBlockGenerator = new CheckpointBlockGenerator()
-
     val ommersPool = TestProbe()
 
     val blacklist: CacheBasedBlacklist = CacheBasedBlacklist.empty(100)
@@ -541,7 +538,6 @@ class SyncControllerSpec
           validators,
           peerMessageBus.ref,
           pendingTransactionsManager.ref,
-          checkpointBlockGenerator,
           ommersPool.ref,
           etcPeerManager.ref,
           blacklist,
@@ -777,7 +773,7 @@ class SyncControllerSpec
     private def testScheduler = system.scheduler.asInstanceOf[ExplicitlyTriggeredScheduler]
 
     def littleTimePasses() =
-      testScheduler.timePasses(100.millis)
+      testScheduler.timePasses(300.millis)
 
     def someTimePasses() =
       testScheduler.timePasses(3000.millis)

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/regular/RegularSyncFixtures.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/regular/RegularSyncFixtures.scala
@@ -72,7 +72,6 @@ trait RegularSyncFixtures { self: Matchers with AsyncMockFactory =>
           syncConfig,
           ommersPool.ref,
           pendingTransactionsManager.ref,
-          checkpointBlockGenerator,
           system.scheduler
         )
         .withDispatcher("akka.actor.default-dispatcher")

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/regular/RegularSyncSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/regular/RegularSyncSpec.scala
@@ -535,8 +535,8 @@ class RegularSyncSpec
 
         ledger.setImportResult(testBlocks(1), Task.now(BlockImportedToTop(Nil)))
 
-        val newCheckpointMsg = NewCheckpoint(block.hash, checkpoint.signatures)
         val checkpointBlock = checkpointBlockGenerator.generate(block, checkpoint)
+        val newCheckpointMsg = NewCheckpoint(checkpointBlock)
         ledger.setImportResult(checkpointBlock, Task.eval(BlockImportedToTop(Nil)))
 
         regularSync ! SyncProtocol.Start
@@ -561,8 +561,8 @@ class RegularSyncSpec
         ledger.setImportResult(parentBlock, Task.eval(BlockImportedToTop(Nil)))
         ledger.importBlock(parentBlock)(Scheduler.global)
 
-        val newCheckpointMsg = NewCheckpoint(parentBlock.hash, checkpoint.signatures)
         val checkpointBlock = checkpointBlockGenerator.generate(parentBlock, checkpoint)
+        val newCheckpointMsg = NewCheckpoint(checkpointBlock)
         ledger.setImportResult(
           checkpointBlock,
           // FIXME: lastCheckpointNumber == 0, refactor FakeLedger?


### PR DESCRIPTION
# Description

Checkpoint creation moved to a respective service, so checkpoints and mined blocks are handled uniformly 