### PR TITLE
[ETCM-631] Create peerId from node's public key

### DIFF
--- a/src/it/scala/io/iohk/ethereum/sync/FastSyncItSpec.scala
+++ b/src/it/scala/io/iohk/ethereum/sync/FastSyncItSpec.scala
@@ -230,7 +230,7 @@ class FastSyncItSpec extends FlatSpecBase with Matchers with BeforeAndAfterAll {
 
       _ <- peer1.connectToPeers(Set(peer2.node, peer3.node, peer4.node))
       _ <- peer1.startFastSync().delayExecution(50.milliseconds)
-      _ <- peer2.importBlocksUntil(1200)(IdentityUpdate).startAndForget
+      _ <- peer2.importBlocksUntil(1200)(IdentityUpdate)
       _ <- peer1.waitForFastSyncFinish()
     } yield {
       // Peer3 is blacklisted

--- a/src/it/scala/io/iohk/ethereum/sync/FastSyncItSpec.scala
+++ b/src/it/scala/io/iohk/ethereum/sync/FastSyncItSpec.scala
@@ -208,7 +208,7 @@ class FastSyncItSpec extends FlatSpecBase with Matchers with BeforeAndAfterAll {
       _ <- peer1.waitForFastSyncFinish()
     } yield {
       // Peer3 is blacklisted
-      val blacklistedPeer = PeerId(s"${peer3.node.addr.getHostAddress}:${peer3.node.tcpPort}")
+      val blacklistedPeer = PeerId(peer3.node.toUri.getUserInfo)
       val blacklistReason = peer1.blacklist.cache.getIfPresent(blacklistedPeer)
 
       assert(peer1.blacklist.isBlacklisted(blacklistedPeer))
@@ -234,7 +234,7 @@ class FastSyncItSpec extends FlatSpecBase with Matchers with BeforeAndAfterAll {
       _ <- peer1.waitForFastSyncFinish()
     } yield {
       // Peer3 is blacklisted
-      val blacklistedPeer = PeerId(s"${peer3.node.addr.getHostAddress}:${peer3.node.tcpPort}")
+      val blacklistedPeer = PeerId(peer3.node.toUri.getUserInfo)
       val blacklistReason = peer1.blacklist.cache.getIfPresent(blacklistedPeer)
 
       assert(peer1.blacklist.isBlacklisted(blacklistedPeer))

--- a/src/main/scala/io/iohk/ethereum/network/ConnectedPeers.scala
+++ b/src/main/scala/io/iohk/ethereum/network/ConnectedPeers.scala
@@ -58,12 +58,12 @@ case class ConnectedPeers(
   def promotePeerToHandshaked(peerAfterHandshake: Peer): ConnectedPeers = {
     if (peerAfterHandshake.incomingConnection)
       copy(
-        incomingPendingPeers = incomingPendingPeers - peerAfterHandshake.id,
+        incomingPendingPeers = incomingPendingPeers - PeerId.fromRef(peerAfterHandshake.ref),
         handshakedPeers = handshakedPeers + (peerAfterHandshake.id -> peerAfterHandshake)
       )
     else
       copy(
-        outgoingPendingPeers = outgoingPendingPeers - peerAfterHandshake.id,
+        outgoingPendingPeers = outgoingPendingPeers - PeerId.fromRef(peerAfterHandshake.ref),
         handshakedPeers = handshakedPeers + (peerAfterHandshake.id -> peerAfterHandshake)
       )
   }

--- a/src/main/scala/io/iohk/ethereum/network/Peer.scala
+++ b/src/main/scala/io/iohk/ethereum/network/Peer.scala
@@ -13,12 +13,10 @@ object PeerId {
 }
 
 final case class Peer(
+    id: PeerId,
     remoteAddress: InetSocketAddress,
     ref: ActorRef,
     incomingConnection: Boolean,
     nodeId: Option[ByteString] = None,
     createTimeMillis: Long = System.currentTimeMillis
-) {
-  // FIXME PeerId should be actual peerId i.e id derived form node public key
-  def id: PeerId = PeerId.fromRef(ref)
-}
+)

--- a/src/main/scala/io/iohk/ethereum/network/PeerManagerActor.scala
+++ b/src/main/scala/io/iohk/ethereum/network/PeerManagerActor.scala
@@ -310,7 +310,19 @@ class PeerManagerActor(
   ): (Peer, ConnectedPeers) = {
     val ref = peerFactory(context, address, incomingConnection)
     context watch ref
-    val pendingPeer = Peer(address, ref, incomingConnection, None, createTimeMillis = System.currentTimeMillis)
+
+    // The peerId is unknown for a pending peer, hence it is created from the PeerActor's path.
+    // Upon successful handshake, the pending peer is updated with the actual peerId derived from
+    // the Node's public key. See: ConnectedPeers#promotePeerToHandshaked
+    val pendingPeer =
+      Peer(
+        PeerId.fromRef(ref),
+        address,
+        ref,
+        incomingConnection,
+        nodeId = None,
+        createTimeMillis = System.currentTimeMillis
+      )
 
     val newConnectedPeers = connectedPeers.addNewPendingPeer(pendingPeer)
 

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/BlockBroadcastSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/BlockBroadcastSpec.scala
@@ -1,7 +1,6 @@
 package io.iohk.ethereum.blockchain.sync
 
 import java.net.InetSocketAddress
-
 import akka.actor.ActorSystem
 import akka.testkit.{TestKit, TestProbe}
 import io.iohk.ethereum.blockchain.sync.regular.BlockBroadcast
@@ -11,7 +10,7 @@ import io.iohk.ethereum.network.EtcPeerManagerActor.{PeerInfo, RemoteStatus}
 import io.iohk.ethereum.network.p2p.messages.PV62.NewBlockHashes
 import io.iohk.ethereum.network.p2p.messages.PV64.NewBlock
 import io.iohk.ethereum.network.p2p.messages.{CommonMessages, PV62, ProtocolVersions}
-import io.iohk.ethereum.network.{EtcPeerManagerActor, Peer}
+import io.iohk.ethereum.network.{EtcPeerManagerActor, Peer, PeerId}
 import io.iohk.ethereum.{Fixtures, WithActorSystemShutDown}
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
@@ -114,11 +113,11 @@ class BlockBroadcastSpec
       NewBlock(Block(firstHeader, BlockBody(Nil, Nil)), initialPeerInfo.chainWeight.increaseTotalDifficulty(-2))
 
     val peer2Probe = TestProbe()
-    val peer2 = Peer(new InetSocketAddress("127.0.0.1", 0), peer2Probe.ref, false)
+    val peer2 = Peer(PeerId("peer2"), new InetSocketAddress("127.0.0.1", 0), peer2Probe.ref, false)
     val peer3Probe = TestProbe()
-    val peer3 = Peer(new InetSocketAddress("127.0.0.1", 0), peer3Probe.ref, false)
+    val peer3 = Peer(PeerId("peer3"), new InetSocketAddress("127.0.0.1", 0), peer3Probe.ref, false)
     val peer4Probe = TestProbe()
-    val peer4 = Peer(new InetSocketAddress("127.0.0.1", 0), peer4Probe.ref, false)
+    val peer4 = Peer(PeerId("peer4"), new InetSocketAddress("127.0.0.1", 0), peer4Probe.ref, false)
 
     //when
     val peers = Seq(peer, peer2, peer3, peer4)
@@ -166,6 +165,6 @@ class BlockBroadcastSpec
     )
 
     val peerProbe = TestProbe()
-    val peer = Peer(new InetSocketAddress("127.0.0.1", 0), peerProbe.ref, false)
+    val peer = Peer(PeerId("peer"), new InetSocketAddress("127.0.0.1", 0), peerProbe.ref, false)
   }
 }

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/PeersClientSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/PeersClientSpec.scala
@@ -1,13 +1,12 @@
 package io.iohk.ethereum.blockchain.sync
 
 import java.net.InetSocketAddress
-
 import akka.actor.ActorSystem
 import akka.testkit.TestProbe
 import akka.util.ByteString
 import io.iohk.ethereum.domain.ChainWeight
 import io.iohk.ethereum.network.EtcPeerManagerActor.{PeerInfo, RemoteStatus}
-import io.iohk.ethereum.network.Peer
+import io.iohk.ethereum.network.{Peer, PeerId}
 import io.iohk.ethereum.network.p2p.messages.ProtocolVersions
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -59,9 +58,9 @@ class PeersClientSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyC
   object Peers {
     implicit val system = ActorSystem("PeersClient_System")
 
-    val peer1 = Peer(new InetSocketAddress("127.0.0.1", 1), TestProbe().ref, false)
-    val peer2 = Peer(new InetSocketAddress("127.0.0.1", 2), TestProbe().ref, false)
-    val peer3 = Peer(new InetSocketAddress("127.0.0.1", 3), TestProbe().ref, false)
+    val peer1 = Peer(PeerId("peer1"), new InetSocketAddress("127.0.0.1", 1), TestProbe().ref, false)
+    val peer2 = Peer(PeerId("peer2"), new InetSocketAddress("127.0.0.1", 2), TestProbe().ref, false)
+    val peer3 = Peer(PeerId("peer3"), new InetSocketAddress("127.0.0.1", 3), TestProbe().ref, false)
 
     private val peerStatus = RemoteStatus(
       protocolVersion = ProtocolVersions.PV63,

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/PivotBlockSelectorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/PivotBlockSelectorSpec.scala
@@ -1,7 +1,6 @@
 package io.iohk.ethereum.blockchain.sync
 
 import java.net.InetSocketAddress
-
 import akka.actor.{ActorRef, ActorSystem}
 import akka.testkit.{TestKit, TestProbe}
 import akka.util.ByteString
@@ -17,7 +16,7 @@ import io.iohk.ethereum.network.p2p.Message
 import io.iohk.ethereum.network.p2p.messages.CommonMessages.NewBlock
 import io.iohk.ethereum.network.p2p.messages.PV62._
 import io.iohk.ethereum.network.p2p.messages.{Codes, ProtocolVersions}
-import io.iohk.ethereum.network.{EtcPeerManagerActor, Peer}
+import io.iohk.ethereum.network.{EtcPeerManagerActor, Peer, PeerId}
 import io.iohk.ethereum.utils.Config.SyncConfig
 import io.iohk.ethereum.{Fixtures, WithActorSystemShutDown}
 import org.scalatest.BeforeAndAfter
@@ -565,10 +564,10 @@ class PivotBlockSelectorSpec
     val peer3TestProbe: TestProbe = TestProbe("peer3")(system)
     val peer4TestProbe: TestProbe = TestProbe("peer4")(system)
 
-    val peer1 = Peer(new InetSocketAddress("127.0.0.1", 0), peer1TestProbe.ref, false)
-    val peer2 = Peer(new InetSocketAddress("127.0.0.2", 0), peer2TestProbe.ref, false)
-    val peer3 = Peer(new InetSocketAddress("127.0.0.3", 0), peer3TestProbe.ref, false)
-    val peer4 = Peer(new InetSocketAddress("127.0.0.4", 0), peer4TestProbe.ref, false)
+    val peer1 = Peer(PeerId("peer1"), new InetSocketAddress("127.0.0.1", 0), peer1TestProbe.ref, false)
+    val peer2 = Peer(PeerId("peer2"), new InetSocketAddress("127.0.0.2", 0), peer2TestProbe.ref, false)
+    val peer3 = Peer(PeerId("peer3"), new InetSocketAddress("127.0.0.3", 0), peer3TestProbe.ref, false)
+    val peer4 = Peer(PeerId("peer4"), new InetSocketAddress("127.0.0.4", 0), peer4TestProbe.ref, false)
 
     val peer1Status =
       RemoteStatus(

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/StateSyncSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/StateSyncSpec.scala
@@ -166,7 +166,12 @@ class StateSyncSpec
 
     val peersMap = (1 to 8).map { i =>
       (
-        Peer(new InetSocketAddress("127.0.0.1", i), TestProbe(i.toString).ref, incomingConnection = false),
+        Peer(
+          PeerId(s"peer$i"),
+          new InetSocketAddress("127.0.0.1", i),
+          TestProbe(i.toString).ref,
+          incomingConnection = false
+        ),
         initialPeerInfo
       )
     }.toMap

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/SyncStateDownloaderStateSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/SyncStateDownloaderStateSpec.scala
@@ -1,7 +1,6 @@
 package io.iohk.ethereum.blockchain.sync
 
 import java.net.InetSocketAddress
-
 import akka.actor.ActorSystem
 import akka.testkit.{TestKit, TestProbe}
 import akka.util.ByteString
@@ -16,7 +15,7 @@ import io.iohk.ethereum.blockchain.sync.fast.SyncStateSchedulerActor.{
 }
 import io.iohk.ethereum.blockchain.sync.fast.DownloaderState
 import io.iohk.ethereum.crypto.kec256
-import io.iohk.ethereum.network.Peer
+import io.iohk.ethereum.network.{Peer, PeerId}
 import io.iohk.ethereum.network.p2p.messages.PV63.NodeData
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AnyFlatSpecLike
@@ -237,10 +236,10 @@ class SyncStateDownloaderStateSpec
     val ref4 = TestProbe().ref
 
     val initialState = DownloaderState(Map.empty, Map.empty)
-    val peer1 = Peer(new InetSocketAddress("127.0.0.1", 1), ref1, incomingConnection = false)
-    val peer2 = Peer(new InetSocketAddress("127.0.0.1", 2), ref2, incomingConnection = false)
-    val peer3 = Peer(new InetSocketAddress("127.0.0.1", 3), ref3, incomingConnection = false)
-    val notKnownPeer = Peer(new InetSocketAddress("127.0.0.1", 4), ref4, incomingConnection = false)
+    val peer1 = Peer(PeerId("peer1"), new InetSocketAddress("127.0.0.1", 1), ref1, incomingConnection = false)
+    val peer2 = Peer(PeerId("peer2"), new InetSocketAddress("127.0.0.1", 2), ref2, incomingConnection = false)
+    val peer3 = Peer(PeerId("peer3"), new InetSocketAddress("127.0.0.1", 3), ref3, incomingConnection = false)
+    val notKnownPeer = Peer(PeerId(""), new InetSocketAddress("127.0.0.1", 4), ref4, incomingConnection = false)
     val peers = NonEmptyList.fromListUnsafe(List(peer1, peer2, peer3))
     val potentialNodes = (1 to 100).map(i => ByteString(i)).toList
     val potentialNodesHashes = potentialNodes.map(node => kec256(node))

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/TestSyncPeers.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/TestSyncPeers.scala
@@ -1,12 +1,11 @@
 package io.iohk.ethereum.blockchain.sync
 import java.net.InetSocketAddress
-
 import akka.actor.ActorSystem
 import akka.testkit.TestProbe
 import akka.util.ByteString
 import io.iohk.ethereum.domain.ChainWeight
 import io.iohk.ethereum.network.EtcPeerManagerActor.{PeerInfo, RemoteStatus}
-import io.iohk.ethereum.network.Peer
+import io.iohk.ethereum.network.{Peer, PeerId}
 import io.iohk.ethereum.network.p2p.messages.ProtocolVersions
 
 trait TestSyncPeers { self: TestSyncConfig =>
@@ -16,9 +15,9 @@ trait TestSyncPeers { self: TestSyncConfig =>
   val peer2TestProbe: TestProbe = TestProbe("peer2")(system)
   val peer3TestProbe: TestProbe = TestProbe("peer3")(system)
 
-  val peer1 = Peer(new InetSocketAddress("127.0.0.1", 0), peer1TestProbe.ref, false)
-  val peer2 = Peer(new InetSocketAddress("127.0.0.2", 0), peer2TestProbe.ref, false)
-  val peer3 = Peer(new InetSocketAddress("127.0.0.3", 0), peer3TestProbe.ref, false)
+  val peer1 = Peer(PeerId("peer1"), new InetSocketAddress("127.0.0.1", 0), peer1TestProbe.ref, false)
+  val peer2 = Peer(PeerId("peer2"), new InetSocketAddress("127.0.0.2", 0), peer2TestProbe.ref, false)
+  val peer3 = Peer(PeerId("peer3"), new InetSocketAddress("127.0.0.3", 0), peer3TestProbe.ref, false)
 
   val peer1Status =
     RemoteStatus(

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/fast/FastSyncBranchResolverActorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/fast/FastSyncBranchResolverActorSpec.scala
@@ -246,7 +246,7 @@ class FastSyncBranchResolverActorSpec
 
     def peerId(number: Int): PeerId = PeerId(s"peer_$number")
     def getPeer(id: PeerId): Peer =
-      Peer(new InetSocketAddress("127.0.0.1", 0), TestProbe(id.value).ref, incomingConnection = false)
+      Peer(id, new InetSocketAddress("127.0.0.1", 0), TestProbe(id.value).ref, incomingConnection = false)
     def getPeerInfo(peer: Peer, protocolVersion: Int = ProtocolVersions.PV64): PeerInfo = {
       val status =
         RemoteStatus(

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/fast/FastSyncBranchResolverSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/fast/FastSyncBranchResolverSpec.scala
@@ -6,7 +6,7 @@ import io.iohk.ethereum.{BlockHelpers, Fixtures}
 import io.iohk.ethereum.blockchain.sync.fast.BinarySearchSupport._
 import io.iohk.ethereum.blockchain.sync.fast.FastSyncBranchResolver.SearchState
 import io.iohk.ethereum.domain.{Block, BlockHeader, Blockchain, BlockchainImpl}
-import io.iohk.ethereum.network.Peer
+import io.iohk.ethereum.network.{Peer, PeerId}
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -169,7 +169,7 @@ class FastSyncBranchResolverSpec extends AnyWordSpec with Matchers with MockFact
       val blocksSavedInPeer: List[Block] =
         commonBlocks :++ BlockHelpers.generateChain(ourBestBlock + 1 - highestCommonBlock, commonBlocks.last)
 
-      val dummyPeer = Peer(new InetSocketAddress("foo", 1), ActorRef.noSender, false, None, 0)
+      val dummyPeer = Peer(PeerId("dummyPeer"), new InetSocketAddress("foo", 1), ActorRef.noSender, false, None, 0)
 
       val initialSearchState = SearchState(1, 10, dummyPeer)
       val ours = blocksSaved.map(b => (b.number, b)).toMap
@@ -245,7 +245,7 @@ class FastSyncBranchResolverSpec extends AnyWordSpec with Matchers with MockFact
       val blocksSaved: List[Block] = BlockHelpers.generateChain(8, BlockHelpers.genesis)
       val blocksSavedInPeer: List[Block] = BlockHelpers.generateChain(8, BlockHelpers.genesis)
 
-      val dummyPeer = Peer(new InetSocketAddress("foo", 1), ActorRef.noSender, false, None, 0)
+      val dummyPeer = Peer(PeerId("dummyPeer"), new InetSocketAddress("foo", 1), ActorRef.noSender, false, None, 0)
 
       val initialSearchState = SearchState(1, 8, dummyPeer)
       val ours = blocksSaved.map(b => (b.number, b)).toMap

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/regular/BlockFetcherSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/regular/BlockFetcherSpec.scala
@@ -12,7 +12,7 @@ import io.iohk.ethereum.blockchain.sync.{PeersClient, TestSyncConfig}
 import io.iohk.ethereum.checkpointing.CheckpointingTestHelpers
 import io.iohk.ethereum.consensus.blocks.CheckpointBlockGenerator
 import io.iohk.ethereum.domain.{Block, ChainWeight, Checkpoint, HeadersSeq}
-import io.iohk.ethereum.network.Peer
+import io.iohk.ethereum.network.{Peer, PeerId}
 import io.iohk.ethereum.network.PeerEventBusActor.PeerEvent.MessageFromPeer
 import io.iohk.ethereum.network.PeerEventBusActor.SubscriptionClassifier.MessageClassifier
 import io.iohk.ethereum.network.PeerEventBusActor.{PeerSelector, Subscribe}
@@ -519,7 +519,7 @@ class BlockFetcherSpec
     )
 
     val fakePeerActor: TestProbe = TestProbe()
-    val fakePeer = Peer(new InetSocketAddress("127.0.0.1", 9000), fakePeerActor.ref, false)
+    val fakePeer = Peer(PeerId("fakePeer"), new InetSocketAddress("127.0.0.1", 9000), fakePeerActor.ref, false)
 
     lazy val blockFetcher = system.actorOf(
       BlockFetcher

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/regular/RegularSyncFixtures.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/regular/RegularSyncFixtures.scala
@@ -98,7 +98,7 @@ trait RegularSyncFixtures { self: Matchers with AsyncMockFactory =>
     def peerId(number: Int): PeerId = PeerId(s"peer_$number")
 
     def getPeer(id: PeerId): Peer =
-      Peer(new InetSocketAddress("127.0.0.1", 0), TestProbe(id.value).ref, incomingConnection = false)
+      Peer(id, new InetSocketAddress("127.0.0.1", 0), TestProbe(id.value).ref, incomingConnection = false)
 
     def getPeerInfo(peer: Peer, protocolVersion: Int = ProtocolVersions.PV64): PeerInfo = {
       val status =

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/DebugServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/DebugServiceSpec.scala
@@ -1,7 +1,6 @@
 package io.iohk.ethereum.jsonrpc
 
 import java.net.InetSocketAddress
-
 import akka.actor.ActorSystem
 import akka.testkit.{TestKit, TestProbe}
 import io.iohk.ethereum.domain.ChainWeight
@@ -9,7 +8,7 @@ import io.iohk.ethereum.jsonrpc.DebugService.{ListPeersInfoRequest, ListPeersInf
 import io.iohk.ethereum.network.EtcPeerManagerActor.{PeerInfo, RemoteStatus}
 import io.iohk.ethereum.network.PeerManagerActor.Peers
 import io.iohk.ethereum.network.p2p.messages.ProtocolVersions
-import io.iohk.ethereum.network.{EtcPeerManagerActor, Peer, PeerActor, PeerManagerActor}
+import io.iohk.ethereum.network.{EtcPeerManagerActor, Peer, PeerActor, PeerId, PeerManagerActor}
 import io.iohk.ethereum.{Fixtures, WithActorSystemShutDown}
 import monix.execution.Scheduler.Implicits.global
 import org.scalamock.scalatest.MockFactory
@@ -79,7 +78,7 @@ class DebugServiceSpec
       bestBlockHash = peerStatus.bestHash
     )
     val peer1Probe = TestProbe()
-    val peer1 = Peer(new InetSocketAddress("127.0.0.1", 1), peer1Probe.ref, false)
+    val peer1 = Peer(PeerId("peer1"), new InetSocketAddress("127.0.0.1", 1), peer1Probe.ref, false)
     val peer1Info: PeerInfo = initialPeerInfo.withForkAccepted(false)
   }
 }

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/NetServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/NetServiceSpec.scala
@@ -2,12 +2,11 @@ package io.iohk.ethereum.jsonrpc
 
 import java.net.InetSocketAddress
 import java.util.concurrent.atomic.AtomicReference
-
 import akka.actor.ActorSystem
 import akka.testkit.TestProbe
 import io.iohk.ethereum.jsonrpc.NetService._
 import io.iohk.ethereum.security.SecureRandomBuilder
-import io.iohk.ethereum.network.{Peer, PeerActor, PeerManagerActor}
+import io.iohk.ethereum.network.{Peer, PeerActor, PeerId, PeerManagerActor}
 import io.iohk.ethereum.utils.{NodeStatus, ServerStatus}
 import io.iohk.ethereum.{NormalPatience, crypto}
 import monix.execution.Scheduler.Implicits.global
@@ -28,9 +27,9 @@ class NetServiceSpec extends AnyFlatSpec with Matchers with ScalaFutures with No
     peerManager.reply(
       PeerManagerActor.Peers(
         Map(
-          Peer(new InetSocketAddress(1), testRef, false) -> PeerActor.Status.Handshaked,
-          Peer(new InetSocketAddress(2), testRef, false) -> PeerActor.Status.Handshaked,
-          Peer(new InetSocketAddress(3), testRef, false) -> PeerActor.Status.Connecting
+          Peer(PeerId("peer1"), new InetSocketAddress(1), testRef, false) -> PeerActor.Status.Handshaked,
+          Peer(PeerId("peer2"), new InetSocketAddress(2), testRef, false) -> PeerActor.Status.Handshaked,
+          Peer(PeerId("peer3"), new InetSocketAddress(3), testRef, false) -> PeerActor.Status.Connecting
         )
       )
     )

--- a/src/test/scala/io/iohk/ethereum/network/EtcPeerManagerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/network/EtcPeerManagerSpec.scala
@@ -311,17 +311,18 @@ class EtcPeerManagerSpec extends AnyFlatSpec with Matchers {
     val fakeNodeId = ByteString()
 
     val peer1Probe = TestProbe()
-    val peer1 = Peer(new InetSocketAddress("127.0.0.1", 1), peer1Probe.ref, false, Some(fakeNodeId))
+    val peer1 = Peer(PeerId("peer1"), new InetSocketAddress("127.0.0.1", 1), peer1Probe.ref, false, Some(fakeNodeId))
     val peer1Info = initialPeerInfo.withForkAccepted(false)
     val peer1InfoPV64 = initialPeerInfoPV64.withForkAccepted(false)
     val peer2Probe = TestProbe()
-    val peer2 = Peer(new InetSocketAddress("127.0.0.1", 2), peer2Probe.ref, false, Some(fakeNodeId))
+    val peer2 = Peer(PeerId("peer2"), new InetSocketAddress("127.0.0.1", 2), peer2Probe.ref, false, Some(fakeNodeId))
     val peer2Info = initialPeerInfo.withForkAccepted(false)
     val peer3Probe = TestProbe()
-    val peer3 = Peer(new InetSocketAddress("127.0.0.1", 3), peer3Probe.ref, false, Some(fakeNodeId))
+    val peer3 = Peer(PeerId("peer3"), new InetSocketAddress("127.0.0.1", 3), peer3Probe.ref, false, Some(fakeNodeId))
 
     val freshPeerProbe = TestProbe()
-    val freshPeer = Peer(new InetSocketAddress("127.0.0.1", 4), freshPeerProbe.ref, false, Some(fakeNodeId))
+    val freshPeer =
+      Peer(PeerId(""), new InetSocketAddress("127.0.0.1", 4), freshPeerProbe.ref, false, Some(fakeNodeId))
     val freshPeerInfo = initialPeerInfo.withForkAccepted(false)
 
     val peerManager = TestProbe()

--- a/src/test/scala/io/iohk/ethereum/network/PeerEventBusActorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/network/PeerEventBusActorSpec.scala
@@ -97,7 +97,8 @@ class PeerEventBusActorSpec extends AnyFlatSpec with Matchers {
     peerEventBusActor.tell(PeerEventBusActor.Subscribe(PeerHandshaked), probe1.ref)
     peerEventBusActor.tell(PeerEventBusActor.Subscribe(PeerHandshaked), probe2.ref)
 
-    val peerHandshaked = new Peer(new InetSocketAddress("127.0.0.1", 0), TestProbe().ref, false, Some(ByteString()))
+    val peerHandshaked =
+      new Peer(PeerId("peer1"), new InetSocketAddress("127.0.0.1", 0), TestProbe().ref, false, Some(ByteString()))
     val msgPeerHandshaked = PeerHandshakeSuccessful(peerHandshaked, initialPeerInfo)
     peerEventBusActor ! PeerEventBusActor.Publish(msgPeerHandshaked)
 

--- a/src/test/scala/io/iohk/ethereum/transactions/PendingTransactionsManagerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/transactions/PendingTransactionsManagerSpec.scala
@@ -215,11 +215,11 @@ class PendingTransactionsManagerSpec extends AnyFlatSpec with Matchers with Scal
       SignedTransaction.sign(tx, keyPair, Some(0x3d))
 
     val peer1TestProbe = TestProbe()
-    val peer1 = Peer(new InetSocketAddress("127.0.0.1", 9000), peer1TestProbe.ref, false)
+    val peer1 = Peer(PeerId("peer1"), new InetSocketAddress("127.0.0.1", 9000), peer1TestProbe.ref, false)
     val peer2TestProbe = TestProbe()
-    val peer2 = Peer(new InetSocketAddress("127.0.0.2", 9000), peer2TestProbe.ref, false)
+    val peer2 = Peer(PeerId("peer2"), new InetSocketAddress("127.0.0.2", 9000), peer2TestProbe.ref, false)
     val peer3TestProbe = TestProbe()
-    val peer3 = Peer(new InetSocketAddress("127.0.0.3", 9000), peer3TestProbe.ref, false)
+    val peer3 = Peer(PeerId("peer3"), new InetSocketAddress("127.0.0.3", 9000), peer3TestProbe.ref, false)
 
     val txPoolConfig = new TxPoolConfig {
       override val txPoolSize: Int = 300


### PR DESCRIPTION
# Description

The node's public key is encoded in the username part of ts URI. 
`enode://pubkey@ip:port`

This PR makes use of this node Id to derive a PeerId

# Proposed Solution

Currently, a PeerId is created from the `PeerActor`'s path. This is changed to create a Peer Id from the Node's pub key.

# Important Changes Introduced

PeerId is unknown for nodes that are not yet handshaked. Currently, they are named `PendingPeers`. 
See: PeerManagerActor and ConnectedPeers. 
Pending peers were stored using Id derived from PeerActor path until successfully handshaked.

# Testing

Unit tests and it tests
> This needs (extensive) testing on the mainnet before it can be merged

