### PR TITLE
[ETCM-715] Add new network metric (tried.peers)

### DIFF
--- a/docker/mantis/grafana/provisioning/dashboards/mantis-dashboard.json
+++ b/docker/mantis/grafana/provisioning/dashboards/mantis-dashboard.json
@@ -3033,6 +3033,144 @@
           "fill": 0,
           "fillGradient": 0,
           "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 8
+          },
+          "hiddenSeries": false,
+          "id": 84,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "hideEmpty": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "connected",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": true,
+          "pluginVersion": "7.3.6",
+          "pointradius": 0.5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [
+            {
+              "alias": "nb_tried_peers",
+              "hiddenSeries": true,
+              "hideTooltip": true,
+              "legend": false
+            },
+            {
+              "alias": "nb_discovered_peers",
+              "hiddenSeries": true,
+              "hideTooltip": true,
+              "legend": false
+            }
+          ],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "app_network_tried_peers_gauge",
+              "interval": "",
+              "legendFormat": "nb_tried_peers",
+              "refId": "Number of tried peers"
+            },
+            {
+              "expr": "app_network_discovery_foundPeers_gauge",
+              "interval": "",
+              "legendFormat": "nb_discovered_peers",
+              "refId": "Number discovered peers"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Ratio of tried / discovered peers",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "transformations": [
+            {
+              "id": "calculateField",
+              "options": {
+                "alias": "Ratio",
+                "binary": {
+                  "left": "nb_tried_peers",
+                  "operator": "/",
+                  "reducer": "sum",
+                  "right": "nb_discovered_peers"
+                },
+                "mode": "binary",
+                "reduce": {
+                  "include": [
+                    "{{instance}}"
+                  ],
+                  "reducer": "sum"
+                }
+              }
+            }
+          ],
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "percentunit",
+              "label": "%",
+              "logBase": 1,
+              "max": 1,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "links": []
+            },
+            "overrides": []
+          },
+          "fill": 0,
+          "fillGradient": 0,
+          "gridPos": {
             "h": 10,
             "w": 8,
             "x": 0,

--- a/src/main/scala/io/iohk/ethereum/network/NetworkMetrics.scala
+++ b/src/main/scala/io/iohk/ethereum/network/NetworkMetrics.scala
@@ -1,7 +1,8 @@
 package io.iohk.ethereum.network
 
-import io.iohk.ethereum.metrics.MetricsContainer
 import java.util.concurrent.atomic.AtomicLong
+
+import io.iohk.ethereum.metrics.MetricsContainer
 
 case object NetworkMetrics extends MetricsContainer {
 
@@ -19,6 +20,9 @@ case object NetworkMetrics extends MetricsContainer {
   final val BlacklistedPeersSize = metrics.registry.gauge("network.peers.blacklisted.gauge", new AtomicLong(0))
 
   final val PendingPeersSize = metrics.registry.gauge("network.peers.pending.gauge", new AtomicLong(0))
+
+  final val TriedPeersSize =
+    metrics.registry.gauge("network.tried.peers.gauge", new AtomicLong(0L))
 
   def registerAddHandshakedPeer(peer: Peer): Unit = {
     if (peer.incomingConnection) {

--- a/src/main/scala/io/iohk/ethereum/network/PeerManagerActor.scala
+++ b/src/main/scala/io/iohk/ethereum/network/PeerManagerActor.scala
@@ -154,6 +154,7 @@ class PeerManagerActor(
     NetworkMetrics.DiscoveredPeersSize.set(nodes.size)
     NetworkMetrics.BlacklistedPeersSize.set(blacklistedPeers.size)
     NetworkMetrics.PendingPeersSize.set(connectedPeers.pendingPeersCount)
+    NetworkMetrics.TriedPeersSize.set(triedNodes.size)
 
     log.info(
       s"Total number of discovered nodes ${nodes.size}. " +

--- a/src/main/scala/io/iohk/ethereum/network/PeerManagerActor.scala
+++ b/src/main/scala/io/iohk/ethereum/network/PeerManagerActor.scala
@@ -156,9 +156,9 @@ class PeerManagerActor(
     NetworkMetrics.PendingPeersSize.set(connectedPeers.pendingPeersCount)
 
     log.info(
-      s"Discovered ${nodes.size} nodes, " +
-        s"Blacklisted ${blacklistedPeers.size} nodes, " +
-        s"handshaked to ${connectedPeers.handshakedPeersCount}/${peerConfiguration.maxOutgoingPeers + peerConfiguration.maxIncomingPeers}, " +
+      s"Total number of discovered nodes ${nodes.size}. " +
+        s"Total number of connection attempts ${triedNodes.size}, blacklisted ${blacklistedPeers.size} nodes. " +
+        s"Handshaked ${connectedPeers.handshakedPeersCount}/${peerConfiguration.maxOutgoingPeers + peerConfiguration.maxIncomingPeers}, " +
         s"pending connection attempts ${connectedPeers.pendingPeersCount}. " +
         s"Trying to connect to ${nodesToConnect.size} more nodes."
     )


### PR DESCRIPTION
# Description

- Detail info log in `PeerManagerActor`
- Create new network metric (tried.peers)
- Create a new Grafana panel computing and displaying the ratio between tried / discovered peers

# Proposed Solution

This let Grafana compute the ratio. It is cleaner from the metrics and Scala code point of view, however it takes time to make it work in the Grafana dashboard.

The alternative is to set a ratio metric in Scala (with the drawback of having convoluted metrics)

# Important Changes Introduced


# Testing

- Use `build.sh` in `docker/mantis`
- Look for the new _network_ panel in Grafana

