### PR TITLE
[ETCM-736] Enable compiler optimizations in Prod

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,9 +13,9 @@ val nixBuild = sys.props.isDefinedAt("nix")
 val mantisDev = sys.props.get("mantisDev").contains("true") || sys.env.get("MANTIS_DEV").contains("true")
 
 lazy val compilerOptimizationsForProd = Seq(
-  "-opt:l:method",      // method-local optimizations
-  "-opt:l:inline",      // inlining optimizations
-  "-opt-inline-from:**" // inlining allowed to all classes
+  "-opt:l:method",  // method-local optimizations
+  "-opt:l:inline",  // inlining optimizations
+  "-opt-inline-from:io.iohk.**" // inlining the project only
 )
 
 // Releasing. https://github.com/olafurpg/sbt-ci-release

--- a/build.sbt
+++ b/build.sbt
@@ -12,6 +12,12 @@ val nixBuild = sys.props.isDefinedAt("nix")
 // Enable dev mode: disable certain flags, etc.
 val mantisDev = sys.props.get("mantisDev").contains("true") || sys.env.get("MANTIS_DEV").contains("true")
 
+lazy val compilerOptimizationsForProd = Seq(
+  "-opt:l:method",      // method-local optimizations
+  "-opt:l:inline",      // inlining optimizations
+  "-opt-inline-from:**" // inlining allowed to all classes
+)
+
 // Releasing. https://github.com/olafurpg/sbt-ci-release
 inThisBuild(List(
   organization := "io.iohk",
@@ -47,6 +53,7 @@ def commonSettings(projectName: String): Seq[sbt.Def.Setting[_]] = Seq(
     "-encoding",
     "utf-8"
   ),
+  scalacOptions ++= (if (mantisDev) Seq.empty else compilerOptimizationsForProd),
   scalacOptions in (Compile, console) ~= (_.filterNot(
     Set(
       "-Ywarn-unused-import",

--- a/nix/protoc.patch
+++ b/nix/protoc.patch
@@ -1,12 +1,12 @@
 diff --git a/build.sbt b/build.sbt
-index 6bf2b25cb..155de447d 100644
+index 4ac21ff40..ccd34412e 100644
 --- a/build.sbt
 +++ b/build.sbt
-@@ -25,6 +25,7 @@ def commonSettings(projectName: String) = Seq(
-     "-encoding",
-     "UTF-8"
-   ),
+@@ -43,6 +43,7 @@ def commonSettings(projectName: String): Seq[sbt.Def.Setting[_]] = Seq(
+   scalaVersion := `scala-2.13`,
+   // Scalanet snapshots are published to Sonatype after each build.
+   resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",
 +  PB.runProtoc in Compile := (args => Process("@protobuf@/bin/protoc", args)!),
-   scalacOptions in (Compile, console) ~= (_.filterNot(
-     Set(
-       "-Ywarn-unused-import",
+   testOptions in Test += Tests
+     .Argument(TestFrameworks.ScalaTest, "-l", "EthashMinerSpec"), // miner tests disabled by default,
+   scalacOptions := Seq(


### PR DESCRIPTION
# Description

Enable compiler inlining optimizations as described here https://www.lightbend.com/blog/scala-inliner-optimizer

> TL;DR
Don’t enable the optimizer during development: it breaks incremental compilation, and it makes the compiler slower. Only enable it for testing, on CI, and to build releases.
Enable method-local optimizations with -opt:l:method. This option is safe for binary compatibility, but typically doesn’t improve performance on its own.
Enable inlining in addition to method-local optimizations with -opt:l:inline and -opt-inline-from:[PATTERN]
Don’t inline from your dependencies when publishing a library, it breaks binary compatibility. Use -opt-inline-from:my.package.** to only inline from packages within your library.
When compiling an application with global inlining (-opt-inline-from:**), ensure that the run-time classpath is exactly the same as the compile-time classpath.
The @inline annotation only has an effect if the inliner is enabled. It tells the inliner to always try to inline the annotated method or callsite.
Without the @inline annotation, the inliner generally inlines higher-order methods and forwarder methods. The main goal is to eliminate megamorphic callsites due to functions passed as argument, and to eliminate value boxing. Other optimizations are delegated to the JVM.

See also [documentation](https://www.scala-lang.org/api/2.13.4/scala/inline.html) and [options renaming ticket](https://github.com/scala/bug/issues/11873)

# Proposed Solution

- Enable the optimizations for production only (see option `-DmantisDev` and flag `MANTISDEV`)
- Restrict the optimization to the project since the main goal is to inline logging calls

~Do we want to set it for tests and integration tests as well? Switching off dev mode might be a more clear way to achieve this...~ We agreed to keep it simple : production mode has optimization, dev mode does not, hence to test with inlinine toggle to production mode

# Important Changes Introduced

## Reminder

To enable dev mode, `-DmantisDev=true` or `MANTIS_DEV=true`

## Ensuring that compile-time and run-time classpaths are the same

**This section is kept for documentation purposes, it has been decided not to enable inline globally**

Difference between the classpaths (on my machine, emptied caches)
| Compile-time  | Run-time | Issue |
| ------------- | ------------- | --- |
|(`sbt export compile:fullClasspath`)| (`sbt export runtime:fullClasspath`)| |
| `scala-collection-compat_2.13-2.3.2.jar`  | `scala-collection-compat_2.13-2.1.6.jar` | See below |
| Scala XML  | ø  | Not an issue
| Scapegoat plugin  | ø  | Not an issue |

_ScalaPb_ library is the only library depending on `scala-collection-compat` (latest 2.4.3) and it also imposes the version of `scala-collection-compat` to be used. Currently the project depends on _ScalaPb_ `0.10.9` which imposes `scala-collection-compat_2.13-2.1.6` (https://github.com/scalapb/ScalaPB/blob/v0.10.9/project/Dependencies.scala#L13) whereas the latest is `0.11.1` imposing `scala-collection-compat-2.4.3`.
Note : Monix also defines a dependency to `scala-collection-compat` 
 via `Def.settings` https://github.com/monix/monix/blob/cb4823427db8b1f8fdf990bf27b307b396892a76/build.sbt#L89, this potentially explains the discrepancy between the classpaths.

Potential solutions
- align the version between the compile-time and run-time classpaths, or
- exclude optimizations fromt the classpath as suggested from libraries (`-opt-inline-from:my.package.**`)

# Testing

- Inlining changes logs can be seen with the scalac `"-Yopt-log-inline", "_"` option.
- Compare `compile:fullClasspath` vs `runtime:fullClasspath`
- Run Mantis
