### PR TITLE
ETCM-165: Fix the 'no pinentry' issue during publishing

### DIFF
--- a/.buildkite/pipeline.nix
+++ b/.buildkite/pipeline.nix
@@ -160,7 +160,7 @@ in
       command = ''
         nix-env -iA nixpkgs.gnupg && nix-shell --run '.buildkite/publish.sh'
       '';
-      branches = "master develop ETCM-165-fix-publish";
+      branches = "master develop";
       timeoutInMinutes = 30;
     };
   };

--- a/.buildkite/pipeline.nix
+++ b/.buildkite/pipeline.nix
@@ -160,7 +160,7 @@ in
       command = ''
         nix-env -iA nixpkgs.gnupg && nix-shell --run '.buildkite/publish.sh'
       '';
-      branches = "master develop";
+      branches = "master develop ETCM-165-fix-publish";
       timeoutInMinutes = 30;
     };
   };

--- a/.buildkite/publish.sh
+++ b/.buildkite/publish.sh
@@ -18,9 +18,9 @@ GPG_EXISTS=$(gpg --list-keys "$GPG_KEY_ID" >&2 && echo "yes" || echo "no")
 
 if [[ "$GPG_EXISTS" == "no" ]]; then
 	echo "$GPG_KEY" | base64 --decode | gpg --batch --import
+    # Local testing showed that without this the SBT plugin got "Bad passphrase".
+    gpg --passphrase $GPG_PASSPHRASE --batch --yes -a -b LICENSE
 fi
-# Local testing showed that without this the SBT plugin got "Bad passphrase".
-gpg --passphrase $GPG_PASSPHRASE --batch --yes -a -b LICENSE
 
 # https://github.com/olafurpg/sbt-ci-release#secrets
 export PGP_SECRET="$GPG_KEY"
@@ -58,7 +58,7 @@ function releaseAll {
     release 2.13.4 1.4.7
 }
 
-if [[ "$BUILDKITE_BRANCH" == "develop" ]]; then
+if [[ "$BUILDKITE_BRANCH" == "develop" ]] || [[ "$BUILDKITE_BRANCH" == "ETCM-165-fix-publish" ]]; then
 
     # Publish the -SNAPSHOT version.
     releaseAll

--- a/.buildkite/publish.sh
+++ b/.buildkite/publish.sh
@@ -58,7 +58,7 @@ function releaseAll {
     release 2.13.4 1.4.7
 }
 
-if [[ "$BUILDKITE_BRANCH" == "develop" ]] || [[ "$BUILDKITE_BRANCH" == "ETCM-165-fix-publish" ]]; then
+if [[ "$BUILDKITE_BRANCH" == "develop" ]]; then
 
     # Publish the -SNAPSHOT version.
     releaseAll


### PR DESCRIPTION
# Description

Publishing fails where it's trying to set the gpg password.

# Proposed Solution

Move it to only apply if the key was just imported.

# Testing

Temporarily enabling snapshot publishing on the PR branch.
This seems to have [worked](https://buildkite.com/input-output-hk/mantis/builds/2317#0c6f79a8-28da-4477-b91b-d2c2bd86e8d7/97).