### PR TITLE
ETS integration RPC endpoints

### DIFF
--- a/src/main/resources/conf/base.conf
+++ b/src/main/resources/conf/base.conf
@@ -332,7 +332,7 @@ mantis {
     testnet-internal-nomad {include required("chains/testnet-internal-nomad-chain.conf")}
 
     testnet-internal-gac {include required("chains/testnet-internal-gac-chain.conf")}
-	
+
     pottery	{include required("chains/pottery-chain.conf")}
   }
 

--- a/src/main/resources/conf/testmode.conf
+++ b/src/main/resources/conf/testmode.conf
@@ -14,10 +14,15 @@ mantis {
 
   blockchains {
     network = "test"
+
+    test {
+        chain-id = 1
+
+        istanbul-block-number = 0
+    }
   }
 
   network.rpc {
     apis = "eth,web3,net,personal,mantis,test,iele,debug,qa,checkpointing"
   }
-
 }

--- a/src/main/resources/conf/testmode.conf
+++ b/src/main/resources/conf/testmode.conf
@@ -18,7 +18,33 @@ mantis {
     test {
         chain-id = 1
 
+        frontier-block-number = 0
+
+        homestead-block-number = 0
+
+        eip106-block-number = 0
+
+        eip150-block-number = 0
+
+        eip155-block-number = 0
+
+        eip160-block-number = 0
+
+        eip161-block-number = 0
+
+        byzantium-block-number = 0
+
+        constantinople-block-number = 0
+
         istanbul-block-number = 0
+
+        atlantis-block-number = 0
+
+        agharta-block-number = 0
+
+        phoenix-block-number = 0
+
+        petersburg-block-number = 0
     }
   }
 

--- a/src/main/scala/io/iohk/ethereum/blockchain/data/GenesisDataLoader.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/data/GenesisDataLoader.scala
@@ -90,13 +90,13 @@ class GenesisDataLoader(blockchain: Blockchain, blockchainConfig: BlockchainConf
     val initalRootHash = MerklePatriciaTrie.EmptyRootHash
 
     val stateMptRootHash = genesisData.alloc.zipWithIndex.foldLeft(initalRootHash) {
-      case (rootHash, (((address, genesisAccount), idx))) =>
+      case (rootHash, ((address, genesisAccount), _)) =>
         val mpt = MerklePatriciaTrie[Array[Byte], Account](rootHash, storage)
         val paddedAddress = address.reverse.padTo(addressLength, "0").reverse.mkString
         val stateRoot = mpt
           .put(
             crypto.kec256(Hex.decode(paddedAddress)),
-            Account(nonce = genesisAccount.nonce, balance = genesisAccount.balance, codeHash = genesisAccount.code)
+            Account(nonce = genesisAccount.nonce, balance = genesisAccount.balance)
           )
           .getRootHash
         stateRoot

--- a/src/main/scala/io/iohk/ethereum/blockchain/data/GenesisDataLoader.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/data/GenesisDataLoader.scala
@@ -201,12 +201,7 @@ object GenesisDataLoader {
     }
 
     object UInt256JsonSerializer
-        extends CustomSerializer[UInt256](formats =>
-          (
-            { case jv => deserializeUint256String(jv) },
-            PartialFunction.empty
-          )
-        )
+        extends CustomSerializer[UInt256](_ => ({ case jv => deserializeUint256String(jv) }, PartialFunction.empty))
   }
 }
 

--- a/src/main/scala/io/iohk/ethereum/blockchain/data/GenesisDataLoader.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/data/GenesisDataLoader.scala
@@ -102,7 +102,8 @@ class GenesisDataLoader(blockchain: Blockchain, blockchainConfig: BlockchainConf
             Account(
               nonce = genesisAccount.nonce
                 .getOrElse(blockchainConfig.accountStartNonce),
-              balance = genesisAccount.balance
+              balance = genesisAccount.balance,
+              codeHash = genesisAccount.code.map(codeValue => crypto.kec256(codeValue)).getOrElse(Account.EmptyCodeHash)
             )
           )
           .getRootHash

--- a/src/main/scala/io/iohk/ethereum/blockchain/data/GenesisDataLoader.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/data/GenesisDataLoader.scala
@@ -90,13 +90,13 @@ class GenesisDataLoader(blockchain: Blockchain, blockchainConfig: BlockchainConf
     val initalRootHash = MerklePatriciaTrie.EmptyRootHash
 
     val stateMptRootHash = genesisData.alloc.zipWithIndex.foldLeft(initalRootHash) {
-      case (rootHash, (((address, AllocAccount(balance)), idx))) =>
+      case (rootHash, (((address, genesisAccount), idx))) =>
         val mpt = MerklePatriciaTrie[Array[Byte], Account](rootHash, storage)
         val paddedAddress = address.reverse.padTo(addressLength, "0").reverse.mkString
         val stateRoot = mpt
           .put(
             crypto.kec256(Hex.decode(paddedAddress)),
-            Account(blockchainConfig.accountStartNonce, UInt256(BigInt(balance)), emptyTrieRootHash, emptyEvmHash)
+            Account(nonce = genesisAccount.nonce, balance = genesisAccount.balance, codeHash = genesisAccount.code)
           )
           .getRootHash
         stateRoot

--- a/src/main/scala/io/iohk/ethereum/blockchain/data/GenesisDataLoader.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/data/GenesisDataLoader.scala
@@ -188,7 +188,7 @@ object GenesisDataLoader {
 
     def deserializeUint256String(jv: JValue): UInt256 = jv match {
       case JString(s) =>
-        Try(UInt256(BigInt(1, Implicits.decode(s)))) match {
+        Try(UInt256(BigInt(s))) match {
           case Failure(_) => throw new RuntimeException("Cannot parse hex string: " + s)
           case Success(value) => value
         }

--- a/src/main/scala/io/iohk/ethereum/blockchain/data/genesis.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/data/genesis.scala
@@ -8,9 +8,9 @@ case class PrecompiledAccountConfig(name: String)
 case class GenesisAccount(
     precompiled: Option[PrecompiledAccountConfig],
     balance: UInt256,
-    code: ByteString,
-    nonce: UInt256,
-    storage: Map[UInt256, UInt256]
+    code: Option[ByteString],
+    nonce: Option[UInt256],
+    storage: Option[Map[UInt256, UInt256]]
 )
 
 case class GenesisData(

--- a/src/main/scala/io/iohk/ethereum/blockchain/data/genesis.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/data/genesis.scala
@@ -1,8 +1,17 @@
 package io.iohk.ethereum.blockchain.data
 
 import akka.util.ByteString
+import io.iohk.ethereum.domain.UInt256
 
-case class AllocAccount(balance: String)
+case class PrecompiledAccountConfig(name: String)
+
+case class GenesisAccount(
+    precompiled: Option[PrecompiledAccountConfig],
+    balance: UInt256,
+    code: ByteString,
+    nonce: UInt256,
+    storage: Map[UInt256, UInt256]
+)
 
 case class GenesisData(
     nonce: ByteString,
@@ -12,5 +21,5 @@ case class GenesisData(
     gasLimit: String,
     coinbase: ByteString,
     timestamp: String,
-    alloc: Map[String, AllocAccount]
+    alloc: Map[String, GenesisAccount]
 )

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/BlockResponse.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/BlockResponse.scala
@@ -30,7 +30,6 @@ trait BaseBlockResponse {
   def timestamp: BigInt
   def transactions: Either[Seq[ByteString], Seq[TransactionResponse]]
   def uncles: Seq[ByteString]
-  def coinbase: Option[ByteString]
 }
 
 case class EthBlockResponse(
@@ -53,8 +52,7 @@ case class EthBlockResponse(
     gasUsed: BigInt,
     timestamp: BigInt,
     transactions: Either[Seq[ByteString], Seq[TransactionResponse]],
-    uncles: Seq[ByteString],
-    coinbase: Option[ByteString]
+    uncles: Seq[ByteString]
 ) extends BaseBlockResponse
 
 //scalastyle:off method.length
@@ -83,8 +81,7 @@ case class BlockResponse(
     transactions: Either[Seq[ByteString], Seq[TransactionResponse]],
     uncles: Seq[ByteString],
     signature: String,
-    signer: String,
-    coinbase: Option[ByteString]
+    signer: String
 ) extends BaseBlockResponse {
   val chainWeight: Option[ChainWeight] = for {
     lcn <- lastCheckpointNumber
@@ -155,8 +152,7 @@ object BlockResponse {
       transactions = transactions,
       uncles = block.body.uncleNodesList.map(_.hash),
       signature = signatureStr,
-      signer = signerStr,
-      coinbase = None
+      signer = signerStr
     )
   }
 

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/BlockResponse.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/BlockResponse.scala
@@ -9,6 +9,52 @@ import io.iohk.ethereum.utils.ByteStringUtils
 
 case class CheckpointResponse(signatures: Seq[ECDSASignature], signers: Seq[ByteString])
 
+trait BaseBlockResponse {
+  def number: BigInt
+  def hash: Option[ByteString]
+  def mixHash: Option[ByteString]
+  def parentHash: ByteString
+  def nonce: Option[ByteString]
+  def sha3Uncles: ByteString
+  def logsBloom: ByteString
+  def transactionsRoot: ByteString
+  def stateRoot: ByteString
+  def receiptsRoot: ByteString
+  def miner: Option[ByteString]
+  def difficulty: BigInt
+  def totalDifficulty: Option[BigInt]
+  def extraData: ByteString
+  def size: BigInt
+  def gasLimit: BigInt
+  def gasUsed: BigInt
+  def timestamp: BigInt
+  def transactions: Either[Seq[ByteString], Seq[TransactionResponse]]
+  def uncles: Seq[ByteString]
+}
+
+case class EthBlockResponse(
+    number: BigInt,
+    hash: Option[ByteString],
+    mixHash: Option[ByteString],
+    parentHash: ByteString,
+    nonce: Option[ByteString],
+    sha3Uncles: ByteString,
+    logsBloom: ByteString,
+    transactionsRoot: ByteString,
+    stateRoot: ByteString,
+    receiptsRoot: ByteString,
+    miner: Option[ByteString],
+    difficulty: BigInt,
+    totalDifficulty: Option[BigInt],
+    extraData: ByteString,
+    size: BigInt,
+    gasLimit: BigInt,
+    gasUsed: BigInt,
+    timestamp: BigInt,
+    transactions: Either[Seq[ByteString], Seq[TransactionResponse]],
+    uncles: Seq[ByteString]
+) extends BaseBlockResponse
+
 //scalastyle:off method.length
 case class BlockResponse(
     number: BigInt,
@@ -36,7 +82,7 @@ case class BlockResponse(
     uncles: Seq[ByteString],
     signature: String,
     signer: String
-) {
+) extends BaseBlockResponse {
   val chainWeight: Option[ChainWeight] = for {
     lcn <- lastCheckpointNumber
     td <- totalDifficulty

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/BlockResponse.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/BlockResponse.scala
@@ -9,6 +9,10 @@ import io.iohk.ethereum.utils.ByteStringUtils
 
 case class CheckpointResponse(signatures: Seq[ECDSASignature], signers: Seq[ByteString])
 
+/*
+  * this trait has been introduced to deal with ETS requirements and discrepancies between mantis and the spec
+  * it should be considered a band-aid solution and replaced with something robust and non-intrusive
+  */
 trait BaseBlockResponse {
   def number: BigInt
   def hash: Option[ByteString]
@@ -30,29 +34,6 @@ trait BaseBlockResponse {
   def transactions: Either[Seq[ByteString], Seq[BaseTransactionResponse]]
   def uncles: Seq[ByteString]
 }
-
-case class EthBlockResponse(
-    number: BigInt,
-    hash: Option[ByteString],
-    mixHash: Option[ByteString],
-    parentHash: ByteString,
-    nonce: Option[ByteString],
-    sha3Uncles: ByteString,
-    logsBloom: ByteString,
-    transactionsRoot: ByteString,
-    stateRoot: ByteString,
-    receiptsRoot: ByteString,
-    miner: Option[ByteString],
-    difficulty: BigInt,
-    totalDifficulty: Option[BigInt],
-    extraData: ByteString,
-    size: BigInt,
-    gasLimit: BigInt,
-    gasUsed: BigInt,
-    timestamp: BigInt,
-    transactions: Either[Seq[ByteString], Seq[BaseTransactionResponse]],
-    uncles: Seq[ByteString]
-) extends BaseBlockResponse
 
 //scalastyle:off method.length
 case class BlockResponse(

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/BlockResponse.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/BlockResponse.scala
@@ -10,9 +10,9 @@ import io.iohk.ethereum.utils.ByteStringUtils
 case class CheckpointResponse(signatures: Seq[ECDSASignature], signers: Seq[ByteString])
 
 /*
-  * this trait has been introduced to deal with ETS requirements and discrepancies between mantis and the spec
-  * it should be considered a band-aid solution and replaced with something robust and non-intrusive
-  */
+ * this trait has been introduced to deal with ETS requirements and discrepancies between mantis and the spec
+ * it should be considered a band-aid solution and replaced with something robust and non-intrusive
+ */
 trait BaseBlockResponse {
   def number: BigInt
   def hash: Option[ByteString]

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/BlockResponse.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/BlockResponse.scala
@@ -30,6 +30,7 @@ trait BaseBlockResponse {
   def timestamp: BigInt
   def transactions: Either[Seq[ByteString], Seq[TransactionResponse]]
   def uncles: Seq[ByteString]
+  def coinbase: Option[ByteString]
 }
 
 case class EthBlockResponse(
@@ -52,7 +53,8 @@ case class EthBlockResponse(
     gasUsed: BigInt,
     timestamp: BigInt,
     transactions: Either[Seq[ByteString], Seq[TransactionResponse]],
-    uncles: Seq[ByteString]
+    uncles: Seq[ByteString],
+    coinbase: Option[ByteString]
 ) extends BaseBlockResponse
 
 //scalastyle:off method.length
@@ -81,7 +83,8 @@ case class BlockResponse(
     transactions: Either[Seq[ByteString], Seq[TransactionResponse]],
     uncles: Seq[ByteString],
     signature: String,
-    signer: String
+    signer: String,
+    coinbase: Option[ByteString]
 ) extends BaseBlockResponse {
   val chainWeight: Option[ChainWeight] = for {
     lcn <- lastCheckpointNumber
@@ -97,7 +100,8 @@ object BlockResponse {
       block: Block,
       weight: Option[ChainWeight] = None,
       fullTxs: Boolean = false,
-      pendingBlock: Boolean = false
+      pendingBlock: Boolean = false,
+      coinbase: Option[ByteString] = None
   ): BlockResponse = {
     val transactions =
       if (fullTxs)
@@ -129,9 +133,9 @@ object BlockResponse {
     BlockResponse(
       number = block.header.number,
       hash = if (pendingBlock) None else Some(block.header.hash),
-      mixHash = if (pendingBlock) None else Some(block.header.mixHash),
+      mixHash = if (block.header.mixHash.isEmpty) None else Some(block.header.mixHash),
       parentHash = block.header.parentHash,
-      nonce = if (pendingBlock) None else Some(block.header.nonce),
+      nonce = if (block.header.nonce.isEmpty) None else Some(block.header.nonce),
       sha3Uncles = block.header.ommersHash,
       logsBloom = block.header.logsBloom,
       transactionsRoot = block.header.transactionsRoot,
@@ -151,7 +155,8 @@ object BlockResponse {
       transactions = transactions,
       uncles = block.body.uncleNodesList.map(_.hash),
       signature = signatureStr,
-      signer = signerStr
+      signer = signerStr,
+      coinbase = None
     )
   }
 

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/BlockResponse.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/BlockResponse.scala
@@ -12,7 +12,6 @@ case class CheckpointResponse(signatures: Seq[ECDSASignature], signers: Seq[Byte
 trait BaseBlockResponse {
   def number: BigInt
   def hash: Option[ByteString]
-  def mixHash: Option[ByteString]
   def parentHash: ByteString
   def nonce: Option[ByteString]
   def sha3Uncles: ByteString
@@ -59,7 +58,6 @@ case class EthBlockResponse(
 case class BlockResponse(
     number: BigInt,
     hash: Option[ByteString],
-    mixHash: Option[ByteString],
     parentHash: ByteString,
     nonce: Option[ByteString],
     sha3Uncles: ByteString,
@@ -130,9 +128,8 @@ object BlockResponse {
     BlockResponse(
       number = block.header.number,
       hash = if (pendingBlock) None else Some(block.header.hash),
-      mixHash = if (block.header.mixHash.isEmpty) None else Some(block.header.mixHash),
       parentHash = block.header.parentHash,
-      nonce = if (block.header.nonce.isEmpty) None else Some(block.header.nonce),
+      nonce = if (pendingBlock) None else Some(block.header.nonce),
       sha3Uncles = block.header.ommersHash,
       logsBloom = block.header.logsBloom,
       transactionsRoot = block.header.transactionsRoot,

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/BlockResponse.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/BlockResponse.scala
@@ -13,6 +13,7 @@ case class CheckpointResponse(signatures: Seq[ECDSASignature], signers: Seq[Byte
 case class BlockResponse(
     number: BigInt,
     hash: Option[ByteString],
+    mixHash: Option[ByteString],
     parentHash: ByteString,
     nonce: Option[ByteString],
     sha3Uncles: ByteString,
@@ -82,6 +83,7 @@ object BlockResponse {
     BlockResponse(
       number = block.header.number,
       hash = if (pendingBlock) None else Some(block.header.hash),
+      mixHash = if (pendingBlock) None else Some(block.header.mixHash),
       parentHash = block.header.parentHash,
       nonce = if (pendingBlock) None else Some(block.header.nonce),
       sha3Uncles = block.header.ommersHash,

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/BlockResponse.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/BlockResponse.scala
@@ -28,7 +28,7 @@ trait BaseBlockResponse {
   def gasLimit: BigInt
   def gasUsed: BigInt
   def timestamp: BigInt
-  def transactions: Either[Seq[ByteString], Seq[TransactionResponse]]
+  def transactions: Either[Seq[ByteString], Seq[BaseTransactionResponse]]
   def uncles: Seq[ByteString]
 }
 
@@ -51,7 +51,7 @@ case class EthBlockResponse(
     gasLimit: BigInt,
     gasUsed: BigInt,
     timestamp: BigInt,
-    transactions: Either[Seq[ByteString], Seq[TransactionResponse]],
+    transactions: Either[Seq[ByteString], Seq[BaseTransactionResponse]],
     uncles: Seq[ByteString]
 ) extends BaseBlockResponse
 

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/EthBlocksService.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/EthBlocksService.scala
@@ -3,7 +3,6 @@ package io.iohk.ethereum.jsonrpc
 import akka.util.ByteString
 import io.iohk.ethereum.domain.Blockchain
 import io.iohk.ethereum.ledger.Ledger
-import io.iohk.ethereum.utils.{BlockchainConfig, Logger}
 import monix.eval.Task
 import org.bouncycastle.util.encoders.Hex
 

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/EthBlocksService.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/EthBlocksService.scala
@@ -15,19 +15,19 @@ object EthBlocksService {
   case class TxCountByBlockHashResponse(txsQuantity: Option[Int])
 
   case class BlockByBlockHashRequest(blockHash: ByteString, fullTxs: Boolean)
-  case class BlockByBlockHashResponse(blockResponse: Option[BlockResponse])
+  case class BlockByBlockHashResponse(blockResponse: Option[BaseBlockResponse])
 
   case class BlockByNumberRequest(block: BlockParam, fullTxs: Boolean)
-  case class BlockByNumberResponse(blockResponse: Option[BlockResponse])
+  case class BlockByNumberResponse(blockResponse: Option[BaseBlockResponse])
 
   case class GetBlockTransactionCountByNumberRequest(block: BlockParam)
   case class GetBlockTransactionCountByNumberResponse(result: BigInt)
 
   case class UncleByBlockHashAndIndexRequest(blockHash: ByteString, uncleIndex: BigInt)
-  case class UncleByBlockHashAndIndexResponse(uncleBlockResponse: Option[BlockResponse])
+  case class UncleByBlockHashAndIndexResponse(uncleBlockResponse: Option[BaseBlockResponse])
 
   case class UncleByBlockNumberAndIndexRequest(block: BlockParam, uncleIndex: BigInt)
-  case class UncleByBlockNumberAndIndexResponse(uncleBlockResponse: Option[BlockResponse])
+  case class UncleByBlockNumberAndIndexResponse(uncleBlockResponse: Option[BaseBlockResponse])
 
   case class GetUncleCountByBlockNumberRequest(block: BlockParam)
   case class GetUncleCountByBlockNumberResponse(result: BigInt)

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/JsonMethodsImplicits.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/JsonMethodsImplicits.scala
@@ -30,7 +30,7 @@ trait JsonMethodsImplicits {
   def encodeAsHex(input: BigInt): JString =
     JString(s"0x${input.toString(16)}")
 
-  protected def decode(s: String): Array[Byte] = {
+  def decode(s: String): Array[Byte] = {
     val stripped = s.replaceFirst("^0x", "")
     val normalized = if (stripped.length % 2 == 1) "0" + stripped else stripped
     Hex.decode(normalized)

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/JsonMethodsImplicits.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/JsonMethodsImplicits.scala
@@ -1,7 +1,6 @@
 package io.iohk.ethereum.jsonrpc
 
 import java.time.Duration
-
 import akka.util.ByteString
 import io.iohk.ethereum.crypto.ECDSASignature
 import io.iohk.ethereum.domain.Address
@@ -13,13 +12,14 @@ import io.iohk.ethereum.jsonrpc.serialization.JsonMethodDecoder.NoParamsMethodDe
 import io.iohk.ethereum.jsonrpc.serialization.{JsonEncoder, JsonMethodCodec, JsonMethodDecoder, JsonSerializers}
 import io.iohk.ethereum.utils.BigIntExtensionMethods.BigIntAsUnsigned
 import org.bouncycastle.util.encoders.Hex
+import org.json4s.Formats
 import org.json4s.JsonAST._
 import org.json4s.JsonDSL._
 
 import scala.util.Try
 
 trait JsonMethodsImplicits {
-  implicit val formats = JsonSerializers.formats
+  implicit val formats: Formats = JsonSerializers.formats
 
   def encodeAsHex(input: ByteString): JString =
     JString(s"0x${Hex.toHexString(input.toArray[Byte])}")

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/JsonRpcController.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/JsonRpcController.scala
@@ -245,6 +245,8 @@ case class JsonRpcController(
       handle[ModifyTimestampRequest, ModifyTimestampResponse](testService.modifyTimestamp, req)
     case req @ JsonRpcRequest(_, "test_rewindToBlock", _, _) =>
       handle[RewindToBlockRequest, RewindToBlockResponse](testService.rewindToBlock, req)
+    case req @ JsonRpcRequest(_, "test_importRawBlock", _, _) =>
+      handle[ImportRawBlockRequest, ImportRawBlockResponse](testService.importRawBlock, req)
     case req @ JsonRpcRequest(_, "miner_setEtherbase", _, _) =>
       handle[SetEtherbaseRequest, SetEtherbaseResponse](testService.setEtherbase, req)
   }

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/JsonRpcController.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/JsonRpcController.scala
@@ -251,6 +251,8 @@ case class JsonRpcController(
       handle[SetEtherbaseRequest, SetEtherbaseResponse](testService.setEtherbase, req)
     case req @ JsonRpcRequest(_, "debug_accountRange", _, _) =>
       handle[AccountsInRangeRequest, AccountsInRangeResponse](testService.getAccountsInRange, req)
+    case req @ JsonRpcRequest(_, "debug_storageRangeAt", _, _) =>
+      handle[StorageRangeRequest, StorageRangeResponse](testService.storageRangeAt, req)
   }
 
   private def handleIeleRequest: PartialFunction[JsonRpcRequest, Task[JsonRpcResponse]] = {

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/JsonRpcController.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/JsonRpcController.scala
@@ -247,6 +247,8 @@ case class JsonRpcController(
       handle[RewindToBlockRequest, RewindToBlockResponse](testService.rewindToBlock, req)
     case req @ JsonRpcRequest(_, "test_importRawBlock", _, _) =>
       handle[ImportRawBlockRequest, ImportRawBlockResponse](testService.importRawBlock, req)
+    case req @ JsonRpcRequest(_, "test_getLogHash", _, _) =>
+      handle[GetLogHashRequest, GetLogHashResponse](testService.getLogHash, req)
     case req @ JsonRpcRequest(_, "miner_setEtherbase", _, _) =>
       handle[SetEtherbaseRequest, SetEtherbaseResponse](testService.setEtherbase, req)
     case req @ JsonRpcRequest(_, "debug_accountRange", _, _) =>

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/JsonRpcController.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/JsonRpcController.scala
@@ -249,6 +249,8 @@ case class JsonRpcController(
       handle[ImportRawBlockRequest, ImportRawBlockResponse](testService.importRawBlock, req)
     case req @ JsonRpcRequest(_, "miner_setEtherbase", _, _) =>
       handle[SetEtherbaseRequest, SetEtherbaseResponse](testService.setEtherbase, req)
+    case req @ JsonRpcRequest(_, "debug_accountRange", _, _) =>
+      handle[AccountsInRangeRequest, AccountsInRangeResponse](testService.getAccountsInRange, req)
   }
 
   private def handleIeleRequest: PartialFunction[JsonRpcRequest, Task[JsonRpcResponse]] = {

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/JsonRpcController.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/JsonRpcController.scala
@@ -251,6 +251,7 @@ case class JsonRpcController(
       handle[GetLogHashRequest, GetLogHashResponse](testService.getLogHash, req)
     case req @ JsonRpcRequest(_, "miner_setEtherbase", _, _) =>
       handle[SetEtherbaseRequest, SetEtherbaseResponse](testService.setEtherbase, req)
+    //FIXME: 'debug_' has it's own 'handle' method, should be aligned (ETCM-806)
     case req @ JsonRpcRequest(_, "debug_accountRange", _, _) =>
       handle[AccountsInRangeRequest, AccountsInRangeResponse](testService.getAccountsInRange, req)
     case req @ JsonRpcRequest(_, "debug_storageRangeAt", _, _) =>

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/JsonRpcRequest.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/JsonRpcRequest.scala
@@ -18,7 +18,8 @@ trait SensitiveInformationToString {
 
 case class JsonRpcRequest(jsonrpc: String, method: String, params: Option[JArray], id: Option[JValue])
     extends SensitiveInformationToString {
-  override def toString(): String = {
+
+  def inspect: String = {
     implicit val formats: Formats = DefaultFormats
     "JsonRpcRequest" + (jsonrpc, method, params.map(write(_)), id.map(write(_))).toString
   }

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/JsonRpcRequest.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/JsonRpcRequest.scala
@@ -1,6 +1,9 @@
 package io.iohk.ethereum.jsonrpc
 
 import org.json4s.JsonAST.{JArray, JValue}
+import org.json4s.native.Serialization.write
+import org.json4s.DefaultFormats
+import org.json4s.Formats
 
 //TODO: work on a more elegant solution
 trait SensitiveInformationToString {
@@ -14,4 +17,9 @@ trait SensitiveInformationToString {
 }
 
 case class JsonRpcRequest(jsonrpc: String, method: String, params: Option[JArray], id: Option[JValue])
-    extends SensitiveInformationToString
+    extends SensitiveInformationToString {
+  override def toString(): String = {
+    implicit val formats: Formats = DefaultFormats
+    "JsonRpcRequest" + (jsonrpc, method, params.map(write(_)), id.map(write(_))).toString
+  }
+}

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/JsonRpcResponse.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/JsonRpcResponse.scala
@@ -1,5 +1,13 @@
 package io.iohk.ethereum.jsonrpc
 
+import org.json4s.native.Serialization.write
 import org.json4s.JsonAST.JValue
+import org.json4s.DefaultFormats
+import org.json4s.Formats
 
-case class JsonRpcResponse(jsonrpc: String, result: Option[JValue], error: Option[JsonRpcError], id: JValue)
+case class JsonRpcResponse(jsonrpc: String, result: Option[JValue], error: Option[JsonRpcError], id: JValue) {
+  def inspect: String = {
+    implicit val formats: Formats = DefaultFormats
+    "JsonRpcResponse" + (jsonrpc, result.map(write(_)), error.map(write(_))).toString
+  }
+}

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/TestJsonMethodsImplicits.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/TestJsonMethodsImplicits.scala
@@ -6,14 +6,11 @@ import io.iohk.ethereum.jsonrpc.TestService._
 import io.iohk.ethereum.jsonrpc.serialization.{JsonEncoder, JsonMethodDecoder}
 import org.json4s.JsonAST._
 import org.json4s.JsonDSL._
-import org.bouncycastle.util.encoders.Hex
 import cats.implicits._
 import io.iohk.ethereum.blockchain.data.GenesisAccount
 
 import scala.util.Try
 import io.iohk.ethereum.domain.UInt256
-import org.json4s
-import org.json4s.Extraction
 
 object TestJsonMethodsImplicits extends JsonMethodsImplicits {
 
@@ -183,6 +180,11 @@ object TestJsonMethodsImplicits extends JsonMethodsImplicits {
       extractHash(blockHash)
         .fold(_ => Left(BigInt(blockHash)), Right(_))
 
-    override def encodeJson(t: AccountsInRangeResponse): JValue = Extraction.decompose(t)
+    override def encodeJson(t: AccountsInRangeResponse): JValue = JObject(
+      "addressMap" -> JObject(
+        t.addressMap.toList.map(addressPair => encodeAsHex(addressPair._1).values -> encodeAsHex(addressPair._2))
+      ),
+      "nextKey" -> encodeAsHex(t.nextKey)
+    )
   }
 }

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/TestJsonMethodsImplicits.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/TestJsonMethodsImplicits.scala
@@ -74,11 +74,14 @@ object TestJsonMethodsImplicits extends JsonMethodsImplicits {
     private def extractGenesis(genesisJson: JValue): Either[JsonRpcError, GenesisParams] = {
       for {
         author <- extractBytes((genesisJson \ "author").extract[String])
+        difficulty = (genesisJson \ "difficulty").extractOrElse("0")
         extraData <- extractBytes((genesisJson \ "extraData").extract[String])
         gasLimit <- extractQuantity(genesisJson \ "gasLimit")
         parentHash <- extractBytes((genesisJson \ "parentHash").extractOrElse(""))
         timestamp <- extractBytes((genesisJson \ "timestamp").extract[String])
-      } yield GenesisParams(author, extraData, gasLimit, parentHash, timestamp)
+        nonce <- extractBytes((genesisJson \ "nonce").extract[String])
+        mixHash <- extractBytes((genesisJson \ "mixHash").extract[String])
+      } yield GenesisParams(author, difficulty, extraData, gasLimit, parentHash, timestamp, nonce, mixHash)
     }
 
     def decodeJson(params: Option[JArray]): Either[JsonRpcError, SetChainParamsRequest] =

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/TestJsonMethodsImplicits.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/TestJsonMethodsImplicits.scala
@@ -131,6 +131,18 @@ object TestJsonMethodsImplicits extends JsonMethodsImplicits {
     override def encodeJson(t: RewindToBlockResponse): JValue = true
   }
 
+  implicit val test_importRawBlock = new JsonMethodDecoder[ImportRawBlockRequest]
+    with JsonEncoder[ImportRawBlockResponse] {
+    def decodeJson(params: Option[JArray]): Either[JsonRpcError, ImportRawBlockRequest] =
+      params match {
+        case Some(JArray(JString(blockRlp) :: Nil)) =>
+          Right(ImportRawBlockRequest(blockRlp))
+        case _ => Left(InvalidParams())
+      }
+
+    override def encodeJson(t: ImportRawBlockResponse): JValue = t.blockHash
+  }
+
   implicit val miner_setEtherbase = new JsonMethodDecoder[SetEtherbaseRequest] with JsonEncoder[SetEtherbaseResponse] {
     def decodeJson(params: Option[JArray]): Either[JsonRpcError, SetEtherbaseRequest] =
       params match {

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/TestJsonMethodsImplicits.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/TestJsonMethodsImplicits.scala
@@ -21,22 +21,22 @@ object TestJsonMethodsImplicits extends JsonMethodsImplicits {
     private def extractAccount(accountJson: JValue): Either[JsonRpcError, GenesisAccount] =
       for {
         storageObject <- Try((accountJson \ "storage").extract[JObject]).toEither.left.map(e =>
-          InvalidParams(e.toString())
+          InvalidParams(e.toString)
         )
         storage <- storageObject.obj.traverse {
           case (key, JString(value)) =>
-            Try(UInt256(decode(key)) -> UInt256(decode(value))).toEither.left.map(e => InvalidParams(e.toString()))
+            Try(UInt256(decode(key)) -> UInt256(decode(value))).toEither.left.map(e => InvalidParams(e.toString))
           case _ => Left(InvalidParams())
         }
         balance = UInt256(decode((accountJson \ "balance").extract[String]))
-        code = ByteString(decode((accountJson \ "code").extract[String]))
-        nonce = UInt256(decode((accountJson \ "nonce").extract[String]))
+        code = Some(ByteString(decode((accountJson \ "code").extract[String])))
+        nonce = Some(UInt256(decode((accountJson \ "nonce").extract[String])))
       } yield GenesisAccount(
         None,
         balance,
         code,
         nonce,
-        storage.toMap
+        Some(storage.toMap)
       )
 
     private def extractAccounts(accountsJson: JValue): Either[JsonRpcError, Map[ByteString, GenesisAccount]] =

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/TestJsonMethodsImplicits.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/TestJsonMethodsImplicits.scala
@@ -216,4 +216,17 @@ object TestJsonMethodsImplicits extends JsonMethodsImplicits {
 
     override def encodeJson(t: StorageRangeResponse): JValue = Extraction.decompose(t)
   }
+
+  implicit val test_getLogHash = new JsonMethodDecoder[GetLogHashRequest] with JsonEncoder[GetLogHashResponse] {
+    def decodeJson(params: Option[JArray]): Either[JsonRpcError, GetLogHashRequest] =
+      params match {
+        case Some(JArray(JString(transactionHashString) :: Nil)) =>
+          for {
+            transactionHash <- extractHash(transactionHashString)
+          } yield GetLogHashRequest(transactionHash)
+        case _ => Left(InvalidParams())
+      }
+
+    override def encodeJson(t: GetLogHashResponse): JValue = encodeAsHex(t.logHash)
+  }
 }

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/TestJsonMethodsImplicits.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/TestJsonMethodsImplicits.scala
@@ -18,210 +18,213 @@ object TestJsonMethodsImplicits extends JsonMethodsImplicits {
   implicit val test_setChainParams: JsonMethodDecoder[SetChainParamsRequest] with JsonEncoder[SetChainParamsResponse] =
     new JsonMethodDecoder[SetChainParamsRequest] with JsonEncoder[SetChainParamsResponse] {
 
-    private def extractAccounts(accountsJson: JValue): Either[JsonRpcError, Map[ByteString, GenesisAccount]] =
-      for {
-        mapping <- Try(accountsJson.extract[JObject]).toEither.leftMap(e => InvalidParams(e.toString))
-        accounts <- mapping.obj.traverse { case (key, value) =>
-          for {
-            address <- extractBytes(key)
-            account <- extractAccount(value)
-          } yield address -> account
-        }
-      } yield accounts.toMap
+      private def extractAccounts(accountsJson: JValue): Either[JsonRpcError, Map[ByteString, GenesisAccount]] =
+        for {
+          mapping <- Try(accountsJson.extract[JObject]).toEither.leftMap(e => InvalidParams(e.toString))
+          accounts <- mapping.obj.traverse { case (key, value) =>
+            for {
+              address <- extractBytes(key)
+              account <- extractAccount(value)
+            } yield address -> account
+          }
+        } yield accounts.toMap
 
-    private def extractAccount(accountJson: JValue): Either[JsonRpcError, GenesisAccount] =
-      for {
-        storageObject <- Try((accountJson \ "storage").extract[JObject]).toEither.leftMap(e => InvalidParams(e.toString))
-        storage <- storageObject.obj.traverse {
-          case (key, JString(value)) =>
-            Try(UInt256(decode(key)) -> UInt256(decode(value))).toEither.leftMap(e => InvalidParams(e.toString))
+      private def extractAccount(accountJson: JValue): Either[JsonRpcError, GenesisAccount] =
+        for {
+          storageObject <- Try((accountJson \ "storage").extract[JObject]).toEither.leftMap(e =>
+            InvalidParams(e.toString)
+          )
+          storage <- storageObject.obj.traverse {
+            case (key, JString(value)) =>
+              Try(UInt256(decode(key)) -> UInt256(decode(value))).toEither.leftMap(e => InvalidParams(e.toString))
+            case _ => Left(InvalidParams())
+          }
+          balance = UInt256(decode((accountJson \ "balance").extract[String]))
+          code = decode((accountJson \ "code").extract[String])
+          codeOpt = if (code.isEmpty) None else Some(ByteString(code))
+          nonce = decode((accountJson \ "nonce").extract[String])
+          nonceOpt = if (nonce.isEmpty || UInt256(nonce) == UInt256.Zero) None else Some(UInt256(nonce))
+        } yield GenesisAccount(
+          None,
+          balance,
+          codeOpt,
+          nonceOpt,
+          Some(storage.toMap)
+        )
+
+      def decodeJson(params: Option[JArray]): Either[JsonRpcError, SetChainParamsRequest] =
+        params match {
+          case Some(JArray(paramsObj :: Nil)) =>
+            for {
+              genesis <- extractGenesis(paramsObj \ "genesis")
+              blockchainParams <- extractBlockchainParams(paramsObj \ "params")
+              sealEngine <- Try((paramsObj \ "sealEngine").extract[String]).toEither.leftMap(_ => InvalidParams())
+              accounts <- extractAccounts(paramsObj \ "accounts")
+            } yield SetChainParamsRequest(ChainParams(genesis, blockchainParams, sealEngine, accounts))
           case _ => Left(InvalidParams())
         }
-        balance = UInt256(decode((accountJson \ "balance").extract[String]))
-        code = decode((accountJson \ "code").extract[String])
-        codeOpt = if (code.isEmpty) None else Some(ByteString(code))
-        nonce = decode((accountJson \ "nonce").extract[String])
-        nonceOpt = if (nonce.isEmpty || UInt256(nonce) == UInt256.Zero) None else Some(UInt256(nonce))
-      } yield GenesisAccount(
-        None,
-        balance,
-        codeOpt,
-        nonceOpt,
-        Some(storage.toMap)
-      )
 
-    def decodeJson(params: Option[JArray]): Either[JsonRpcError, SetChainParamsRequest] =
-      params match {
-        case Some(JArray(paramsObj :: Nil)) =>
-          for {
-            genesis <- extractGenesis(paramsObj \ "genesis")
-            blockchainParams <- extractBlockchainParams(paramsObj \ "params")
-            sealEngine <- Try((paramsObj \ "sealEngine").extract[String]).toEither.leftMap(_ => InvalidParams())
-            accounts <- extractAccounts(paramsObj \ "accounts")
-          } yield SetChainParamsRequest(ChainParams(genesis, blockchainParams, sealEngine, accounts))
-        case _ => Left(InvalidParams())
+      private def extractGenesis(genesisJson: JValue): Either[JsonRpcError, GenesisParams] = {
+        for {
+          author <- extractBytes((genesisJson \ "author").extract[String])
+          difficulty = (genesisJson \ "difficulty").extractOrElse("0")
+          extraData <- extractBytes((genesisJson \ "extraData").extract[String])
+          gasLimit <- extractQuantity(genesisJson \ "gasLimit")
+          parentHash <- extractBytes((genesisJson \ "parentHash").extractOrElse(""))
+          timestamp <- extractBytes((genesisJson \ "timestamp").extract[String])
+          nonce <- extractBytes((genesisJson \ "nonce").extract[String])
+          mixHash <- extractBytes((genesisJson \ "mixHash").extract[String])
+        } yield GenesisParams(author, difficulty, extraData, gasLimit, parentHash, timestamp, nonce, mixHash)
       }
 
-    private def extractGenesis(genesisJson: JValue): Either[JsonRpcError, GenesisParams] = {
-      for {
-        author <- extractBytes((genesisJson \ "author").extract[String])
-        difficulty = (genesisJson \ "difficulty").extractOrElse("0")
-        extraData <- extractBytes((genesisJson \ "extraData").extract[String])
-        gasLimit <- extractQuantity(genesisJson \ "gasLimit")
-        parentHash <- extractBytes((genesisJson \ "parentHash").extractOrElse(""))
-        timestamp <- extractBytes((genesisJson \ "timestamp").extract[String])
-        nonce <- extractBytes((genesisJson \ "nonce").extract[String])
-        mixHash <- extractBytes((genesisJson \ "mixHash").extract[String])
-      } yield GenesisParams(author, difficulty, extraData, gasLimit, parentHash, timestamp, nonce, mixHash)
-    }
+      private def extractBlockchainParams(blockchainParamsJson: JValue): Either[JsonRpcError, BlockchainParams] = {
+        for {
+          eIP150ForkBlock <- optionalQuantity(blockchainParamsJson \ "EIP150ForkBlock")
+          eIP158ForkBlock <- optionalQuantity(blockchainParamsJson \ "EIP158ForkBlock")
+          accountStartNonce <- optionalQuantity(blockchainParamsJson \ "accountStartNonce")
+          allowFutureBlocks = (blockchainParamsJson \ "allowFutureBlocks").extractOrElse(true)
+          blockReward <- optionalQuantity(blockchainParamsJson \ "blockReward")
+          byzantiumForkBlock <- optionalQuantity(blockchainParamsJson \ "byzantiumForkBlock")
+          homesteadForkBlock <- optionalQuantity(blockchainParamsJson \ "homesteadForkBlock")
+          constantinopleForkBlock <- optionalQuantity(blockchainParamsJson \ "constantinopleForkBlock")
+          istanbulForkBlock <- optionalQuantity(blockchainParamsJson \ "istanbulForkBlock")
+        } yield BlockchainParams(
+          eIP150ForkBlock.getOrElse(0),
+          eIP158ForkBlock.getOrElse(0),
+          accountStartNonce.getOrElse(0),
+          allowFutureBlocks,
+          blockReward.getOrElse(0),
+          byzantiumForkBlock.getOrElse(0),
+          homesteadForkBlock.getOrElse(0),
+          0,
+          constantinopleForkBlock.getOrElse(0),
+          istanbulForkBlock.getOrElse(0)
+        )
+      }
 
-    private def extractBlockchainParams(blockchainParamsJson: JValue): Either[JsonRpcError, BlockchainParams] = {
-      for {
-        eIP150ForkBlock <- optionalQuantity(blockchainParamsJson \ "EIP150ForkBlock")
-        eIP158ForkBlock <- optionalQuantity(blockchainParamsJson \ "EIP158ForkBlock")
-        accountStartNonce <- optionalQuantity(blockchainParamsJson \ "accountStartNonce")
-        allowFutureBlocks = (blockchainParamsJson \ "allowFutureBlocks").extractOrElse(true)
-        blockReward <- optionalQuantity(blockchainParamsJson \ "blockReward")
-        byzantiumForkBlock <- optionalQuantity(blockchainParamsJson \ "byzantiumForkBlock")
-        homesteadForkBlock <- optionalQuantity(blockchainParamsJson \ "homesteadForkBlock")
-        constantinopleForkBlock <- optionalQuantity(blockchainParamsJson \ "constantinopleForkBlock")
-        istanbulForkBlock <- optionalQuantity(blockchainParamsJson \ "istanbulForkBlock")
-      } yield BlockchainParams(
-        eIP150ForkBlock.getOrElse(0),
-        eIP158ForkBlock.getOrElse(0),
-        accountStartNonce.getOrElse(0),
-        allowFutureBlocks,
-        blockReward.getOrElse(0),
-        byzantiumForkBlock.getOrElse(0),
-        homesteadForkBlock.getOrElse(0),
-        0,
-        constantinopleForkBlock.getOrElse(0),
-        istanbulForkBlock.getOrElse(0)
-      )
+      override def encodeJson(t: SetChainParamsResponse): JValue = true
     }
-
-    override def encodeJson(t: SetChainParamsResponse): JValue = true
-  }
 
   implicit val test_mineBlocks: JsonMethodDecoder[MineBlocksRequest] with JsonEncoder[MineBlocksResponse] =
     new JsonMethodDecoder[MineBlocksRequest] with JsonEncoder[MineBlocksResponse] {
-    def decodeJson(params: Option[JArray]): Either[JsonRpcError, MineBlocksRequest] =
-      params match {
-        case Some(JArray(JInt(numBlocks) :: Nil)) =>
-          Right(MineBlocksRequest(numBlocks.toInt))
-        case _ => Left(InvalidParams())
-      }
+      def decodeJson(params: Option[JArray]): Either[JsonRpcError, MineBlocksRequest] =
+        params match {
+          case Some(JArray(JInt(numBlocks) :: Nil)) =>
+            Right(MineBlocksRequest(numBlocks.toInt))
+          case _ => Left(InvalidParams())
+        }
 
-    override def encodeJson(t: MineBlocksResponse): JValue = true
-  }
+      override def encodeJson(t: MineBlocksResponse): JValue = true
+    }
 
-  implicit val test_modifyTimestamp: JsonMethodDecoder[ModifyTimestampRequest] with JsonEncoder[ModifyTimestampResponse] =
+  implicit val test_modifyTimestamp
+      : JsonMethodDecoder[ModifyTimestampRequest] with JsonEncoder[ModifyTimestampResponse] =
     new JsonMethodDecoder[ModifyTimestampRequest] with JsonEncoder[ModifyTimestampResponse] {
-    def decodeJson(params: Option[JArray]): Either[JsonRpcError, ModifyTimestampRequest] =
-      params match {
-        case Some(JArray(JInt(timestamp) :: Nil)) =>
-          Right(ModifyTimestampRequest(timestamp.toLong))
-        case _ => Left(InvalidParams())
-      }
+      def decodeJson(params: Option[JArray]): Either[JsonRpcError, ModifyTimestampRequest] =
+        params match {
+          case Some(JArray(JInt(timestamp) :: Nil)) =>
+            Right(ModifyTimestampRequest(timestamp.toLong))
+          case _ => Left(InvalidParams())
+        }
 
-    override def encodeJson(t: ModifyTimestampResponse): JValue = true
-  }
+      override def encodeJson(t: ModifyTimestampResponse): JValue = true
+    }
 
   implicit val test_rewindToBlock: JsonMethodDecoder[RewindToBlockRequest] with JsonEncoder[RewindToBlockResponse] =
     new JsonMethodDecoder[RewindToBlockRequest] with JsonEncoder[RewindToBlockResponse] {
-    def decodeJson(params: Option[JArray]): Either[JsonRpcError, RewindToBlockRequest] =
-      params match {
-        case Some(JArray(JInt(blockNum) :: Nil)) =>
-          Right(RewindToBlockRequest(blockNum.toLong))
-        case _ => Left(InvalidParams())
-      }
+      def decodeJson(params: Option[JArray]): Either[JsonRpcError, RewindToBlockRequest] =
+        params match {
+          case Some(JArray(JInt(blockNum) :: Nil)) =>
+            Right(RewindToBlockRequest(blockNum.toLong))
+          case _ => Left(InvalidParams())
+        }
 
-    override def encodeJson(t: RewindToBlockResponse): JValue = true
-  }
+      override def encodeJson(t: RewindToBlockResponse): JValue = true
+    }
 
   implicit val test_importRawBlock: JsonMethodDecoder[ImportRawBlockRequest] with JsonEncoder[ImportRawBlockResponse] =
     new JsonMethodDecoder[ImportRawBlockRequest] with JsonEncoder[ImportRawBlockResponse] {
-    def decodeJson(params: Option[JArray]): Either[JsonRpcError, ImportRawBlockRequest] =
-      params match {
-        case Some(JArray(JString(blockRlp) :: Nil)) =>
-          Right(ImportRawBlockRequest(blockRlp))
-        case _ => Left(InvalidParams())
-      }
+      def decodeJson(params: Option[JArray]): Either[JsonRpcError, ImportRawBlockRequest] =
+        params match {
+          case Some(JArray(JString(blockRlp) :: Nil)) =>
+            Right(ImportRawBlockRequest(blockRlp))
+          case _ => Left(InvalidParams())
+        }
 
-    override def encodeJson(t: ImportRawBlockResponse): JValue = t.blockHash
-  }
+      override def encodeJson(t: ImportRawBlockResponse): JValue = t.blockHash
+    }
 
   implicit val miner_setEtherbase: JsonMethodDecoder[SetEtherbaseRequest] with JsonEncoder[SetEtherbaseResponse] =
     new JsonMethodDecoder[SetEtherbaseRequest] with JsonEncoder[SetEtherbaseResponse] {
-    def decodeJson(params: Option[JArray]): Either[JsonRpcError, SetEtherbaseRequest] =
-      params match {
-        case Some(JArray((addressStr: JString) :: Nil)) =>
-          extractAddress(addressStr).map(address => SetEtherbaseRequest(address))
-        case _ => Left(InvalidParams())
-      }
+      def decodeJson(params: Option[JArray]): Either[JsonRpcError, SetEtherbaseRequest] =
+        params match {
+          case Some(JArray((addressStr: JString) :: Nil)) =>
+            extractAddress(addressStr).map(address => SetEtherbaseRequest(address))
+          case _ => Left(InvalidParams())
+        }
 
-    def encodeJson(t: SetEtherbaseResponse): JValue = true
-  }
+      def encodeJson(t: SetEtherbaseResponse): JValue = true
+    }
 
   implicit val debug_accountRange: JsonMethodDecoder[AccountsInRangeRequest] with JsonEncoder[AccountsInRangeResponse] =
     new JsonMethodDecoder[AccountsInRangeRequest] with JsonEncoder[AccountsInRangeResponse] {
-    override def decodeJson(params: Option[JArray]): Either[JsonRpcError, AccountsInRangeRequest] =
-      params match {
-        case Some(JArray(blockHashOrNumber :: txIndex :: addressHash :: maxResults :: Nil)) =>
-          for {
-            txIndex <- extractQuantity(txIndex)
-            maxResults <- extractQuantity(maxResults)
-            addressHash <- extractBytes(addressHash.extract[String])
-            blockHashOrNumberEither = extractBlockHashOrNumber(blockHashOrNumber.extract[String])
-          } yield AccountsInRangeRequest(
-            AccountsInRangeRequestParams(blockHashOrNumberEither, txIndex, addressHash, maxResults)
-          )
-        case _ => Left(InvalidParams())
-      }
+      override def decodeJson(params: Option[JArray]): Either[JsonRpcError, AccountsInRangeRequest] =
+        params match {
+          case Some(JArray(blockHashOrNumber :: txIndex :: addressHash :: maxResults :: Nil)) =>
+            for {
+              txIndex <- extractQuantity(txIndex)
+              maxResults <- extractQuantity(maxResults)
+              addressHash <- extractBytes(addressHash.extract[String])
+              blockHashOrNumberEither = extractBlockHashOrNumber(blockHashOrNumber.extract[String])
+            } yield AccountsInRangeRequest(
+              AccountsInRangeRequestParams(blockHashOrNumberEither, txIndex, addressHash, maxResults)
+            )
+          case _ => Left(InvalidParams())
+        }
 
-    private def extractBlockHashOrNumber(blockHash: String): Either[BigInt, ByteString] =
-      extractHash(blockHash).fold(_ => Left(BigInt(blockHash)), Right(_))
+      private def extractBlockHashOrNumber(blockHash: String): Either[BigInt, ByteString] =
+        extractHash(blockHash).fold(_ => Left(BigInt(blockHash)), Right(_))
 
-    override def encodeJson(t: AccountsInRangeResponse): JValue = JObject(
-      "addressMap" -> JObject(
-        t.addressMap.toList.map(addressPair => encodeAsHex(addressPair._1).values -> encodeAsHex(addressPair._2))
-      ),
-      "nextKey" -> encodeAsHex(t.nextKey)
-    )
-  }
+      override def encodeJson(t: AccountsInRangeResponse): JValue = JObject(
+        "addressMap" -> JObject(
+          t.addressMap.toList.map(addressPair => encodeAsHex(addressPair._1).values -> encodeAsHex(addressPair._2))
+        ),
+        "nextKey" -> encodeAsHex(t.nextKey)
+      )
+    }
 
   implicit val debug_storageRangeAt: JsonMethodDecoder[StorageRangeRequest] with JsonEncoder[StorageRangeResponse] =
     new JsonMethodDecoder[StorageRangeRequest] with JsonEncoder[StorageRangeResponse] {
-    override def decodeJson(params: Option[JArray]): Either[JsonRpcError, StorageRangeRequest] =
-      params match {
-        case Some(JArray(blockHashOrNumber :: txIndex :: address :: begin :: maxResults :: Nil)) =>
-          for {
-            txIndex <- extractQuantity(txIndex)
-            maxResults <- extractQuantity(maxResults)
-            begin <- extractQuantity(begin)
-            addressHash <- extractBytes(address.extract[String])
-            blockHashOrNumberEither = extractBlockHashOrNumber(blockHashOrNumber.extract[String])
-          } yield StorageRangeRequest(
-            StorageRangeParams(blockHashOrNumberEither, txIndex, addressHash, begin, maxResults)
-          )
-        case _ => Left(InvalidParams())
-      }
+      override def decodeJson(params: Option[JArray]): Either[JsonRpcError, StorageRangeRequest] =
+        params match {
+          case Some(JArray(blockHashOrNumber :: txIndex :: address :: begin :: maxResults :: Nil)) =>
+            for {
+              txIndex <- extractQuantity(txIndex)
+              maxResults <- extractQuantity(maxResults)
+              begin <- extractQuantity(begin)
+              addressHash <- extractBytes(address.extract[String])
+              blockHashOrNumberEither = extractBlockHashOrNumber(blockHashOrNumber.extract[String])
+            } yield StorageRangeRequest(
+              StorageRangeParams(blockHashOrNumberEither, txIndex, addressHash, begin, maxResults)
+            )
+          case _ => Left(InvalidParams())
+        }
 
-    private def extractBlockHashOrNumber(blockHash: String): Either[BigInt, ByteString] =
-      extractHash(blockHash).fold(_ => Left(BigInt(blockHash)), Right(_))
+      private def extractBlockHashOrNumber(blockHash: String): Either[BigInt, ByteString] =
+        extractHash(blockHash).fold(_ => Left(BigInt(blockHash)), Right(_))
 
-    override def encodeJson(t: StorageRangeResponse): JValue = Extraction.decompose(t)
-  }
+      override def encodeJson(t: StorageRangeResponse): JValue = Extraction.decompose(t)
+    }
 
   implicit val test_getLogHash: JsonMethodDecoder[GetLogHashRequest] with JsonEncoder[GetLogHashResponse] =
     new JsonMethodDecoder[GetLogHashRequest] with JsonEncoder[GetLogHashResponse] {
-    def decodeJson(params: Option[JArray]): Either[JsonRpcError, GetLogHashRequest] =
-      params match {
-        case Some(JArray(JString(transactionHashString) :: Nil)) =>
-          extractHash(transactionHashString).map(th => GetLogHashRequest(th))
-        case _ => Left(InvalidParams())
-      }
+      def decodeJson(params: Option[JArray]): Either[JsonRpcError, GetLogHashRequest] =
+        params match {
+          case Some(JArray(JString(transactionHashString) :: Nil)) =>
+            extractHash(transactionHashString).map(th => GetLogHashRequest(th))
+          case _ => Left(InvalidParams())
+        }
 
-    override def encodeJson(t: GetLogHashResponse): JValue = encodeAsHex(t.logHash)
-  }
+      override def encodeJson(t: GetLogHashResponse): JValue = encodeAsHex(t.logHash)
+    }
 }

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/TestJsonMethodsImplicits.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/TestJsonMethodsImplicits.scala
@@ -54,26 +54,26 @@ object TestJsonMethodsImplicits extends JsonMethodsImplicits {
 
     private def extractBlockchainParams(blockchainParamsJson: JValue): Either[JsonRpcError, BlockchainParams] = {
       for {
-        eIP150ForkBlock <- extractQuantity(blockchainParamsJson \ "EIP150ForkBlock")
-        eIP158ForkBlock <- extractQuantity(blockchainParamsJson \ "EIP158ForkBlock")
+        eIP150ForkBlock <- optionalQuantity(blockchainParamsJson \ "EIP150ForkBlock")
+        eIP158ForkBlock <- optionalQuantity(blockchainParamsJson \ "EIP158ForkBlock")
         accountStartNonce <- optionalQuantity(blockchainParamsJson \ "accountStartNonce")
         allowFutureBlocks = (blockchainParamsJson \ "allowFutureBlocks").extractOrElse(true)
         blockReward <- optionalQuantity(blockchainParamsJson \ "blockReward")
-        byzantiumForkBlock <- extractQuantity(blockchainParamsJson \ "byzantiumForkBlock")
-        homesteadForkBlock <- extractQuantity(blockchainParamsJson \ "homesteadForkBlock")
-        constantinopleForkBlock <- extractQuantity(blockchainParamsJson \ "constantinopleForkBlock")
-        istanbulForkBlock <- extractQuantity(blockchainParamsJson \ "istanbulForkBlock")
+        byzantiumForkBlock <- optionalQuantity(blockchainParamsJson \ "byzantiumForkBlock")
+        homesteadForkBlock <- optionalQuantity(blockchainParamsJson \ "homesteadForkBlock")
+        constantinopleForkBlock <- optionalQuantity(blockchainParamsJson \ "constantinopleForkBlock")
+        istanbulForkBlock <- optionalQuantity(blockchainParamsJson \ "istanbulForkBlock")
       } yield BlockchainParams(
-        eIP150ForkBlock,
-        eIP158ForkBlock,
+        eIP150ForkBlock.getOrElse(0),
+        eIP158ForkBlock.getOrElse(0),
         accountStartNonce.getOrElse(0),
         allowFutureBlocks,
         blockReward.getOrElse(0),
-        byzantiumForkBlock,
-        homesteadForkBlock,
+        byzantiumForkBlock.getOrElse(0),
+        homesteadForkBlock.getOrElse(0),
         0,
-        constantinopleForkBlock,
-        istanbulForkBlock
+        constantinopleForkBlock.getOrElse(0),
+        istanbulForkBlock.getOrElse(0)
       )
     }
 

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/TestService.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/TestService.scala
@@ -172,8 +172,7 @@ class TestService(
     val world =
       blockchain.getWorldStateProxy(0, UInt256.Zero, genesisBlock.header.stateRoot, false, config.ethCompatibleStorage)
 
-    val accountsWithCodes = accounts
-      .filter(pair => pair._2.code.isDefined)
+    val accountsWithCodes = accounts.filter(pair => pair._2.code.isDefined)
 
     val worldToPersist = accountsWithCodes.foldLeft(world)((world, addressAccountPair) => {
       world.saveCode(Address(addressAccountPair._1), addressAccountPair._2.code.get)
@@ -187,8 +186,7 @@ class TestService(
     val world =
       blockchain.getWorldStateProxy(0, UInt256.Zero, genesisBlock.header.stateRoot, false, config.ethCompatibleStorage)
 
-    val accountsWithStorageData = accounts
-      .filter(pair => pair._2.storage.isDefined && pair._2.storage.get.nonEmpty)
+    val accountsWithStorageData = accounts.filter(pair => pair._2.storage.isDefined && pair._2.storage.get.nonEmpty)
 
     val worldToPersist = accountsWithStorageData.foldLeft(world)((world, addressAccountPair) => {
       val address = Address(addressAccountPair._1)
@@ -291,10 +289,7 @@ class TestService(
         .slice(accountRangeOffset, accountRangeOffset + request.parameters.maxResults.toInt + 1)
 
       val addressesForExistingAccounts = accountBatch
-        .filter(key => {
-          val accountOpt = blockchain.getAccount(Address(key), blockOpt.get.header.number)
-          accountOpt.isDefined
-        })
+        .filter(key => blockchain.getAccount(Address(key), blockOpt.get.header.number).isDefined)
         .map(key => (key, Address(crypto.kec256(Hex.decode(key)))))
 
       AccountsInRangeResponse(

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/TestService.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/TestService.scala
@@ -17,7 +17,6 @@ import monix.eval.Task
 import monix.execution.Scheduler
 import org.bouncycastle.util.encoders.Hex
 import io.iohk.ethereum.jsonrpc.JsonMethodsImplicits._
-
 import io.iohk.ethereum.rlp.RLPList
 
 import scala.concurrent.duration._
@@ -74,7 +73,7 @@ object TestService {
       maxResults: BigInt
   )
 
-  case class StorageEntry(key: ByteString, value: ByteString)
+  case class StorageEntry(key: String, value: String)
 
   case class SetChainParamsRequest(chainParams: ChainParams)
   case class SetChainParamsResponse()
@@ -98,7 +97,7 @@ object TestService {
   case class AccountsInRangeResponse(addressMap: Map[ByteString, ByteString], nextKey: ByteString)
 
   case class StorageRangeRequest(parameters: StorageRangeParams)
-  case class StorageRangeResponse(complete: Boolean, storage: Map[ByteString, StorageEntry])
+  case class StorageRangeResponse(complete: Boolean, storage: Map[String, StorageEntry])
 
   case class GetLogHashRequest(transactionHash: ByteString)
   case class GetLogHashResponse(logHash: ByteString)
@@ -339,7 +338,12 @@ class TestService(
       Right(
         StorageRangeResponse(
           complete = true,
-          storage = Map(request.parameters.address -> StorageEntry(ByteString(""), ByteString("")))
+          storage = Map(
+            encodeAsHex(request.parameters.address).values -> StorageEntry(
+              encodeAsHex(request.parameters.begin).values,
+              encodeAsHex(storage).values
+            )
+          )
         )
       )
     )

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/TestService.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/TestService.scala
@@ -41,11 +41,24 @@ object TestService {
       homesteadForkBlock: BigInt,
       maximumExtraDataSize: BigInt
   )
+
   case class ChainParams(
       genesis: GenesisParams,
       blockchainParams: BlockchainParams,
       sealEngine: String,
       accounts: Map[ByteString, GenesisAccount]
+  )
+
+  case class AccountsInRangeRequestParams(
+      blockHashOrNumber: Either[BigInt, ByteString],
+      txIndex: BigInt,
+      addressHash: ByteString,
+      maxResults: BigInt
+  )
+
+  case class AccountsInRange(
+      addressMap: Map[ByteString, ByteString],
+      nextKey: ByteString
   )
 
   case class SetChainParamsRequest(chainParams: ChainParams)
@@ -65,6 +78,9 @@ object TestService {
 
   case class ImportRawBlockRequest(blockRlp: String)
   case class ImportRawBlockResponse(blockHash: String)
+
+  case class AccountsInRangeRequest(parameters: AccountsInRangeRequestParams)
+  case class AccountsInRangeResponse(addressMap: Map[String, String], nextKey: String)
 }
 
 class TestService(
@@ -193,4 +209,6 @@ class TestService(
       }
     // .timeout(timeout.duration)
   }
+
+  def getAccountsInRange(request: AccountsInRangeRequest): ServiceResponse[AccountsInRangeResponse] = ???
 }

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/TestService.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/TestService.scala
@@ -315,7 +315,11 @@ class TestService(
       block <- blockOpt.toRight(StorageRangeResponse(complete = false, Map.empty))
       accountOpt = blockchain.getAccount(Address(request.parameters.address), block.header.number)
       account <- accountOpt.toRight(StorageRangeResponse(complete = false, Map.empty))
-      storage = blockchain.getAccountStorageAt(account.storageRoot, request.parameters.begin, ethCompatibleStorage = true)
+      storage = blockchain.getAccountStorageAt(
+        account.storageRoot,
+        request.parameters.begin,
+        ethCompatibleStorage = true
+      )
     } yield StorageRangeResponse(
       complete = true,
       storage = Map(

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/TransactionResponse.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/TransactionResponse.scala
@@ -31,23 +31,6 @@ final case class TransactionResponse(
     input: ByteString
 ) extends BaseTransactionResponse
 
-final case class EthTransactionResponse(
-    hash: ByteString,
-    nonce: BigInt,
-    blockHash: Option[ByteString],
-    blockNumber: Option[BigInt],
-    transactionIndex: Option[BigInt],
-    from: Option[ByteString],
-    to: Option[ByteString],
-    value: BigInt,
-    gasPrice: BigInt,
-    gas: BigInt,
-    input: ByteString,
-    r: ByteString,
-    s: ByteString,
-    v: ByteString
-) extends BaseTransactionResponse
-
 final case class TransactionData(
     stx: SignedTransaction,
     blockHeader: Option[BlockHeader] = None,
@@ -78,32 +61,4 @@ object TransactionResponse {
       input = stx.tx.payload
     )
 
-}
-
-object EthTransactionResponse {
-
-  def apply(tx: TransactionData): EthTransactionResponse =
-    EthTransactionResponse(tx.stx, tx.blockHeader, tx.transactionIndex)
-
-  def apply(
-      stx: SignedTransaction,
-      blockHeader: Option[BlockHeader] = None,
-      transactionIndex: Option[Int] = None
-  ): EthTransactionResponse =
-    EthTransactionResponse(
-      hash = stx.hash,
-      nonce = stx.tx.nonce,
-      blockHash = blockHeader.map(_.hash),
-      blockNumber = blockHeader.map(_.number),
-      transactionIndex = transactionIndex.map(txIndex => BigInt(txIndex)),
-      from = SignedTransaction.getSender(stx).map(_.bytes),
-      to = stx.tx.receivingAddress.map(_.bytes),
-      value = stx.tx.value,
-      gasPrice = stx.tx.gasPrice,
-      gas = stx.tx.gasLimit,
-      input = stx.tx.payload,
-      r = UInt256(stx.signature.r).bytes,
-      s = UInt256(stx.signature.s).bytes,
-      v = ByteString(stx.signature.v)
-    )
 }

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/TransactionResponse.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/TransactionResponse.scala
@@ -1,7 +1,21 @@
 package io.iohk.ethereum.jsonrpc
 
 import akka.util.ByteString
-import io.iohk.ethereum.domain.{BlockHeader, SignedTransaction}
+import io.iohk.ethereum.domain.{BlockHeader, SignedTransaction, UInt256}
+
+trait BaseTransactionResponse {
+  def hash: ByteString
+  def nonce: BigInt
+  def blockHash: Option[ByteString]
+  def blockNumber: Option[BigInt]
+  def transactionIndex: Option[BigInt]
+  def from: Option[ByteString]
+  def to: Option[ByteString]
+  def value: BigInt
+  def gasPrice: BigInt
+  def gas: BigInt
+  def input: ByteString
+}
 
 final case class TransactionResponse(
     hash: ByteString,
@@ -15,7 +29,24 @@ final case class TransactionResponse(
     gasPrice: BigInt,
     gas: BigInt,
     input: ByteString
-)
+) extends BaseTransactionResponse
+
+final case class EthTransactionResponse(
+    hash: ByteString,
+    nonce: BigInt,
+    blockHash: Option[ByteString],
+    blockNumber: Option[BigInt],
+    transactionIndex: Option[BigInt],
+    from: Option[ByteString],
+    to: Option[ByteString],
+    value: BigInt,
+    gasPrice: BigInt,
+    gas: BigInt,
+    input: ByteString,
+    r: ByteString,
+    s: ByteString,
+    v: ByteString
+) extends BaseTransactionResponse
 
 final case class TransactionData(
     stx: SignedTransaction,
@@ -47,4 +78,32 @@ object TransactionResponse {
       input = stx.tx.payload
     )
 
+}
+
+object EthTransactionResponse {
+
+  def apply(tx: TransactionData): EthTransactionResponse =
+    EthTransactionResponse(tx.stx, tx.blockHeader, tx.transactionIndex)
+
+  def apply(
+      stx: SignedTransaction,
+      blockHeader: Option[BlockHeader] = None,
+      transactionIndex: Option[Int] = None
+  ): EthTransactionResponse =
+    EthTransactionResponse(
+      hash = stx.hash,
+      nonce = stx.tx.nonce,
+      blockHash = blockHeader.map(_.hash),
+      blockNumber = blockHeader.map(_.number),
+      transactionIndex = transactionIndex.map(txIndex => BigInt(txIndex)),
+      from = SignedTransaction.getSender(stx).map(_.bytes),
+      to = stx.tx.receivingAddress.map(_.bytes),
+      value = stx.tx.value,
+      gasPrice = stx.tx.gasPrice,
+      gas = stx.tx.gasLimit,
+      input = stx.tx.payload,
+      r = UInt256(stx.signature.r).bytes,
+      s = UInt256(stx.signature.s).bytes,
+      v = ByteString(stx.signature.v)
+    )
 }

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/serialization/JsonSerializers.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/serialization/JsonSerializers.scala
@@ -8,7 +8,7 @@ import org.json4s.{CustomSerializer, DefaultFormats, Formats, JNull, JString}
 
 object JsonSerializers {
   implicit val formats: Formats =
-    DefaultFormats + UnformattedDataJsonSerializer + QuantitiesSerializer + OptionNoneToJNullSerializer + AddressJsonSerializer
+    DefaultFormats.preservingEmptyValues + UnformattedDataJsonSerializer + QuantitiesSerializer + OptionNoneToJNullSerializer + AddressJsonSerializer
 
   object UnformattedDataJsonSerializer
       extends CustomSerializer[ByteString](_ =>

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/serialization/JsonSerializers.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/serialization/JsonSerializers.scala
@@ -8,7 +8,7 @@ import org.json4s.{CustomSerializer, DefaultFormats, Formats, JNull, JString}
 
 object JsonSerializers {
   implicit val formats: Formats =
-    DefaultFormats.preservingEmptyValues + UnformattedDataJsonSerializer + QuantitiesSerializer + OptionNoneToJNullSerializer + AddressJsonSerializer
+    DefaultFormats + UnformattedDataJsonSerializer + QuantitiesSerializer + OptionNoneToJNullSerializer + AddressJsonSerializer
 
   object UnformattedDataJsonSerializer
       extends CustomSerializer[ByteString](_ =>

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/server/controllers/JsonRpcBaseController.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/server/controllers/JsonRpcBaseController.scala
@@ -49,6 +49,8 @@ trait JsonRpcBaseController {
   def handleRequest(request: JsonRpcRequest): Task[JsonRpcResponse] = {
     val startTimeNanos = System.nanoTime()
 
+    log.debug("received request {}", request)
+
     val notFoundFn: PartialFunction[JsonRpcRequest, Task[JsonRpcResponse]] = { case _ =>
       JsonRpcControllerMetrics.NotFoundMethodsCounter.increment()
       Task.now(errorResponse(request, MethodNotFound))

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/server/controllers/JsonRpcBaseController.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/server/controllers/JsonRpcBaseController.scala
@@ -49,7 +49,7 @@ trait JsonRpcBaseController {
   def handleRequest(request: JsonRpcRequest): Task[JsonRpcResponse] = {
     val startTimeNanos = System.nanoTime()
 
-    log.debug("received request {}", request)
+    log.debug(s"received request ${request.inspect}")
 
     val notFoundFn: PartialFunction[JsonRpcRequest, Task[JsonRpcResponse]] = { case _ =>
       JsonRpcControllerMetrics.NotFoundMethodsCounter.increment()
@@ -76,6 +76,7 @@ trait JsonRpcBaseController {
             JsonRpcControllerMetrics.recordMethodTime(request.method, time)
           }
       }
+      .flatTap { response => Task { log.debug(s"sending response ${response.inspect}") } }
       .onErrorRecoverWith { case t: Throwable =>
         JsonRpcControllerMetrics.MethodsExceptionCounter.increment()
         log.error(s"Error serving request: ${request.toStringWithSensitiveInformation}", t)

--- a/src/main/scala/io/iohk/ethereum/ledger/BlockPreparator.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/BlockPreparator.scala
@@ -60,7 +60,9 @@ class BlockPreparator(
       block: Block,
       worldStateProxy: InMemoryWorldStateProxy
   ): InMemoryWorldStateProxy = {
-    if (!Config.testmode) {
+    if (Config.testmode) {
+      worldStateProxy
+    } else {
       val blockNumber = block.header.number
 
       val minerRewardForBlock = blockRewardCalculator.calculateMiningRewardForBlock(blockNumber)
@@ -104,8 +106,7 @@ class BlockPreparator(
         log.debug(s"Paying block $blockNumber reward of $ommerReward to ommer with account address $ommerAddress")
         increaseAccountBalance(ommerAddress, UInt256(ommerReward))(ws)
       }
-    } else
-      worldStateProxy
+    }
   }
 
   /**

--- a/src/main/scala/io/iohk/ethereum/ledger/BlockPreparator.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/BlockPreparator.scala
@@ -64,11 +64,9 @@ class BlockPreparator(
       worldStateProxy
     } else {
       val blockNumber = block.header.number
-
       val minerRewardForBlock = blockRewardCalculator.calculateMiningRewardForBlock(blockNumber)
       val minerRewardForOmmers =
         blockRewardCalculator.calculateMiningRewardForOmmers(blockNumber, block.body.uncleNodesList.size)
-
       val minerAddress = Address(block.header.beneficiary)
       val treasuryAddress = blockchainConfig.treasuryAddress
       val existsTreasuryContract = worldStateProxy.getAccount(treasuryAddress).isDefined
@@ -92,7 +90,6 @@ class BlockPreparator(
           val treasuryReward = minerRewardForBlock * TreasuryRewardPercentageAfterECIP1098 / 100
           val worldAfterTreasuryReward =
             increaseAccountBalance(treasuryAddress, UInt256(treasuryReward))(worldAfterMinerReward)
-
           log.debug(
             s"Paying block $blockNumber reward of $minerReward to miner with address $minerAddress" +
               s"paying treasury reward of $treasuryReward to treasury with address $treasuryAddress"

--- a/src/main/scala/io/iohk/ethereum/ledger/BlockPreparator.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/BlockPreparator.scala
@@ -59,10 +59,8 @@ class BlockPreparator(
   private[ledger] def payBlockReward(
       block: Block,
       worldStateProxy: InMemoryWorldStateProxy
-  ): InMemoryWorldStateProxy = {
-    if (Config.testmode) {
-      worldStateProxy
-    } else {
+  ): InMemoryWorldStateProxy =
+    if (!Config.testmode) {
       val blockNumber = block.header.number
       val minerRewardForBlock = blockRewardCalculator.calculateMiningRewardForBlock(blockNumber)
       val minerRewardForOmmers =
@@ -103,8 +101,10 @@ class BlockPreparator(
         log.debug(s"Paying block $blockNumber reward of $ommerReward to ommer with account address $ommerAddress")
         increaseAccountBalance(ommerAddress, UInt256(ommerReward))(ws)
       }
+    } else {
+      //FIXME needs to be part of setting up the application and not a runtime flag
+      worldStateProxy
     }
-  }
 
   /**
     * v0 ≡ Tg (Tx gas limit) * Tp (Tx gas price). See YP equation number (68)

--- a/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
@@ -28,7 +28,7 @@ import io.iohk.ethereum.network.p2p.EthereumMessageDecoder
 import io.iohk.ethereum.network.rlpx.AuthHandshaker
 import io.iohk.ethereum.network.{PeerManagerActor, ServerActor, _}
 import io.iohk.ethereum.ommers.OmmersPool
-import io.iohk.ethereum.testmode.{TestLedgerBuilder, TestmodeConsensusBuilder}
+import io.iohk.ethereum.testmode.{TestEthBlockServiceWrapper, TestLedgerBuilder, TestmodeConsensusBuilder}
 import io.iohk.ethereum.transactions.{PendingTransactionsManager, TransactionHistoryService}
 import io.iohk.ethereum.utils.Config.SyncConfig
 import io.iohk.ethereum.utils._
@@ -365,6 +365,11 @@ trait TestServiceBuilder {
 
   lazy val testService =
     new TestService(blockchain, pendingTransactionsManager, consensusConfig, consensus, testLedgerWrapper)(scheduler)
+}
+
+trait TestEthBlockServiceBuilder extends EthBlocksServiceBuilder {
+  self: BlockchainBuilder with TestLedgerBuilder =>
+  override lazy val ethBlocksService = new TestEthBlockServiceWrapper(blockchain, ledger)
 }
 
 trait EthProofServiceBuilder {

--- a/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
@@ -368,8 +368,8 @@ trait TestServiceBuilder {
 }
 
 trait TestEthBlockServiceBuilder extends EthBlocksServiceBuilder {
-  self: BlockchainBuilder with TestLedgerBuilder =>
-  override lazy val ethBlocksService = new TestEthBlockServiceWrapper(blockchain, ledger)
+  self: BlockchainBuilder with TestLedgerBuilder with ConsensusBuilder =>
+  override lazy val ethBlocksService = new TestEthBlockServiceWrapper(blockchain, ledger, consensus)
 }
 
 trait EthProofServiceBuilder {

--- a/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
@@ -554,7 +554,7 @@ trait JSONRpcControllerBuilder {
     with CheckpointingServiceBuilder
     with MantisServiceBuilder =>
 
-  private val testService =
+  private lazy val testService =
     if (Config.testmode) Some(this.asInstanceOf[TestServiceBuilder].testService)
     else None
 

--- a/src/main/scala/io/iohk/ethereum/nodebuilder/StdNode.scala
+++ b/src/main/scala/io/iohk/ethereum/nodebuilder/StdNode.scala
@@ -104,4 +104,9 @@ abstract class BaseNode extends Node {
 }
 
 class StdNode extends BaseNode with StdLedgerBuilder with StdConsensusBuilder
-class TestNode extends BaseNode with TestLedgerBuilder with TestmodeConsensusBuilder with TestServiceBuilder
+class TestNode
+    extends BaseNode
+    with TestLedgerBuilder
+    with TestmodeConsensusBuilder
+    with TestServiceBuilder
+    with TestEthBlockServiceBuilder

--- a/src/main/scala/io/iohk/ethereum/testmode/TestEthBlockServiceWrapper.scala
+++ b/src/main/scala/io/iohk/ethereum/testmode/TestEthBlockServiceWrapper.scala
@@ -2,7 +2,13 @@ package io.iohk.ethereum.testmode
 
 import io.iohk.ethereum.domain.{Block, BlockHeader, Blockchain, SignedTransaction, UInt256}
 import io.iohk.ethereum.jsonrpc.EthBlocksService.{BlockByBlockHashResponse, BlockByNumberResponse}
-import io.iohk.ethereum.jsonrpc.{BaseBlockResponse, BaseTransactionResponse, EthBlocksService, ServiceResponse, TransactionData}
+import io.iohk.ethereum.jsonrpc.{
+  BaseBlockResponse,
+  BaseTransactionResponse,
+  EthBlocksService,
+  ServiceResponse,
+  TransactionData
+}
 import io.iohk.ethereum.ledger.Ledger
 import io.iohk.ethereum.utils.Logger
 import io.iohk.ethereum.consensus.Consensus
@@ -128,7 +134,7 @@ object EthTransactionResponse {
       stx: SignedTransaction,
       blockHeader: Option[BlockHeader] = None,
       transactionIndex: Option[Int] = None
-   ): EthTransactionResponse =
+  ): EthTransactionResponse =
     EthTransactionResponse(
       hash = stx.hash,
       nonce = stx.tx.nonce,

--- a/src/main/scala/io/iohk/ethereum/testmode/TestEthBlockServiceWrapper.scala
+++ b/src/main/scala/io/iohk/ethereum/testmode/TestEthBlockServiceWrapper.scala
@@ -1,8 +1,8 @@
 package io.iohk.ethereum.testmode
 
-import io.iohk.ethereum.domain.{Block, Blockchain, UInt256}
+import io.iohk.ethereum.domain.{Block, BlockHeader, Blockchain, SignedTransaction, UInt256}
 import io.iohk.ethereum.jsonrpc.EthBlocksService.{BlockByBlockHashResponse, BlockByNumberResponse}
-import io.iohk.ethereum.jsonrpc.{BaseBlockResponse, BaseTransactionResponse, EthBlocksService, EthTransactionResponse, ServiceResponse, TransactionData}
+import io.iohk.ethereum.jsonrpc.{BaseBlockResponse, BaseTransactionResponse, EthBlocksService, ServiceResponse, TransactionData}
 import io.iohk.ethereum.ledger.Ledger
 import io.iohk.ethereum.utils.Logger
 import io.iohk.ethereum.consensus.Consensus
@@ -106,3 +106,48 @@ case class EthBlockResponse(
     transactions: Either[Seq[ByteString], Seq[BaseTransactionResponse]],
     uncles: Seq[ByteString]
 ) extends BaseBlockResponse
+
+final case class EthTransactionResponse(
+    hash: ByteString,
+    nonce: BigInt,
+    blockHash: Option[ByteString],
+    blockNumber: Option[BigInt],
+    transactionIndex: Option[BigInt],
+    from: Option[ByteString],
+    to: Option[ByteString],
+    value: BigInt,
+    gasPrice: BigInt,
+    gas: BigInt,
+    input: ByteString,
+    r: ByteString,
+    s: ByteString,
+    v: ByteString
+) extends BaseTransactionResponse
+
+object EthTransactionResponse {
+
+  def apply(tx: TransactionData): EthTransactionResponse =
+    EthTransactionResponse(tx.stx, tx.blockHeader, tx.transactionIndex)
+
+  def apply(
+      stx: SignedTransaction,
+      blockHeader: Option[BlockHeader] = None,
+      transactionIndex: Option[Int] = None
+   ): EthTransactionResponse =
+    EthTransactionResponse(
+      hash = stx.hash,
+      nonce = stx.tx.nonce,
+      blockHash = blockHeader.map(_.hash),
+      blockNumber = blockHeader.map(_.number),
+      transactionIndex = transactionIndex.map(txIndex => BigInt(txIndex)),
+      from = SignedTransaction.getSender(stx).map(_.bytes),
+      to = stx.tx.receivingAddress.map(_.bytes),
+      value = stx.tx.value,
+      gasPrice = stx.tx.gasPrice,
+      gas = stx.tx.gasLimit,
+      input = stx.tx.payload,
+      r = UInt256(stx.signature.r).bytes,
+      s = UInt256(stx.signature.s).bytes,
+      v = ByteString(stx.signature.v)
+    )
+}

--- a/src/main/scala/io/iohk/ethereum/testmode/TestEthBlockServiceWrapper.scala
+++ b/src/main/scala/io/iohk/ethereum/testmode/TestEthBlockServiceWrapper.scala
@@ -1,0 +1,71 @@
+package io.iohk.ethereum.testmode
+
+import io.iohk.ethereum.domain.Blockchain
+import io.iohk.ethereum.jsonrpc.EthBlocksService.{BlockByBlockHashResponse, BlockByNumberResponse}
+import io.iohk.ethereum.jsonrpc.{BaseBlockResponse, EthBlockResponse, EthBlocksService, ServiceResponse}
+import io.iohk.ethereum.ledger.Ledger
+import io.iohk.ethereum.utils.Logger
+
+class TestEthBlockServiceWrapper(blockchain: Blockchain, ledger: Ledger)
+    extends EthBlocksService(blockchain, ledger)
+    with Logger {
+
+  /**
+    * Implements the eth_getBlockByHash method that fetches a requested block.
+    *
+    * @param request with the hash of the block requested
+    * @return the block requested or None if the client doesn't have the block
+    */
+  override def getByBlockHash(
+      request: EthBlocksService.BlockByBlockHashRequest
+  ): ServiceResponse[EthBlocksService.BlockByBlockHashResponse] = super
+    .getByBlockHash(request)
+    .map(
+      _.map(blockByBlockResponse =>
+        BlockByBlockHashResponse(
+          blockByBlockResponse.blockResponse.map(response => toEthResponse(response))
+        )
+      )
+    )
+
+  /**
+    * Implements the eth_getBlockByNumber method that fetches a requested block.
+    *
+    * @param request with the block requested (by it's number or by tag)
+    * @return the block requested or None if the client doesn't have the block
+    */
+  override def getBlockByNumber(
+      request: EthBlocksService.BlockByNumberRequest
+  ): ServiceResponse[EthBlocksService.BlockByNumberResponse] = super
+    .getBlockByNumber(request)
+    .map(
+      _.map(blockByBlockResponse =>
+        BlockByNumberResponse(
+          blockByBlockResponse.blockResponse.map(response => toEthResponse(response))
+        )
+      )
+    )
+
+  private def toEthResponse(response: BaseBlockResponse) = EthBlockResponse(
+    response.number,
+    response.hash,
+    response.mixHash,
+    response.parentHash,
+    response.nonce,
+    response.sha3Uncles,
+    response.logsBloom,
+    response.transactionsRoot,
+    response.stateRoot,
+    response.receiptsRoot,
+    response.miner,
+    response.difficulty,
+    response.totalDifficulty,
+    response.extraData,
+    response.size,
+    response.gasLimit,
+    response.gasUsed,
+    response.timestamp,
+    response.transactions,
+    response.uncles
+  )
+}

--- a/src/main/scala/io/iohk/ethereum/testmode/TestEthBlockServiceWrapper.scala
+++ b/src/main/scala/io/iohk/ethereum/testmode/TestEthBlockServiceWrapper.scala
@@ -44,9 +44,7 @@ class TestEthBlockServiceWrapper(blockchain: Blockchain, ledger: Ledger, consens
       _.map(blockByBlockResponse =>
         BlockByNumberResponse(
           blockByBlockResponse.blockResponse
-            .map(response =>
-              toEthResponse(response).copy(coinbase = Some(ByteString(consensus.config.generic.coinbase.toArray)))
-            )
+            .map(response => toEthResponse(response))
         )
       )
     )
@@ -71,7 +69,6 @@ class TestEthBlockServiceWrapper(blockchain: Blockchain, ledger: Ledger, consens
     response.gasUsed,
     response.timestamp,
     response.transactions,
-    response.uncles,
-    response.coinbase
+    response.uncles
   )
 }

--- a/src/main/scala/io/iohk/ethereum/testmode/TestEthBlockServiceWrapper.scala
+++ b/src/main/scala/io/iohk/ethereum/testmode/TestEthBlockServiceWrapper.scala
@@ -25,9 +25,7 @@ class TestEthBlockServiceWrapper(blockchain: Blockchain, ledger: Ledger, consens
     .map(
       _.map(blockByBlockResponse => {
         val fullBlock = blockchain.getBlockByNumber(blockByBlockResponse.blockResponse.get.number).get
-        BlockByBlockHashResponse(
-          blockByBlockResponse.blockResponse.map(response => toEthResponse(fullBlock, response))
-        )
+        BlockByBlockHashResponse(blockByBlockResponse.blockResponse.map(response => toEthResponse(fullBlock, response)))
       })
     )
 
@@ -44,10 +42,7 @@ class TestEthBlockServiceWrapper(blockchain: Blockchain, ledger: Ledger, consens
     .map(
       _.map(blockByBlockResponse => {
         val fullBlock = blockchain.getBlockByNumber(blockByBlockResponse.blockResponse.get.number).get
-        BlockByNumberResponse(
-          blockByBlockResponse.blockResponse
-            .map(response => toEthResponse(fullBlock, response))
-        )
+        BlockByNumberResponse(blockByBlockResponse.blockResponse.map(response => toEthResponse(fullBlock, response)))
       })
     )
 

--- a/src/main/scala/io/iohk/ethereum/testmode/TestEthBlockServiceWrapper.scala
+++ b/src/main/scala/io/iohk/ethereum/testmode/TestEthBlockServiceWrapper.scala
@@ -1,6 +1,6 @@
 package io.iohk.ethereum.testmode
 
-import io.iohk.ethereum.domain.{Block, Blockchain}
+import io.iohk.ethereum.domain.{Block, Blockchain, UInt256}
 import io.iohk.ethereum.jsonrpc.EthBlocksService.{BlockByBlockHashResponse, BlockByNumberResponse}
 import io.iohk.ethereum.jsonrpc.{
   BaseBlockResponse,
@@ -62,9 +62,9 @@ class TestEthBlockServiceWrapper(blockchain: Blockchain, ledger: Ledger, consens
   private def toEthResponse(block: Block, response: BaseBlockResponse) = EthBlockResponse(
     response.number,
     response.hash,
-    response.mixHash,
+    if (block.header.mixHash.isEmpty) Some(UInt256.Zero.bytes) else Some(block.header.mixHash),
     response.parentHash,
-    response.nonce,
+    if (block.header.nonce.isEmpty) None else Some(block.header.nonce),
     response.sha3Uncles,
     response.logsBloom,
     response.transactionsRoot,

--- a/src/main/scala/io/iohk/ethereum/testmode/TestEthBlockServiceWrapper.scala
+++ b/src/main/scala/io/iohk/ethereum/testmode/TestEthBlockServiceWrapper.scala
@@ -5,8 +5,10 @@ import io.iohk.ethereum.jsonrpc.EthBlocksService.{BlockByBlockHashResponse, Bloc
 import io.iohk.ethereum.jsonrpc.{BaseBlockResponse, EthBlockResponse, EthBlocksService, ServiceResponse}
 import io.iohk.ethereum.ledger.Ledger
 import io.iohk.ethereum.utils.Logger
+import io.iohk.ethereum.consensus.Consensus
+import akka.util.ByteString
 
-class TestEthBlockServiceWrapper(blockchain: Blockchain, ledger: Ledger)
+class TestEthBlockServiceWrapper(blockchain: Blockchain, ledger: Ledger, consensus: Consensus)
     extends EthBlocksService(blockchain, ledger)
     with Logger {
 
@@ -41,7 +43,10 @@ class TestEthBlockServiceWrapper(blockchain: Blockchain, ledger: Ledger)
     .map(
       _.map(blockByBlockResponse =>
         BlockByNumberResponse(
-          blockByBlockResponse.blockResponse.map(response => toEthResponse(response))
+          blockByBlockResponse.blockResponse
+            .map(response =>
+              toEthResponse(response).copy(coinbase = Some(ByteString(consensus.config.generic.coinbase.toArray)))
+            )
         )
       )
     )
@@ -66,6 +71,7 @@ class TestEthBlockServiceWrapper(blockchain: Blockchain, ledger: Ledger)
     response.gasUsed,
     response.timestamp,
     response.transactions,
-    response.uncles
+    response.uncles,
+    response.coinbase
   )
 }

--- a/src/main/scala/io/iohk/ethereum/testmode/TestEthBlockServiceWrapper.scala
+++ b/src/main/scala/io/iohk/ethereum/testmode/TestEthBlockServiceWrapper.scala
@@ -2,15 +2,7 @@ package io.iohk.ethereum.testmode
 
 import io.iohk.ethereum.domain.{Block, Blockchain, UInt256}
 import io.iohk.ethereum.jsonrpc.EthBlocksService.{BlockByBlockHashResponse, BlockByNumberResponse}
-import io.iohk.ethereum.jsonrpc.{
-  BaseBlockResponse,
-  BaseTransactionResponse,
-  EthBlockResponse,
-  EthBlocksService,
-  EthTransactionResponse,
-  ServiceResponse,
-  TransactionData
-}
+import io.iohk.ethereum.jsonrpc.{BaseBlockResponse, BaseTransactionResponse, EthBlocksService, EthTransactionResponse, ServiceResponse, TransactionData}
 import io.iohk.ethereum.ledger.Ledger
 import io.iohk.ethereum.utils.Logger
 import io.iohk.ethereum.consensus.Consensus
@@ -91,3 +83,26 @@ class TestEthBlockServiceWrapper(blockchain: Blockchain, ledger: Ledger, consens
     }
   })
 }
+
+case class EthBlockResponse(
+    number: BigInt,
+    hash: Option[ByteString],
+    mixHash: Option[ByteString],
+    parentHash: ByteString,
+    nonce: Option[ByteString],
+    sha3Uncles: ByteString,
+    logsBloom: ByteString,
+    transactionsRoot: ByteString,
+    stateRoot: ByteString,
+    receiptsRoot: ByteString,
+    miner: Option[ByteString],
+    difficulty: BigInt,
+    totalDifficulty: Option[BigInt],
+    extraData: ByteString,
+    size: BigInt,
+    gasLimit: BigInt,
+    gasUsed: BigInt,
+    timestamp: BigInt,
+    transactions: Either[Seq[ByteString], Seq[BaseTransactionResponse]],
+    uncles: Seq[ByteString]
+) extends BaseBlockResponse

--- a/src/main/scala/io/iohk/ethereum/testmode/TestmodeConsensus.scala
+++ b/src/main/scala/io/iohk/ethereum/testmode/TestmodeConsensus.scala
@@ -15,6 +15,7 @@ import io.iohk.ethereum.ledger.{BlockExecutionError, BlockExecutionSuccess, Bloc
 import io.iohk.ethereum.nodebuilder._
 import io.iohk.ethereum.utils.BlockchainConfig
 import monix.eval.Task
+import io.iohk.ethereum.consensus.pow.validators.ValidatorsExecutor
 
 class TestmodeConsensus(
     override val vm: VMImpl,

--- a/src/main/scala/io/iohk/ethereum/testmode/TestmodeConsensus.scala
+++ b/src/main/scala/io/iohk/ethereum/testmode/TestmodeConsensus.scala
@@ -5,6 +5,7 @@ import io.iohk.ethereum.consensus._
 import io.iohk.ethereum.consensus.blocks.{BlockTimestampProvider, NoOmmersBlockGenerator, TestBlockGenerator}
 import io.iohk.ethereum.consensus.difficulty.DifficultyCalculator
 import io.iohk.ethereum.consensus.pow.MinerResponses.MinerNotExist
+import io.iohk.ethereum.consensus.pow.validators.ValidatorsExecutor
 import io.iohk.ethereum.consensus.pow.{MinerProtocol, MinerResponse}
 import io.iohk.ethereum.consensus.validators._
 import io.iohk.ethereum.consensus.validators.std.{StdBlockValidator, StdSignedTransactionValidator}
@@ -64,7 +65,7 @@ class TestmodeConsensus(
     }
   }
 
-  override def validators: Validators = new TestValidators
+  override def validators: Validators = ValidatorsExecutor.apply(blockchainConfig, Protocol.PoW)
 
   override val blockPreparator: BlockPreparator = new BlockPreparator(
     vm = vm,

--- a/src/main/scala/io/iohk/ethereum/testmode/TestmodeConsensus.scala
+++ b/src/main/scala/io/iohk/ethereum/testmode/TestmodeConsensus.scala
@@ -65,7 +65,7 @@ class TestmodeConsensus(
     }
   }
 
-  override def validators: Validators = ValidatorsExecutor.apply(blockchainConfig, Protocol.PoW)
+  override def validators: Validators = ValidatorsExecutor.apply(blockchainConfig, Protocol.MockedPow)
 
   override val blockPreparator: BlockPreparator = new BlockPreparator(
     vm = vm,

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/EthBlocksServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/EthBlocksServiceSpec.scala
@@ -83,7 +83,7 @@ class EthBlocksServiceSpec
     response.blockResponse shouldBe Some(
       BlockResponse(blockToRequest, fullTxs = true, weight = Some(blockWeight))
     )
-    response.blockResponse.get.chainWeight shouldBe Some(blockWeight)
+    response.blockResponse.get.asInstanceOf[BlockResponse].chainWeight shouldBe Some(blockWeight)
     response.blockResponse.get.transactions.toOption shouldBe Some(stxResponses)
   }
 
@@ -98,7 +98,7 @@ class EthBlocksServiceSpec
     }
 
     response.blockResponse shouldBe Some(BlockResponse(blockToRequest, fullTxs = true))
-    response.blockResponse.get.chainWeight shouldBe None
+    response.blockResponse.get.asInstanceOf[BlockResponse].chainWeight shouldBe None
     response.blockResponse.get.transactions.toOption shouldBe Some(stxResponses)
   }
 
@@ -115,7 +115,7 @@ class EthBlocksServiceSpec
     response.blockResponse shouldBe Some(
       BlockResponse(blockToRequest, fullTxs = false, weight = Some(blockWeight))
     )
-    response.blockResponse.get.chainWeight shouldBe Some(blockWeight)
+    response.blockResponse.get.asInstanceOf[BlockResponse].chainWeight shouldBe Some(blockWeight)
     response.blockResponse.get.transactions.left.toOption shouldBe Some(blockToRequest.body.transactionList.map(_.hash))
   }
 
@@ -178,7 +178,7 @@ class EthBlocksServiceSpec
     response.blockResponse shouldBe Some(
       BlockResponse(blockToRequest, fullTxs = true, weight = Some(blockWeight))
     )
-    response.blockResponse.get.chainWeight shouldBe Some(blockWeight)
+    response.blockResponse.get.asInstanceOf[BlockResponse].chainWeight shouldBe Some(blockWeight)
     response.blockResponse.get.transactions.toOption shouldBe Some(stxResponses)
   }
 
@@ -194,7 +194,7 @@ class EthBlocksServiceSpec
     }
 
     response.blockResponse shouldBe Some(BlockResponse(blockToRequest, fullTxs = true))
-    response.blockResponse.get.chainWeight shouldBe None
+    response.blockResponse.get.asInstanceOf[BlockResponse].chainWeight shouldBe None
     response.blockResponse.get.transactions.toOption shouldBe Some(stxResponses)
   }
 
@@ -212,7 +212,7 @@ class EthBlocksServiceSpec
     response.blockResponse shouldBe Some(
       BlockResponse(blockToRequest, fullTxs = false, weight = Some(blockWeight))
     )
-    response.blockResponse.get.chainWeight shouldBe Some(blockWeight)
+    response.blockResponse.get.asInstanceOf[BlockResponse].chainWeight shouldBe Some(blockWeight)
     response.blockResponse.get.transactions.left.toOption shouldBe Some(blockToRequest.body.transactionList.map(_.hash))
   }
 
@@ -289,7 +289,7 @@ class EthBlocksServiceSpec
     val response = ethBlocksService.getUncleByBlockHashAndIndex(request).runSyncUnsafe(Duration.Inf).toOption.get
 
     response.uncleBlockResponse shouldBe Some(BlockResponse(uncle, None, pendingBlock = false))
-    response.uncleBlockResponse.get.chainWeight shouldBe None
+    response.uncleBlockResponse.get.asInstanceOf[BlockResponse].chainWeight shouldBe None
     response.uncleBlockResponse.get.transactions shouldBe Left(Nil)
     response.uncleBlockResponse.get.uncles shouldBe Nil
   }
@@ -305,7 +305,7 @@ class EthBlocksServiceSpec
     val response = ethBlocksService.getUncleByBlockHashAndIndex(request).runSyncUnsafe(Duration.Inf).toOption.get
 
     response.uncleBlockResponse shouldBe Some(BlockResponse(uncle, Some(uncleWeight), pendingBlock = false))
-    response.uncleBlockResponse.get.chainWeight shouldBe Some(uncleWeight)
+    response.uncleBlockResponse.get.asInstanceOf[BlockResponse].chainWeight shouldBe Some(uncleWeight)
     response.uncleBlockResponse.get.transactions shouldBe Left(Nil)
     response.uncleBlockResponse.get.uncles shouldBe Nil
   }
@@ -363,7 +363,7 @@ class EthBlocksServiceSpec
     val response = ethBlocksService.getUncleByBlockNumberAndIndex(request).runSyncUnsafe(Duration.Inf).toOption.get
 
     response.uncleBlockResponse shouldBe Some(BlockResponse(uncle, None, pendingBlock = false))
-    response.uncleBlockResponse.get.chainWeight shouldBe None
+    response.uncleBlockResponse.get.asInstanceOf[BlockResponse].chainWeight shouldBe None
     response.uncleBlockResponse.get.transactions shouldBe Left(Nil)
     response.uncleBlockResponse.get.uncles shouldBe Nil
   }
@@ -380,7 +380,7 @@ class EthBlocksServiceSpec
     val response = ethBlocksService.getUncleByBlockNumberAndIndex(request).runSyncUnsafe(Duration.Inf).toOption.get
 
     response.uncleBlockResponse shouldBe Some(BlockResponse(uncle, Some(uncleWeight), pendingBlock = false))
-    response.uncleBlockResponse.get.chainWeight shouldBe Some(uncleWeight)
+    response.uncleBlockResponse.get.asInstanceOf[BlockResponse].chainWeight shouldBe Some(uncleWeight)
     response.uncleBlockResponse.get.transactions shouldBe Left(Nil)
     response.uncleBlockResponse.get.uncles shouldBe Nil
   }


### PR DESCRIPTION
# Description

Initial integration of ETS (Ethereum tests) executed through Retesteth test suite.

# Proposed Solution

Some of existing endpoints were updated according to newer changes in the runner and the tests. Additional methods were added, such as test_importRawBlock, test_getLogHash, debug_accountRangeAt and debug_storageRangeAt. Follow up tasks/bugs are created in order to ensure further progress and fixes for the tests that are failing.

Modifications were made to standard eth RPC responses because of Mantis custom fields that are avalable only when "testmode" is configured.

