### PR TITLE
Rollback ETS subproject to 8.0.2 to fix retesteth crashes

### DIFF
--- a/ets/retesteth
+++ b/ets/retesteth
@@ -2,4 +2,9 @@
 
 dir="$(cd "$(dirname "$0")" && pwd)"
 
-retesteth $@ -- --testpath $dir/tests --datadir $dir/config --clients mantis
+separator="--"
+if [[ $@ =~ "--" ]]; then
+  separator=""
+fi
+
+retesteth $@ $separator --testpath $dir/tests --datadir $dir/config --clients mantis

--- a/test-ets.sh
+++ b/test-ets.sh
@@ -28,10 +28,12 @@ function run_and_annotate {
   if [[ -z "$summary" ]]; then
     summary="retesteth crashed; check the artifacts"
   fi
+  passed=$(grep -oP 'Total Tests Run: \d+' "retesteth-$1-log.txt")
+  failed=$(grep -oP 'TOTAL ERRORS DETECTED: \d+' "retesteth-$1-log.txt")
 
   cat <<EOF | buildkite-agent annotate --context "retesteth-$1" --style "$style"
 <details>
-<summary>retesteth: $1</summary>
+<summary>retesteth: $1 -- $passed -- $failed</summary>
 <pre class="term"><code>
 $summary
 </code></pre>


### PR DESCRIPTION
There is some incompatibility between the previous version of the Ethereum tests (8.0.3) and retesteth. This change rolls it back one version so that we get a test report for the BlockchainTests on CI.

Current score:
- BlockchainTests: 894 tests pass, 960 errors
- GeneralStateTests: 2061 tests pass, 407 errors