### PR TITLE
[kaizen] update jvmopts to match the CI

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,4 +1,5 @@
 -Xms1g
 -Xmx4g
--XX:ReservedCodeCacheSize=128m
+-XX:ReservedCodeCacheSize=256m
 -XX:MaxMetaspaceSize=1g
+-Xss4M


### PR DESCRIPTION
# Description

This CI updates the `.jvmopts` to have the same parameters as the CI. It allows to get the same results as the CI when running retesteth on mantis. I initially wanted to add a `.sbtopts` file but as we already have a `.jvmopts` file I updated this one instead.

# Testing

Running `./retesteth -t GeneralStateTest` as per `ets/README.md` should give the same result as the CI (currently Total Tests Run: 2061 -- TOTAL ERRORS DETECTED: 407)

