### PR TITLE
[Kaizen] Sagano target block time 15s

### DIFF
--- a/src/main/resources/conf/chains/testnet-internal-nomad-chain.conf
+++ b/src/main/resources/conf/chains/testnet-internal-nomad-chain.conf
@@ -5,7 +5,7 @@
 
     # Possibility to set Proof of Work target time for testing purposes.
     # null means that the standard difficulty calculation rules are used
-    pow-target-time = 10 seconds
+    pow-target-time = 15 seconds
 
     # Frontier block number
     frontier-block-number = "0"


### PR DESCRIPTION
Configuration change for Sagano testnet: set block target time to 15s.