### PR TITLE
Release/v3.2.3

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -3,4 +3,4 @@
 // based on `git` tags by https://github.com/dwijnand/sbt-dynver,
 // which is a dependency of `sbt-ci-release`.
 
-version in ThisBuild := "3.2.2-SNAPSHOT"
+version in ThisBuild := "3.2.3-SNAPSHOT"


### PR DESCRIPTION
Release PR:
- Bump version to 3.2.3
- Set Sagano target block time to 15s (#989)
- Remove treasury opt out flag (#980)
- Update jvmopts to allow more nesting of smart contracts (#987)
- Move networking and regular sync to cache-based blacklist (#983)