### PR TITLE
[ETCM-846] make ETS stBadOpcode tests pass

### DIFF
--- a/src/main/scala/io/iohk/ethereum/jsonrpc/TestService.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/TestService.scala
@@ -181,7 +181,10 @@ class TestService(
       Account.EmptyStorageRootHash,
       blockchain.getStateStorage.getBackingStorage(0)
     )
-    val storagesToPersist = accounts.map(pair => pair._2.storage).collect { case Some(map) if map.nonEmpty => map }
+    val storagesToPersist = accounts
+      .flatMap(pair => pair._2.storage)
+      .map(accountStorage => accountStorage.filterNot { case (_, v) => v.isZero })
+      .filter(_.nonEmpty)
     for { storage <- storagesToPersist } {
       storage.foldLeft(emptyStorage) { case (storage, (key, value)) => storage.put(key, value) }
     }

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/TestService.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/TestService.scala
@@ -244,7 +244,7 @@ class TestService(
   }
 
   private def getBlockForMining(parentBlock: Block): Task[PendingBlock] = {
-    implicit val timeout: Timeout = Timeout(5.seconds)
+    implicit val timeout: Timeout = Timeout(20.seconds)
     pendingTransactionsManager
       .askFor[PendingTransactionsResponse](PendingTransactionsManager.GetPendingTransactions)
       .timeout(timeout.duration)

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/TestService.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/TestService.scala
@@ -157,13 +157,9 @@ class TestService(
 
     //save account codes to world state
     storeGenesisAccountCodes(newBlockchainConfig, genesisData.alloc)
-    val storesRootHash = storeGenesisAccountStorageData(newBlockchainConfig, genesisData.alloc)
+    storeGenesisAccountStorageData(newBlockchainConfig, genesisData.alloc)
     // update test ledger with new config
     testLedgerWrapper.blockchainConfig = newBlockchainConfig
-
-    // remove current genesis (Try because it may not exist)
-    Try(blockchain.removeBlock(blockchain.genesisHeader.hash, withState = false))
-    genesisDataLoader.loadGenesisData(genesisData, storesRootHash)
 
     accountAddresses = genesisData.alloc.keys.toList
     accountRangeOffset = 0
@@ -185,7 +181,7 @@ class TestService(
     InMemoryWorldStateProxy.persistState(worldToPersist)
   }
 
-  private def storeGenesisAccountStorageData(config: BlockchainConfig, accounts: Map[String, GenesisAccount]) = {
+  private def storeGenesisAccountStorageData(config: BlockchainConfig, accounts: Map[String, GenesisAccount]): Unit = {
     val genesisBlock = blockchain.getBlockByNumber(0).get
     val world =
       blockchain.getWorldStateProxy(0, UInt256.Zero, genesisBlock.header.stateRoot, false, config.ethCompatibleStorage)
@@ -203,9 +199,7 @@ class TestService(
       updatedWorld
     })
 
-    InMemoryWorldStateProxy.persistState(worldToPersist).contractStorages.map { case (address, values) =>
-      address -> ByteString(values.inner.getRootHash)
-    }
+    InMemoryWorldStateProxy.persistState(worldToPersist)
   }
 
   def mineBlocks(request: MineBlocksRequest): ServiceResponse[MineBlocksResponse] = {

--- a/test-ets.sh
+++ b/test-ets.sh
@@ -4,6 +4,8 @@ git submodule init
 git submodule update
 
 echo "booting Mantis and waiting for RPC API to be up"
+# deleting the state folder in case there is some remaining data from a previous run
+rm -rf ~/.mantis/test
 $SBT -Dconfig.file=./src/main/resources/conf/testmode.conf run &> mantis-log.txt &
 
 while ! nc -z localhost 8546; do   


### PR DESCRIPTION
# Description

This PR is part of the ogoing effort to make ETS pass all tests. The `stBadOpcode` suite did not pass because the accounts were not imported with the root hash for their storage. 

# Proposed Solution

The `getGenesisStateRoot` now create an in memory trie in order to compte the resulting hash. 

As this change is not specific to `stBadOpcode`, it also makes most the previously failing tests pass (9 failing test for `GeneralStateTests` while we had around 400 before).

