### PR TITLE
ETCM-370: Refine responses validation on block fetcher side 

### DIFF
--- a/src/it/scala/io/iohk/ethereum/sync/util/RegularSyncItSpecUtils.scala
+++ b/src/it/scala/io/iohk/ethereum/sync/util/RegularSyncItSpecUtils.scala
@@ -24,7 +24,6 @@ import io.iohk.ethereum.consensus.{ConsensusConfig, FullConsensusConfig, pow}
 import io.iohk.ethereum.crypto
 import io.iohk.ethereum.domain._
 import io.iohk.ethereum.ledger._
-import io.iohk.ethereum.network.PeerEventBusActor.PeerEvent.MessageFromPeer
 import io.iohk.ethereum.network.PeerId
 import io.iohk.ethereum.network.p2p.messages.CommonMessages.NewBlock
 import io.iohk.ethereum.nodebuilder.VmSetup

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/Blacklist.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/Blacklist.scala
@@ -163,12 +163,16 @@ object Blacklist {
         val code: Int = 27
         val name: String = "UnrequestedBodies"
       }
-      case object RegularSyncRequestFailedType extends BlacklistReasonType with RegularSyncBlacklistGroup {
+      case object UnrequestedHeadersType extends BlacklistReasonType with RegularSyncBlacklistGroup {
         val code: Int = 28
+        val name: String = "UnrequestedHeaders"
+      }
+      case object RegularSyncRequestFailedType extends BlacklistReasonType with RegularSyncBlacklistGroup {
+        val code: Int = 29
         val name: String = "RegularSyncRequestFailed"
       }
       case object BlockImportErrorType extends BlacklistReasonType with RegularSyncBlacklistGroup {
-        val code: Int = 29
+        val code: Int = 30
         val name: String = "BlockImportError"
       }
     }
@@ -280,6 +284,10 @@ object Blacklist {
     case object UnrequestedBodies extends BlacklistReason {
       val reasonType: BlacklistReasonType = UnrequestedBodiesType
       val description: String = "Received unrequested bodies"
+    }
+    case object UnrequestedHeaders extends BlacklistReason {
+      val reasonType: BlacklistReasonType = UnrequestedHeadersType
+      val description: String = "Received unrequested headers"
     }
     final case class RegularSyncRequestFailed(error: String) extends BlacklistReason {
       val reasonType: BlacklistReasonType = RegularSyncRequestFailedType

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/regular/HeadersFetcher.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/regular/HeadersFetcher.scala
@@ -36,9 +36,9 @@ class HeadersFetcher(
         log.debug("Start fetching headers from block {}", blockNumber)
         requestHeaders(blockNumber, amount)
         Behaviors.same
-      case AdaptedMessage(_, BlockHeaders(headers)) =>
+      case AdaptedMessage(peer, BlockHeaders(headers)) =>
         log.debug("Fetched {} headers starting from block {}", headers.size, headers.headOption.map(_.number))
-        supervisor ! BlockFetcher.ReceivedHeaders(headers)
+        supervisor ! BlockFetcher.ReceivedHeaders(peer, headers)
         Behaviors.same
       case HeadersFetcher.RetryHeadersRequest =>
         supervisor ! BlockFetcher.RetryHeadersRequest

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/regular/RegularSync.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/regular/RegularSync.scala
@@ -2,7 +2,6 @@ package io.iohk.ethereum.blockchain.sync.regular
 
 import akka.actor.{Actor, ActorLogging, ActorRef, AllForOneStrategy, Cancellable, Props, Scheduler, SupervisorStrategy}
 import akka.actor.typed.{ActorRef => TypedActorRef}
-import io.iohk.ethereum.blockchain.sync.SyncProtocol
 import io.iohk.ethereum.blockchain.sync.{Blacklist, SyncProtocol}
 import io.iohk.ethereum.blockchain.sync.SyncProtocol.Status
 import io.iohk.ethereum.blockchain.sync.SyncProtocol.Status.Progress

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/regular/BlockFetcherStateSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/regular/BlockFetcherStateSpec.scala
@@ -3,6 +3,7 @@ package io.iohk.ethereum.blockchain.sync.regular
 import akka.actor.ActorSystem
 import akka.testkit.{TestKit, TestProbe}
 import io.iohk.ethereum.Mocks.MockValidatorsAlwaysSucceed
+import io.iohk.ethereum.blockchain.sync.regular.BlockFetcherState.HeadersNotMatchingReadyBlocks
 import io.iohk.ethereum.{BlockHelpers, WithActorSystemShutDown}
 import io.iohk.ethereum.network.PeerId
 import io.iohk.ethereum.utils.ByteStringUtils
@@ -69,7 +70,7 @@ class BlockFetcherStateSpec
           .appendHeaders(blocks.map(_.header))
           .map(_.handleRequestedBlocks(blocks, peer))
 
-        assert(result.map(_.waitingHeaders) === Left("Given headers should form a sequence with ready blocks"))
+        assert(result.map(_.waitingHeaders) === Left(HeadersNotMatchingReadyBlocks))
       }
     }
   }

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/regular/RegularSyncSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/regular/RegularSyncSpec.scala
@@ -1,8 +1,9 @@
 package io.iohk.ethereum.blockchain.sync.regular
 
-import akka.actor.{ActorRef, ActorSystem}
+import akka.actor.{ActorRef, ActorSystem, typed}
+import akka.actor.typed.{ActorRef => TypedActorRef}
 import akka.testkit.TestActor.AutoPilot
-import akka.testkit.TestKit
+import akka.testkit.{TestKit, TestProbe}
 import akka.util.ByteString
 import cats.data.NonEmptyList
 import cats.effect.Resource
@@ -10,6 +11,7 @@ import cats.syntax.traverse._
 import io.iohk.ethereum.blockchain.sync.Blacklist.BlacklistReason
 import io.iohk.ethereum.blockchain.sync.SyncProtocol.Status
 import io.iohk.ethereum.blockchain.sync.SyncProtocol.Status.Progress
+import io.iohk.ethereum.blockchain.sync.regular.BlockFetcher.Start
 import io.iohk.ethereum.blockchain.sync.regular.RegularSync.NewCheckpoint
 import io.iohk.ethereum.blockchain.sync.{PeersClient, SyncProtocol}
 import io.iohk.ethereum.crypto.kec256
@@ -37,6 +39,7 @@ import org.scalatest.{Assertion, BeforeAndAfterEach}
 
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future, Promise}
+import scala.math.BigInt
 
 class RegularSyncSpec
     extends WordSpecBase
@@ -112,29 +115,101 @@ class RegularSyncSpec
         peersClient.expectMsg(PeersClient.BlacklistPeer(defaultPeer.id, BlacklistReason.RegularSyncRequestFailed("a random reason")))
       })
 
-      //TODO: To be re-enabled with ETCM-370
-      "blacklist peer which returns headers starting from one with higher number than expected" ignore sync(
-        new Fixture(
-          testSystem
-        ) {
+      "blacklist peer which returns headers starting from one with higher number than expected" in sync(
+        new Fixture(testSystem) {
+          var blockFetcher: ActorRef = _
+
           regularSync ! SyncProtocol.Start
+          peerEventBus.expectMsgClass(classOf[Subscribe])
+          blockFetcher = peerEventBus.sender()
 
           peersClient.expectMsgEq(blockHeadersChunkRequest(0))
-          peersClient.reply(PeersClient.Response(defaultPeer, BlockHeaders(testBlocksChunked(1).headers)))
+          peersClient.reply(PeersClient.Response(defaultPeer, BlockHeaders(testBlocksChunked.head.headers)))
+
+          val getBodies: PeersClient.Request[GetBlockBodies] = PeersClient.Request.create(
+            GetBlockBodies(testBlocksChunked.head.headers.map(_.hash)),
+            PeersClient.BestPeer
+          )
+          peersClient.expectMsgEq(getBodies)
+          peersClient.reply(PeersClient.Response(defaultPeer, BlockBodies(testBlocksChunked.head.bodies)))
+
+          blockFetcher ! MessageFromPeer(NewBlock(testBlocks.last, ChainWeight.totalDifficultyOnly(testBlocks.last.number)), defaultPeer.id)
+          peersClient.expectMsgEq(blockHeadersChunkRequest(1))
+          peersClient.reply(PeersClient.Response(defaultPeer, BlockHeaders(testBlocksChunked(5).headers)))
           peersClient.expectMsgPF() {
             case PeersClient.BlacklistPeer(id, _) if id == defaultPeer.id => true
           }
         }
       )
 
-      //TODO: To be re-enabled with ETCM-370
-      "blacklist peer which returns headers not forming a chain" ignore sync(new Fixture(testSystem) {
+      "blacklist peer which returns headers not forming a chain" in sync(new Fixture(testSystem) {
         regularSync ! SyncProtocol.Start
 
         peersClient.expectMsgEq(blockHeadersChunkRequest(0))
         peersClient.reply(
-          PeersClient.Response(defaultPeer, BlockHeaders(testBlocksChunked.head.headers.filter(_.number % 2 == 0)))
+          PeersClient.Response(defaultPeer, BlockHeaders(testBlocks.headers.filter(_.number % 2 == 0)))
         )
+        peersClient.expectMsgPF() {
+          case PeersClient.BlacklistPeer(id, _) if id == defaultPeer.id => true
+        }
+      })
+
+      "blacklist peer which sends headers that were not requested" in sync(new Fixture(testSystem) {
+        import akka.actor.typed.scaladsl.adapter._
+
+        val blockImporter = TestProbe()
+        val fetcher: typed.ActorRef[BlockFetcher.FetchCommand] =
+          system.spawn(
+            BlockFetcher(peersClient.ref, peerEventBus.ref, regularSync, syncConfig, validators.blockValidator),
+            "block-fetcher"
+          )
+
+        fetcher ! Start(blockImporter.ref, 0)
+
+        peersClient.expectMsgEq(blockHeadersChunkRequest(0))
+        peersClient.reply(PeersClient.Response(defaultPeer, BlockHeaders(testBlocksChunked.head.headers)))
+
+        val getBodies: PeersClient.Request[GetBlockBodies] = PeersClient.Request.create(
+          GetBlockBodies(testBlocksChunked.head.headers.map(_.hash)),
+          PeersClient.BestPeer
+        )
+
+        peersClient.expectMsgEq(getBodies)
+        peersClient.reply(PeersClient.Response(defaultPeer, BlockBodies(testBlocksChunked.head.bodies)))
+
+        fetcher ! BlockFetcher.ReceivedHeaders(defaultPeer, testBlocksChunked(3).headers)
+
+        peersClient.expectMsgPF() {
+          case PeersClient.BlacklistPeer(id, _) if id == defaultPeer.id => true
+        }
+      })
+
+      "blacklist peer which sends bodies that were not requested" in sync(new Fixture(testSystem) {
+        import akka.actor.typed.scaladsl.adapter._
+
+        var blockFetcherAdapter: TypedActorRef[MessageFromPeer] = _
+        val blockImporter = TestProbe()
+        val fetcher: typed.ActorRef[BlockFetcher.FetchCommand] =
+          system.spawn(
+            BlockFetcher(peersClient.ref, peerEventBus.ref, regularSync, syncConfig, validators.blockValidator),
+            "block-fetcher"
+          )
+
+        fetcher ! Start(blockImporter.ref, 0)
+
+        peersClient.expectMsgEq(blockHeadersChunkRequest(0))
+        peersClient.reply(PeersClient.Response(defaultPeer, BlockHeaders(testBlocksChunked.head.headers)))
+
+        val getBodies: PeersClient.Request[GetBlockBodies] = PeersClient.Request.create(
+          GetBlockBodies(testBlocksChunked.head.headers.map(_.hash)),
+          PeersClient.BestPeer
+        )
+
+        peersClient.expectMsgEq(getBodies)
+        peersClient.reply(PeersClient.Response(defaultPeer, BlockBodies(testBlocksChunked.head.bodies)))
+
+        fetcher ! BlockFetcher.ReceivedBodies(defaultPeer, testBlocksChunked(3).bodies)
+
         peersClient.expectMsgPF() {
           case PeersClient.BlacklistPeer(id, _) if id == defaultPeer.id => true
         }


### PR DESCRIPTION
Currently `BlockFetcher` performs bunch of validations on received responses but then it doesn't blacklist peer even if the response is clearly invalid.

The goal of this PR is to:
  - refine validations performed in block fetcher
  - restructure validation errors into proper error hierarchy (currently they are just strings)
  - restore blacklisting, but make it depend on error returned (e.g. it's important to check whether received headers are forming chain with ones already enqueued but it should not result with blacklist, on the other hand if received headers are not forming chain themselves - it's clearly wrong response and it's worth blacklisting peer, who provided it)
- restore and extend test cases for blacklisting behaviour in Regular Sync