### PR TITLE
[ETCM-865] Fix DAG size calculation

### DIFF
--- a/src/main/scala/io/iohk/ethereum/consensus/pow/miners/EthashDAGManager.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/pow/miners/EthashDAGManager.scala
@@ -16,7 +16,7 @@ class EthashDAGManager(blockCreator: PoWBlockCreator) extends Logger {
 
   def calculateDagSize(blockNumber: Long, epoch: Long): (Array[Array[Int]], Long) = {
     (currentEpoch, currentEpochDag, currentEpochDagSize) match {
-      case (_, Some(dag), Some(dagSize)) => (dag, dagSize)
+      case (Some(`epoch`), Some(dag), Some(dagSize)) => (dag, dagSize)
       case _ =>
         val seed = EthashUtils.seed(blockNumber, blockCreator.blockchainConfig.ecip1099BlockNumber.toLong)
         val dagSize = EthashUtils.dagSize(epoch)

--- a/src/test/scala/io/iohk/ethereum/Timeouts.scala
+++ b/src/test/scala/io/iohk/ethereum/Timeouts.scala
@@ -8,5 +8,5 @@ object Timeouts {
   val normalTimeout: FiniteDuration = 3.seconds
   val longTimeout: FiniteDuration = 10.seconds
   val veryLongTimeout: FiniteDuration = 30.seconds
-  val miningTimeout: FiniteDuration = 5.minutes
+  val miningTimeout: FiniteDuration = 20.minutes
 }

--- a/src/test/scala/io/iohk/ethereum/consensus/pow/miners/EthashMinerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/pow/miners/EthashMinerSpec.scala
@@ -24,13 +24,17 @@ class EthashMinerSpec extends AnyFlatSpec with Matchers {
     executeTest(parentBlock)
   }
 
-  it should "mine valid block on the beginning of the new epoch" taggedAs PoWMinerSpecTag in new TestSetup {
+  it should "mine valid block on the end and beginning of the new epoch" taggedAs PoWMinerSpecTag in new TestSetup {
     val epochLength: Int = EthashUtils.EPOCH_LENGTH_BEFORE_ECIP_1099
-    val parentBlockNumber: Int = epochLength - 1 // 29999, mined block will be 30000 (first block of the new epoch)
-    val parentBlock: Block = origin.copy(header = origin.header.copy(number = parentBlockNumber))
-    setBlockForMining(parentBlock)
+    val parent29998: Int = epochLength - 2 // 29998, mined block will be 29999 (last block of the epoch)
+    val parentBlock29998: Block = origin.copy(header = origin.header.copy(number = parent29998))
+    setBlockForMining(parentBlock29998)
+    executeTest(parentBlock29998)
 
-    executeTest(parentBlock)
+    val parent29999: Int = epochLength - 1 // 29999, mined block will be 30000 (first block of the new epoch)
+    val parentBlock29999: Block = origin.copy(header = origin.header.copy(number = parent29999))
+    setBlockForMining(parentBlock29999)
+    executeTest(parentBlock29999)
   }
 
   it should "mine valid blocks on the end of the epoch" taggedAs PoWMinerSpecTag in new TestSetup {


### PR DESCRIPTION
# Description

Fix for error that occurred in Sagano testnet
`Error while validation block before execution: HeaderPoWError`

# Testing
On a local machine all tests run, but on CI `EthashMinerSpec` fails and it was failing already, actually these tests have always been disabled.
People can run the test locally (ask me for details)
Will ask help devops to check the issue

