### PR TITLE
ETCM-843: Verify wrong genesis hash causes disconnection and blacklis…

### DIFF
--- a/src/it/scala/io/iohk/ethereum/sync/RegularSyncItSpec.scala
+++ b/src/it/scala/io/iohk/ethereum/sync/RegularSyncItSpec.scala
@@ -3,7 +3,6 @@ package io.iohk.ethereum.sync
 import com.typesafe.config.ConfigValueFactory
 import io.iohk.ethereum.FreeSpecBase
 import io.iohk.ethereum.metrics.{Metrics, MetricsConfig}
-import io.iohk.ethereum.network.PeerId
 import io.iohk.ethereum.sync.util.RegularSyncItSpecUtils.FakePeer
 import io.iohk.ethereum.sync.util.SyncCommonItSpec._
 import io.iohk.ethereum.utils.Config


### PR DESCRIPTION
Part of the handshake between peers is the exchange of genesis hash (in `Status`).
If the genesis hash is wrong we should disconnect and blacklist.
It appeared this functionality was already in place, so I just added missing tests.
