### PR TITLE
ETCM-845: Through rpc expose only blocks that are saved to storage

### DIFF
--- a/src/main/scala/io/iohk/ethereum/domain/Blockchain.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/Blockchain.scala
@@ -289,10 +289,11 @@ class BlockchainImpl(
   override def getLatestCheckpointBlockNumber(): BigInt =
     bestKnownBlockAndLatestCheckpoint.get().latestCheckpointNumber
 
+  //returns the best known block if it's available in the storage, otherwise the best stored block
   override def getBestBlock(): Option[Block] = {
     val bestBlockNumber = getBestBlockNumber()
     log.debug("Trying to get best block with number {}", bestBlockNumber)
-    getBlockByNumber(bestBlockNumber)
+    getBlockByNumber(bestBlockNumber) orElse getBlockByNumber(appStateStorage.getBestBlockNumber())
   }
 
   override def getAccount(address: Address, blockNumber: BigInt): Option[Account] =

--- a/src/test/scala/io/iohk/ethereum/ledger/BlockImportSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/BlockImportSpec.scala
@@ -146,7 +146,7 @@ class BlockImportSpec extends AnyFlatSpec with Matchers with ScalaFutures {
     blockQueue.isQueued(oldBlock3.header.hash) shouldBe true
   }
 
-  it should "fail to get bestblock after reorganisation of the longer chain to a shorter one if desync state happened between cache and db" in new EphemBlockchain {
+  it should "get best stored block after reorganisation of the longer chain to a shorter one if desync state happened between cache and db" in new EphemBlockchain {
     val block1: Block = getBlock(bestNum - 2)
     // new chain is shorter but has a higher weight
     val newBlock2: Block = getBlock(bestNum - 1, difficulty = 101, parent = block1.header.hash)
@@ -192,7 +192,7 @@ class BlockImportSpec extends AnyFlatSpec with Matchers with ScalaFutures {
     // dying before updating the storage but after updating the cache, inconsistency is created
     blockchain.saveBestKnownBlocks(oldBlock4.number)
 
-    blockchain.getBestBlock() shouldBe None
+    blockchain.getBestBlock() shouldBe Some(ancestorForValidation)
   }
 
   it should "handle error when trying to reorganise chain" in new EphemBlockchain {


### PR DESCRIPTION
# Description

Several endpoints make use of the "best known block", which fails in case the best block wasn't yet saved to storage and only available in memory.

#Solution

fallback to best saved block in case best known block is not (yet) available
