### PR TITLE
[ETCM-878] blockchain tests : BlockchainTests/vmArithmeticTest

### DIFF
--- a/ets/README.md
+++ b/ets/README.md
@@ -37,6 +37,7 @@ You can also run parts of the suite; refer to `ets/retesteth --help` for details
 You should run Mantis outside Nix as that is probably more convenient for your
 tooling (eg. attaching a debugger.)
 
+    rm -rf ~/.mantis/test # delete the storage to be sure no previous run is affecting the tests
     sbt -Dconfig.file=./src/main/resources/conf/testmode.conf -Dlogging.logs-level=WARN run
 
 Retesteth will need to be able to connect to Mantis, running on the host
@@ -44,8 +45,22 @@ system. First, find the IP it should use:
 
     nix-in-docker/run --command "getent hosts host.docker.internal"
 
-Edit `ets/config/mantis` and replace `0.0.0.0` with this IP.
-
 Finally, run retesteth in Nix in Docker:
 
-    nix-in-docker/run --command "ets/retesteth -t GeneralStateTests"
+    nix-in-docker/run --command "ets/retesteth -t GeneralStateTests -- --nodes <ip>:8546"
+
+## Useful options:
+
+You can run one test be selecting one suite and using `--singletest`, for instance: 
+
+    nix-in-docker/run -t BlockchainTests/ValidBlocks/VMTests/vmArithmeticTest -- --nodes <ip>:8546 --singletest add0"
+
+However it's not always clear in wich subfolder the suite is when looking at the output of retesteth.
+
+To get more insight about what is happening, you can use `--verbosity 6`. It will print every RPC call 
+made by retesteth and also print out the state by using our `debug_*` endpoints. Note however that 
+`debug_accountRange` and `debug_storageRangeAt` implementations are not complete at the moment :
+
+ - `debug_accountRange` will only list accounts known at the genesis state. 
+ - `debug_storageRangeAt` is not able to show the state after an arbitrary transaction inside a block.
+It will just return the state after all transaction in the block have run.

--- a/ets/README.md
+++ b/ets/README.md
@@ -37,7 +37,6 @@ You can also run parts of the suite; refer to `ets/retesteth --help` for details
 You should run Mantis outside Nix as that is probably more convenient for your
 tooling (eg. attaching a debugger.)
 
-    rm -rf ~/.mantis/test # delete the storage to be sure no previous run is affecting the tests
     sbt -Dconfig.file=./src/main/resources/conf/testmode.conf -Dlogging.logs-level=WARN run
 
 Retesteth will need to be able to connect to Mantis, running on the host
@@ -51,7 +50,7 @@ Finally, run retesteth in Nix in Docker:
 
 ## Useful options:
 
-You can run one test be selecting one suite and using `--singletest`, for instance: 
+You can run one test by selecting one suite and using `--singletest`, for instance: 
 
     nix-in-docker/run -t BlockchainTests/ValidBlocks/VMTests/vmArithmeticTest -- --nodes <ip>:8546 --singletest add0"
 

--- a/src/main/scala/io/iohk/ethereum/Mantis.scala
+++ b/src/main/scala/io/iohk/ethereum/Mantis.scala
@@ -2,6 +2,7 @@ package io.iohk.ethereum
 
 import io.iohk.ethereum.nodebuilder.{StdNode, TestNode}
 import io.iohk.ethereum.utils.{Config, Logger}
+import org.rocksdb
 
 import java.nio.file.{Files, Paths}
 import java.util.logging.LogManager
@@ -24,14 +25,7 @@ object Mantis extends Logger {
   }
 
   private def deleteRocksDBFiles(): Unit = {
-    val path = Paths.get(Config.Db.RocksDb.path)
-    if (path.toFile.exists()) {
-      log.info("Deleting previous database {}", Config.Db.RocksDb.path)
-      Files
-        .list(path)
-        .map(_.toFile)
-        .filter(_.isFile)
-        .forEach(f => f.delete())
-    }
+    log.warn("Deleting previous database {}", Config.Db.RocksDb.path)
+    rocksdb.RocksDB.destroyDB(Config.Db.RocksDb.path, new rocksdb.Options())
   }
 }

--- a/src/main/scala/io/iohk/ethereum/Mantis.scala
+++ b/src/main/scala/io/iohk/ethereum/Mantis.scala
@@ -3,8 +3,8 @@ package io.iohk.ethereum
 import io.iohk.ethereum.nodebuilder.{StdNode, TestNode}
 import io.iohk.ethereum.utils.{Config, Logger}
 
+import java.nio.file.{Files, Paths}
 import java.util.logging.LogManager
-import scala.reflect.io.Directory
 
 object Mantis extends Logger {
   def main(args: Array[String]): Unit = {
@@ -13,8 +13,7 @@ object Mantis extends Logger {
     val node =
       if (Config.testmode) {
         log.info("Starting Mantis in test mode")
-        log.info("Deleting previous database {}", Config.Db.RocksDb.path)
-        Directory(Config.Db.RocksDb.path).deleteRecursively()
+        deleteRocksDBFiles()
         new TestNode
       } else new StdNode
 
@@ -22,5 +21,17 @@ object Mantis extends Logger {
     log.info("Using network {}", Config.blockchains.network)
 
     node.start()
+  }
+
+  private def deleteRocksDBFiles(): Unit = {
+    val path = Paths.get(Config.Db.RocksDb.path)
+    if (path.toFile.exists()) {
+      log.info("Deleting previous database {}", Config.Db.RocksDb.path)
+      Files
+        .list(path)
+        .map(_.toFile)
+        .filter(_.isFile)
+        .forEach(f => f.delete())
+    }
   }
 }

--- a/src/main/scala/io/iohk/ethereum/Mantis.scala
+++ b/src/main/scala/io/iohk/ethereum/Mantis.scala
@@ -3,7 +3,6 @@ package io.iohk.ethereum
 import io.iohk.ethereum.nodebuilder.{StdNode, TestNode}
 import io.iohk.ethereum.utils.{Config, Logger}
 
-import java.nio.file.Path
 import java.util.logging.LogManager
 import scala.reflect.io.Directory
 
@@ -14,7 +13,7 @@ object Mantis extends Logger {
     val node =
       if (Config.testmode) {
         log.info("Starting Mantis in test mode")
-        log.info(s"Deleting previous database ${Config.Db.RocksDb.path}")
+        log.info("Deleting previous database {}", Config.Db.RocksDb.path)
         Directory(Config.Db.RocksDb.path).deleteRecursively()
         new TestNode
       } else new StdNode

--- a/src/main/scala/io/iohk/ethereum/Mantis.scala
+++ b/src/main/scala/io/iohk/ethereum/Mantis.scala
@@ -2,7 +2,10 @@ package io.iohk.ethereum
 
 import io.iohk.ethereum.nodebuilder.{StdNode, TestNode}
 import io.iohk.ethereum.utils.{Config, Logger}
+
+import java.nio.file.Path
 import java.util.logging.LogManager
+import scala.reflect.io.Directory
 
 object Mantis extends Logger {
   def main(args: Array[String]): Unit = {
@@ -11,6 +14,8 @@ object Mantis extends Logger {
     val node =
       if (Config.testmode) {
         log.info("Starting Mantis in test mode")
+        log.info(s"Deleting previous database ${Config.Db.RocksDb.path}")
+        Directory(Config.Db.RocksDb.path).deleteRecursively()
         new TestNode
       } else new StdNode
 

--- a/src/main/scala/io/iohk/ethereum/domain/Blockchain.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/Blockchain.scala
@@ -324,8 +324,8 @@ class BlockchainImpl(
     val bigIntValue = mpt.get(position).getOrElse(BigInt(0))
     val byteArrayValue = bigIntValue.toByteArray
 
-    // BigInt.toArray actually might return one more byte than necessary because it add a sign bit, which in our case
-    // will always be 0. This would adds unwanted 0 bytes and might cause the value to be 33 byte long while an EVM
+    // BigInt.toArray actually might return one more byte than necessary because it adds a sign bit, which in our case
+    // will always be 0. This would add unwanted 0 bytes and might cause the value to be 33 byte long while an EVM
     // word is 32 byte long.
     if (bigIntValue != 0)
       ByteString(byteArrayValue.dropWhile(_ == 0))

--- a/src/main/scala/io/iohk/ethereum/domain/Blockchain.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/Blockchain.scala
@@ -320,7 +320,17 @@ class BlockchainImpl(
     val mpt =
       if (ethCompatibleStorage) domain.EthereumUInt256Mpt.storageMpt(rootHash, storage)
       else domain.ArbitraryIntegerMpt.storageMpt(rootHash, storage)
-    ByteString(mpt.get(position).getOrElse(BigInt(0)).toByteArray)
+
+    val bigIntValue = mpt.get(position).getOrElse(BigInt(0))
+    val byteArrayValue = bigIntValue.toByteArray
+
+    // BigInt.toArray actually might return one more byte than necessary because it add a sign bit, which in our case
+    // will always be 0. This would adds unwanted 0 bytes and might cause the value to be 33 byte long while an EVM
+    // word is 32 byte long.
+    if (bigIntValue != 0)
+      ByteString(byteArrayValue.dropWhile(_ == 0))
+    else
+      ByteString(byteArrayValue)
   }
 
   override def getStorageProofAt(

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/TestJsonMethodsImplicits.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/TestJsonMethodsImplicits.scala
@@ -186,7 +186,7 @@ object TestJsonMethodsImplicits extends JsonMethodsImplicits {
               addressHash <- extractBytes(addressHash.extract[String])
               blockHashOrNumberEither = extractBlockHashOrNumber(blockHashOrNumber.extract[String])
             } yield AccountsInRangeRequest(
-              AccountsInRangeRequestParams(blockHashOrNumberEither, txIndex, addressHash, maxResults)
+              AccountsInRangeRequestParams(blockHashOrNumberEither, txIndex, addressHash, maxResults.toInt)
             )
           case _ => Left(InvalidParams())
         }

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/TestJsonMethodsImplicits.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/TestJsonMethodsImplicits.scala
@@ -60,7 +60,8 @@ object TestJsonMethodsImplicits extends JsonMethodsImplicits {
               genesis <- extractGenesis(paramsObj \ "genesis")
               blockchainParams <- extractBlockchainParams(paramsObj \ "params")
               sealEngine <- Try((paramsObj \ "sealEngine").extract[String]).toEither
-                .leftMap(_ => InvalidParams()).flatMap(extractSealEngine)
+                .leftMap(_ => InvalidParams())
+                .flatMap(extractSealEngine)
               accounts <- extractAccounts(paramsObj \ "accounts")
             } yield SetChainParamsRequest(ChainParams(genesis, blockchainParams, sealEngine, accounts))
           case _ => Left(InvalidParams())

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/TestJsonMethodsImplicits.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/TestJsonMethodsImplicits.scala
@@ -214,7 +214,7 @@ object TestJsonMethodsImplicits extends JsonMethodsImplicits {
               addressHash <- extractBytes(address.extract[String])
               blockHashOrNumberEither = extractBlockHashOrNumber(blockHashOrNumber.extract[String])
             } yield StorageRangeRequest(
-              StorageRangeParams(blockHashOrNumberEither, txIndex, addressHash, begin, maxResults)
+              StorageRangeParams(blockHashOrNumberEither, txIndex, addressHash, begin, maxResults.toInt)
             )
           case _ => Left(InvalidParams())
         }

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/TestService.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/TestService.scala
@@ -260,7 +260,7 @@ class TestService(
 
   def importRawBlock(request: ImportRawBlockRequest): ServiceResponse[ImportRawBlockResponse] = {
     Try(decode(request.blockRlp).toBlock) match {
-      case Failure(e) =>
+      case Failure(_) =>
         Task.now(Left(JsonRpcError(-1, "block validation failed!", None)))
       case Success(value) =>
         testModeComponentsProvider

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/TestService.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/TestService.scala
@@ -276,7 +276,7 @@ class TestService(
         val blockHash = s"0x${ByteStringUtils.hash2string(blockImportData.head.block.header.hash)}"
         ImportRawBlockResponse(blockHash).rightNow
       case e =>
-        log.warn(s"Block import failed with ${e}")
+        log.warn("Block import failed with {}", e)
         Task.now(Left(JsonRpcError(-1, "block validation failed!", None)))
     }
   }

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/TestService.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/TestService.scala
@@ -362,6 +362,7 @@ class TestService(
     * _txIndex is executed. This is currently not supported in mantis.
     * @see https://github.com/ethereum/retesteth/wiki/RPC-Methods#debug_storagerangeat
     */
+  // TODO ETCM-784, ETCM-758: see how we can get a state after an arbitrary transation
   def storageRangeAt(request: StorageRangeRequest): ServiceResponse[StorageRangeResponse] = {
 
     val blockOpt = request.parameters.blockHashOrNumber

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/TestService.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/TestService.scala
@@ -217,7 +217,9 @@ class TestService(
   def mineBlocks(request: MineBlocksRequest): ServiceResponse[MineBlocksResponse] = {
     def mineBlock(): Task[Unit] = {
       getBlockForMining(blockchain.getBestBlock().get)
-        .flatMap(blockForMining => testModeComponentsProvider.ledger(currentConfig, sealEngine).importBlock(blockForMining.block))
+        .flatMap(blockForMining =>
+          testModeComponentsProvider.ledger(currentConfig, sealEngine).importBlock(blockForMining.block)
+        )
         .map { res =>
           log.info("Block mining result: " + res)
           pendingTransactionsManager ! PendingTransactionsManager.ClearPendingTransactions

--- a/src/main/scala/io/iohk/ethereum/ledger/BlockExecution.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/BlockExecution.scala
@@ -73,7 +73,7 @@ class BlockExecution(
     *
     * @param block the block with transactions to run
     */
-  private[ledger] def executeBlockTransactions(
+  protected[ledger] def executeBlockTransactions(
       block: Block,
       parent: BlockHeader
   ): Either[BlockExecutionError, BlockResult] = {
@@ -87,6 +87,14 @@ class BlockExecution(
       ethCompatibleStorage = blockchainConfig.ethCompatibleStorage
     )
 
+    executeBlockTransactions(block, blockHeaderNumber, initialWorld)
+  }
+
+  protected def executeBlockTransactions(
+      block: Block,
+      blockHeaderNumber: BigInt,
+      initialWorld: InMemoryWorldStateProxy
+  ): Either[BlockExecutionError.TxsExecutionError, BlockResult] = {
     val inputWorld = blockchainConfig.daoForkConfig match {
       case Some(daoForkConfig) if daoForkConfig.isDaoForkBlock(blockHeaderNumber) =>
         drainDaoForkAccounts(initialWorld, daoForkConfig)

--- a/src/main/scala/io/iohk/ethereum/ledger/BlockPreparator.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/BlockPreparator.scala
@@ -70,7 +70,7 @@ class BlockPreparator(
       if (!treasuryEnabled(blockNumber) || !existsTreasuryContract) {
         val minerReward = minerRewardForOmmers + minerRewardForBlock
         val worldAfterMinerReward = increaseAccountBalance(minerAddress, UInt256(minerReward))(worldStateProxy)
-        log.debug(s"Paying block $blockNumber reward of $minerReward to miner with address $minerAddress")
+        log.debug("Paying block {} reward of {} to miner with address {}", blockNumber, minerReward, minerAddress)
         worldAfterMinerReward
       } else {
         val minerReward = minerRewardForOmmers + minerRewardForBlock * MinerRewardPercentageAfterECIP1098 / 100
@@ -79,8 +79,12 @@ class BlockPreparator(
         val worldAfterTreasuryReward =
           increaseAccountBalance(treasuryAddress, UInt256(treasuryReward))(worldAfterMinerReward)
         log.debug(
-          s"Paying block $blockNumber reward of $minerReward to miner with address $minerAddress" +
-            s"paying treasury reward of $treasuryReward to treasury with address $treasuryAddress"
+          "Paying block {} reward of {} to miner with address {} paying treasury reward of {} to treasury with address {}",
+          blockNumber,
+          minerReward,
+          minerAddress,
+          treasuryReward,
+          treasuryAddress
         )
         worldAfterTreasuryReward
       }
@@ -88,7 +92,7 @@ class BlockPreparator(
       val ommerAddress = Address(ommer.beneficiary)
       val ommerReward = blockRewardCalculator.calculateOmmerRewardForInclusion(blockNumber, ommer.number)
 
-      log.debug(s"Paying block $blockNumber reward of $ommerReward to ommer with account address $ommerAddress")
+      log.debug("Paying block {} reward of {} to ommer with account address {}", blockNumber, ommerReward, ommerAddress)
       increaseAccountBalance(ommerAddress, UInt256(ommerReward))(ws)
     }
   }

--- a/src/main/scala/io/iohk/ethereum/ledger/BlockPreparator.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/BlockPreparator.scala
@@ -54,11 +54,10 @@ class BlockPreparator(
     * @param worldStateProxy the initial state
     * @return the state after paying the appropriate reward to who corresponds
     */
-  private[ledger] def payBlockReward(
+  protected[ledger] def payBlockReward(
       block: Block,
       worldStateProxy: InMemoryWorldStateProxy
-  ): InMemoryWorldStateProxy =
-    if (!Config.testmode) {
+  ): InMemoryWorldStateProxy = {
       val blockNumber = block.header.number
       val minerRewardForBlock = blockRewardCalculator.calculateMiningRewardForBlock(blockNumber)
       val minerRewardForOmmers =
@@ -92,9 +91,6 @@ class BlockPreparator(
         log.debug(s"Paying block $blockNumber reward of $ommerReward to ommer with account address $ommerAddress")
         increaseAccountBalance(ommerAddress, UInt256(ommerReward))(ws)
       }
-    } else {
-      //FIXME needs to be part of setting up the application and not a runtime flag
-      worldStateProxy
     }
 
   private def treasuryEnabled(blockNo: BigInt): Boolean =

--- a/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
@@ -28,7 +28,12 @@ import io.iohk.ethereum.network.p2p.EthereumMessageDecoder
 import io.iohk.ethereum.network.rlpx.AuthHandshaker
 import io.iohk.ethereum.network.{PeerManagerActor, ServerActor, _}
 import io.iohk.ethereum.ommers.OmmersPool
-import io.iohk.ethereum.testmode.{TestEthBlockServiceWrapper, TestModeServiceBuilder, TestmodeConsensusBuilder}
+import io.iohk.ethereum.testmode.{
+  TestBlockchainBuilder,
+  TestEthBlockServiceWrapper,
+  TestModeServiceBuilder,
+  TestmodeConsensusBuilder
+}
 import io.iohk.ethereum.transactions.{PendingTransactionsManager, TransactionHistoryService}
 import io.iohk.ethereum.utils.Config.SyncConfig
 import io.iohk.ethereum.utils._
@@ -357,7 +362,7 @@ trait DebugServiceBuilder {
 }
 
 trait TestServiceBuilder {
-  self: BlockchainBuilder
+  self: TestBlockchainBuilder
     with PendingTransactionsManagerBuilder
     with ConsensusConfigBuilder
     with BlockchainConfigBuilder
@@ -371,12 +376,13 @@ trait TestServiceBuilder {
       pendingTransactionsManager,
       consensusConfig,
       testModeComponentsProvider,
-      blockchainConfig
+      blockchainConfig,
+      preimages
     )(scheduler)
 }
 
 trait TestEthBlockServiceBuilder extends EthBlocksServiceBuilder {
-  self: BlockchainBuilder with TestModeServiceBuilder with ConsensusBuilder =>
+  self: TestBlockchainBuilder with TestModeServiceBuilder with ConsensusBuilder =>
   override lazy val ethBlocksService = new TestEthBlockServiceWrapper(blockchain, ledger, consensus)
 }
 

--- a/src/main/scala/io/iohk/ethereum/nodebuilder/StdNode.scala
+++ b/src/main/scala/io/iohk/ethereum/nodebuilder/StdNode.scala
@@ -5,8 +5,9 @@ import io.iohk.ethereum.consensus.StdConsensusBuilder
 import io.iohk.ethereum.metrics.{Metrics, MetricsConfig}
 import io.iohk.ethereum.network.discovery.PeerDiscoveryManager
 import io.iohk.ethereum.network.{PeerManagerActor, ServerActor}
-import io.iohk.ethereum.testmode.{TestModeServiceBuilder, TestmodeConsensusBuilder}
+import io.iohk.ethereum.testmode.{TestBlockchainBuilder, TestModeServiceBuilder, TestmodeConsensusBuilder}
 import io.iohk.ethereum.utils.Config
+
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Await
 import scala.util.{Failure, Success, Try}
@@ -110,3 +111,4 @@ class TestNode
     with TestmodeConsensusBuilder
     with TestServiceBuilder
     with TestEthBlockServiceBuilder
+    with TestBlockchainBuilder

--- a/src/main/scala/io/iohk/ethereum/testmode/SealEngineType.scala
+++ b/src/main/scala/io/iohk/ethereum/testmode/SealEngineType.scala
@@ -8,4 +8,3 @@ object SealEngineType {
   // Do not check `nonce` and `mixhash` field in blockHeaders + Do not check mining reward (block + uncle headers)
   object NoReward extends SealEngineType
 }
-

--- a/src/main/scala/io/iohk/ethereum/testmode/SealEngineType.scala
+++ b/src/main/scala/io/iohk/ethereum/testmode/SealEngineType.scala
@@ -1,0 +1,11 @@
+package io.iohk.ethereum.testmode
+
+sealed trait SealEngineType
+
+object SealEngineType {
+  // Do not check `nonce` and `mixhash` field in blockHeaders
+  object NoProof extends SealEngineType
+  // Do not check `nonce` and `mixhash` field in blockHeaders + Do not check mining reward (block + uncle headers)
+  object NoReward extends SealEngineType
+}
+

--- a/src/main/scala/io/iohk/ethereum/testmode/TestBlockchainBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/testmode/TestBlockchainBuilder.scala
@@ -1,0 +1,51 @@
+package io.iohk.ethereum.testmode
+
+import akka.util.ByteString
+import io.iohk.ethereum.crypto
+import io.iohk.ethereum.domain.{BlockchainImpl, UInt256}
+import io.iohk.ethereum.ledger.InMemoryWorldStateProxy
+import io.iohk.ethereum.nodebuilder.{BlockchainBuilder, StorageBuilder}
+
+trait TestBlockchainBuilder extends BlockchainBuilder {
+  self: StorageBuilder =>
+
+  lazy val preimages: collection.concurrent.Map[ByteString, UInt256] =
+    new collection.concurrent.TrieMap[ByteString, UInt256]()
+
+  override lazy val blockchain: BlockchainImpl = {
+    val storages = storagesInstance.storages
+    new BlockchainImpl(
+      blockHeadersStorage = storages.blockHeadersStorage,
+      blockBodiesStorage = storages.blockBodiesStorage,
+      blockNumberMappingStorage = storages.blockNumberMappingStorage,
+      receiptStorage = storages.receiptStorage,
+      evmCodeStorage = storages.evmCodeStorage,
+      pruningMode = storages.pruningMode,
+      nodeStorage = storages.nodeStorage,
+      cachedNodeStorage = storages.cachedNodeStorage,
+      chainWeightStorage = storages.chainWeightStorage,
+      transactionMappingStorage = storages.transactionMappingStorage,
+      appStateStorage = storages.appStateStorage,
+      stateStorage = storages.stateStorage
+    ) {
+      override def getWorldStateProxy(
+          blockNumber: BigInt,
+          accountStartNonce: UInt256,
+          stateRootHash: ByteString,
+          noEmptyAccounts: Boolean,
+          ethCompatibleStorage: Boolean
+      ): InMemoryWorldStateProxy =
+        TestModeWorldStateProxy(
+          evmCodeStorage,
+          stateStorage.getBackingStorage(blockNumber),
+          accountStartNonce,
+          (number: BigInt) => getBlockHeaderByNumber(number).map(_.hash),
+          stateRootHash,
+          noEmptyAccounts,
+          ethCompatibleStorage,
+          key => preimages.put(crypto.kec256(key.bytes), key)
+        )
+    }
+  }
+
+}

--- a/src/main/scala/io/iohk/ethereum/testmode/TestModeComponentsProvider.scala
+++ b/src/main/scala/io/iohk/ethereum/testmode/TestModeComponentsProvider.scala
@@ -19,10 +19,28 @@ class TestModeComponentsProvider(
     vm: VMImpl
 ) {
 
-  def ledger(blockchainConfig: BlockchainConfig,sealEngine: SealEngineType): Ledger =
-    new LedgerImpl(blockchain, blockchainConfig, syncConfig, consensus(blockchainConfig, sealEngine), validationExecutionContext)
-  def stxLedger(blockchainConfig: BlockchainConfig,sealEngine: SealEngineType): StxLedger =
+  def ledger(blockchainConfig: BlockchainConfig, sealEngine: SealEngineType): Ledger =
+    new LedgerImpl(
+      blockchain,
+      blockchainConfig,
+      syncConfig,
+      consensus(blockchainConfig, sealEngine),
+      validationExecutionContext
+    )
+  def stxLedger(blockchainConfig: BlockchainConfig, sealEngine: SealEngineType): StxLedger =
     new StxLedger(blockchain, blockchainConfig, consensus(blockchainConfig, sealEngine).blockPreparator)
-  def consensus(blockchainConfig: BlockchainConfig, sealEngine: SealEngineType, blockTimestamp: Long = 0): TestmodeConsensus =
-    new TestmodeConsensus(vm, blockchain, blockchainConfig, consensusConfig, difficultyCalculator, sealEngine, blockTimestamp)
+  def consensus(
+      blockchainConfig: BlockchainConfig,
+      sealEngine: SealEngineType,
+      blockTimestamp: Long = 0
+  ): TestmodeConsensus =
+    new TestmodeConsensus(
+      vm,
+      blockchain,
+      blockchainConfig,
+      consensusConfig,
+      difficultyCalculator,
+      sealEngine,
+      blockTimestamp
+    )
 }

--- a/src/main/scala/io/iohk/ethereum/testmode/TestModeComponentsProvider.scala
+++ b/src/main/scala/io/iohk/ethereum/testmode/TestModeComponentsProvider.scala
@@ -19,10 +19,10 @@ class TestModeComponentsProvider(
     vm: VMImpl
 ) {
 
-  def ledger(blockchainConfig: BlockchainConfig): Ledger =
-    new LedgerImpl(blockchain, blockchainConfig, syncConfig, consensus(blockchainConfig), validationExecutionContext)
-  def stxLedger(blockchainConfig: BlockchainConfig): StxLedger =
-    new StxLedger(blockchain, blockchainConfig, consensus(blockchainConfig).blockPreparator)
-  def consensus(blockchainConfig: BlockchainConfig, blockTimestamp: Long = 0): TestmodeConsensus =
-    new TestmodeConsensus(vm, blockchain, blockchainConfig, consensusConfig, difficultyCalculator, blockTimestamp)
+  def ledger(blockchainConfig: BlockchainConfig,sealEngine: SealEngineType): Ledger =
+    new LedgerImpl(blockchain, blockchainConfig, syncConfig, consensus(blockchainConfig, sealEngine), validationExecutionContext)
+  def stxLedger(blockchainConfig: BlockchainConfig,sealEngine: SealEngineType): StxLedger =
+    new StxLedger(blockchain, blockchainConfig, consensus(blockchainConfig, sealEngine).blockPreparator)
+  def consensus(blockchainConfig: BlockchainConfig, sealEngine: SealEngineType, blockTimestamp: Long = 0): TestmodeConsensus =
+    new TestmodeConsensus(vm, blockchain, blockchainConfig, consensusConfig, difficultyCalculator, sealEngine, blockTimestamp)
 }

--- a/src/main/scala/io/iohk/ethereum/testmode/TestModeServiceBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/testmode/TestModeServiceBuilder.scala
@@ -31,7 +31,7 @@ trait TestModeServiceBuilder extends LedgerBuilder {
       vm
     )
 
-  private def testLedger: Ledger = testModeComponentsProvider.ledger(blockchainConfig)
+  private def testLedger: Ledger = testModeComponentsProvider.ledger(blockchainConfig, SealEngineType.NoReward)
 
   class TestLedgerProxy extends Ledger {
     override def consensus: Consensus = testLedger.consensus
@@ -45,5 +45,5 @@ trait TestModeServiceBuilder extends LedgerBuilder {
   }
 
   override lazy val ledger: Ledger = new TestLedgerProxy
-  override lazy val stxLedger: StxLedger = testModeComponentsProvider.stxLedger(blockchainConfig)
+  override lazy val stxLedger: StxLedger = testModeComponentsProvider.stxLedger(blockchainConfig, SealEngineType.NoReward)
 }

--- a/src/main/scala/io/iohk/ethereum/testmode/TestModeServiceBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/testmode/TestModeServiceBuilder.scala
@@ -45,5 +45,6 @@ trait TestModeServiceBuilder extends LedgerBuilder {
   }
 
   override lazy val ledger: Ledger = new TestLedgerProxy
-  override lazy val stxLedger: StxLedger = testModeComponentsProvider.stxLedger(blockchainConfig, SealEngineType.NoReward)
+  override lazy val stxLedger: StxLedger =
+    testModeComponentsProvider.stxLedger(blockchainConfig, SealEngineType.NoReward)
 }

--- a/src/main/scala/io/iohk/ethereum/testmode/TestModeServiceBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/testmode/TestModeServiceBuilder.scala
@@ -12,7 +12,7 @@ import monix.execution.Scheduler
 
 trait TestModeServiceBuilder extends LedgerBuilder {
   self: BlockchainConfigBuilder
-    with BlockchainBuilder
+    with TestBlockchainBuilder
     with SyncConfigBuilder
     with ConsensusBuilder
     with ActorSystemBuilder

--- a/src/main/scala/io/iohk/ethereum/testmode/TestModeWorldStateProxy.scala
+++ b/src/main/scala/io/iohk/ethereum/testmode/TestModeWorldStateProxy.scala
@@ -11,17 +11,19 @@ import io.iohk.ethereum.mpt.MerklePatriciaTrie
 /** This is a wrapper around InMemoryWorldStateProxy.
   * Its only role is to store the storage key encountered during a run to store them for debugging purpose.
   */
-class TestModeWorldStateProxy(
-    stateStorage: MptStorage,
-    accountsStateTrie: InMemorySimpleMapProxy[Address, Account, MerklePatriciaTrie[Address, Account]],
-    contractStorages: Map[Address, InMemorySimpleMapProxy[BigInt, BigInt, MerklePatriciaTrie[BigInt, BigInt]]],
-    evmCodeStorage: EvmCodeStorage,
-    accountCodes: Map[Address, Code],
-    getBlockByNumber: (BigInt) => Option[ByteString],
-    accountStartNonce: UInt256,
-    touchedAccounts: Set[Address],
-    noEmptyAccountsCond: Boolean,
-    ethCompatibleStorage: Boolean,
+case class TestModeWorldStateProxy(
+    override val stateStorage: MptStorage,
+    override val accountsStateTrie: InMemorySimpleMapProxy[Address, Account, MerklePatriciaTrie[Address, Account]],
+    // format: off
+    override val contractStorages: Map[Address, InMemorySimpleMapProxy[BigInt, BigInt, MerklePatriciaTrie[BigInt, BigInt]]],
+    // format: on
+    override val evmCodeStorage: EvmCodeStorage,
+    override val accountCodes: Map[Address, Code],
+    override val getBlockByNumber: (BigInt) => Option[ByteString],
+    override val accountStartNonce: UInt256,
+    override val touchedAccounts: Set[Address],
+    override val noEmptyAccountsCond: Boolean,
+    override val ethCompatibleStorage: Boolean,
     saveStoragePreimage: (UInt256) => Unit
 ) extends InMemoryWorldStateProxy(
       stateStorage,
@@ -37,10 +39,10 @@ class TestModeWorldStateProxy(
     ) {
 
   override def saveAccount(address: Address, account: Account): TestModeWorldStateProxy =
-    copyWith(accountsStateTrie = accountsStateTrie.put(address, account))
+    copy(accountsStateTrie = accountsStateTrie.put(address, account))
 
   override def deleteAccount(address: Address): TestModeWorldStateProxy =
-    copyWith(
+    copy(
       accountsStateTrie = accountsStateTrie.remove(address),
       contractStorages = contractStorages - address,
       accountCodes = accountCodes - address
@@ -48,51 +50,27 @@ class TestModeWorldStateProxy(
 
   override def touchAccounts(addresses: Address*): TestModeWorldStateProxy =
     if (noEmptyAccounts)
-      copyWith(touchedAccounts = touchedAccounts ++ addresses.toSet)
+      copy(touchedAccounts = touchedAccounts ++ addresses.toSet)
     else
       this
 
   override def clearTouchedAccounts: TestModeWorldStateProxy =
-    copyWith(touchedAccounts = touchedAccounts.empty)
+    copy(touchedAccounts = touchedAccounts.empty)
 
   override def keepPrecompileTouched(world: InMemoryWorldStateProxy): TestModeWorldStateProxy = {
     if (world.touchedAccounts.contains(ripmdContractAddress))
-      copyWith(touchedAccounts = touchedAccounts + ripmdContractAddress)
+      copy(touchedAccounts = touchedAccounts + ripmdContractAddress)
     else
       this
   }
 
   override def saveCode(address: Address, code: ByteString): TestModeWorldStateProxy =
-    copyWith(accountCodes = accountCodes + (address -> code))
+    copy(accountCodes = accountCodes + (address -> code))
 
   override def saveStorage(address: Address, storage: InMemoryWorldStateProxyStorage): TestModeWorldStateProxy = {
     storage.wrapped.cache.foreach { case (key, _) => saveStoragePreimage(UInt256(key)) }
-    copyWith(contractStorages = contractStorages + (address -> storage.wrapped))
+    copy(contractStorages = contractStorages + (address -> storage.wrapped))
   }
-
-  private def copyWith(
-      stateStorage: MptStorage = stateStorage,
-      accountsStateTrie: InMemorySimpleMapProxy[Address, Account, MerklePatriciaTrie[Address, Account]] =
-        accountsStateTrie,
-      contractStorages: Map[Address, InMemorySimpleMapProxy[BigInt, BigInt, MerklePatriciaTrie[BigInt, BigInt]]] =
-        contractStorages,
-      evmCodeStorage: EvmCodeStorage = evmCodeStorage,
-      accountCodes: Map[Address, Code] = accountCodes,
-      touchedAccounts: Set[Address] = touchedAccounts
-  ): TestModeWorldStateProxy =
-    new TestModeWorldStateProxy(
-      stateStorage,
-      accountsStateTrie,
-      contractStorages,
-      evmCodeStorage,
-      accountCodes,
-      getBlockByNumber,
-      accountStartNonce,
-      touchedAccounts,
-      noEmptyAccountsCond,
-      ethCompatibleStorage,
-      saveStoragePreimage
-    )
 }
 
 object TestModeWorldStateProxy {
@@ -106,19 +84,18 @@ object TestModeWorldStateProxy {
       ethCompatibleStorage: Boolean,
       saveStoragePreimage: (UInt256) => Unit
   ): TestModeWorldStateProxy = {
-    val accountsStateTrieProxy = createProxiedAccountsStateTrie(nodesKeyValueStorage, stateRootHash)
     new TestModeWorldStateProxy(
-      nodesKeyValueStorage,
-      accountsStateTrieProxy,
-      Map.empty,
-      evmCodeStorage,
-      Map.empty,
-      getBlockHashByNumber,
-      accountStartNonce,
-      Set.empty,
-      noEmptyAccounts,
-      ethCompatibleStorage,
-      saveStoragePreimage
+      stateStorage = nodesKeyValueStorage,
+      accountsStateTrie = createProxiedAccountsStateTrie(nodesKeyValueStorage, stateRootHash),
+      contractStorages = Map.empty,
+      evmCodeStorage = evmCodeStorage,
+      accountCodes = Map.empty,
+      getBlockByNumber = getBlockHashByNumber,
+      accountStartNonce = accountStartNonce,
+      touchedAccounts = Set.empty,
+      noEmptyAccountsCond = noEmptyAccounts,
+      ethCompatibleStorage = ethCompatibleStorage,
+      saveStoragePreimage = saveStoragePreimage
     )
   }
 

--- a/src/main/scala/io/iohk/ethereum/testmode/TestModeWorldStateProxy.scala
+++ b/src/main/scala/io/iohk/ethereum/testmode/TestModeWorldStateProxy.scala
@@ -1,0 +1,136 @@
+package io.iohk.ethereum.testmode
+
+import akka.util.ByteString
+import io.iohk.ethereum.db.storage.{EvmCodeStorage, MptStorage}
+import io.iohk.ethereum.db.storage.EvmCodeStorage.Code
+import io.iohk.ethereum.domain.Account.accountSerializer
+import io.iohk.ethereum.domain.{Account, Address, UInt256}
+import io.iohk.ethereum.ledger.{InMemorySimpleMapProxy, InMemoryWorldStateProxy, InMemoryWorldStateProxyStorage}
+import io.iohk.ethereum.mpt.MerklePatriciaTrie
+
+/** This is a wrapper around InMemoryWorldStateProxy.
+  * Its only role is to store the storage key encountered during a run to store them for debugging purpose.
+  */
+class TestModeWorldStateProxy(
+    stateStorage: MptStorage,
+    accountsStateTrie: InMemorySimpleMapProxy[Address, Account, MerklePatriciaTrie[Address, Account]],
+    contractStorages: Map[Address, InMemorySimpleMapProxy[BigInt, BigInt, MerklePatriciaTrie[BigInt, BigInt]]],
+    evmCodeStorage: EvmCodeStorage,
+    accountCodes: Map[Address, Code],
+    getBlockByNumber: (BigInt) => Option[ByteString],
+    accountStartNonce: UInt256,
+    touchedAccounts: Set[Address],
+    noEmptyAccountsCond: Boolean,
+    ethCompatibleStorage: Boolean,
+    saveStoragePreimage: (UInt256) => Unit
+) extends InMemoryWorldStateProxy(
+      stateStorage,
+      accountsStateTrie,
+      contractStorages,
+      evmCodeStorage,
+      accountCodes,
+      getBlockByNumber,
+      accountStartNonce,
+      touchedAccounts,
+      noEmptyAccountsCond,
+      ethCompatibleStorage
+    ) {
+
+  override def saveAccount(address: Address, account: Account): TestModeWorldStateProxy =
+    copyWith(accountsStateTrie = accountsStateTrie.put(address, account))
+
+  override def deleteAccount(address: Address): TestModeWorldStateProxy =
+    copyWith(
+      accountsStateTrie = accountsStateTrie.remove(address),
+      contractStorages = contractStorages - address,
+      accountCodes = accountCodes - address
+    )
+
+  override def touchAccounts(addresses: Address*): TestModeWorldStateProxy =
+    if (noEmptyAccounts)
+      copyWith(touchedAccounts = touchedAccounts ++ addresses.toSet)
+    else
+      this
+
+  override def clearTouchedAccounts: TestModeWorldStateProxy =
+    copyWith(touchedAccounts = touchedAccounts.empty)
+
+  override def keepPrecompileTouched(world: InMemoryWorldStateProxy): TestModeWorldStateProxy = {
+    if (world.touchedAccounts.contains(ripmdContractAddress))
+      copyWith(touchedAccounts = touchedAccounts + ripmdContractAddress)
+    else
+      this
+  }
+
+  override def saveCode(address: Address, code: ByteString): TestModeWorldStateProxy =
+    copyWith(accountCodes = accountCodes + (address -> code))
+
+  override def saveStorage(address: Address, storage: InMemoryWorldStateProxyStorage): TestModeWorldStateProxy = {
+    storage.wrapped.cache.foreach { case (key, _) => saveStoragePreimage(UInt256(key)) }
+    copyWith(contractStorages = contractStorages + (address -> storage.wrapped))
+  }
+
+  private def copyWith(
+      stateStorage: MptStorage = stateStorage,
+      accountsStateTrie: InMemorySimpleMapProxy[Address, Account, MerklePatriciaTrie[Address, Account]] =
+        accountsStateTrie,
+      contractStorages: Map[Address, InMemorySimpleMapProxy[BigInt, BigInt, MerklePatriciaTrie[BigInt, BigInt]]] =
+        contractStorages,
+      evmCodeStorage: EvmCodeStorage = evmCodeStorage,
+      accountCodes: Map[Address, Code] = accountCodes,
+      touchedAccounts: Set[Address] = touchedAccounts
+  ): TestModeWorldStateProxy =
+    new TestModeWorldStateProxy(
+      stateStorage,
+      accountsStateTrie,
+      contractStorages,
+      evmCodeStorage,
+      accountCodes,
+      getBlockByNumber,
+      accountStartNonce,
+      touchedAccounts,
+      noEmptyAccountsCond,
+      ethCompatibleStorage,
+      saveStoragePreimage
+    )
+}
+
+object TestModeWorldStateProxy {
+  def apply(
+      evmCodeStorage: EvmCodeStorage,
+      nodesKeyValueStorage: MptStorage,
+      accountStartNonce: UInt256,
+      getBlockHashByNumber: BigInt => Option[ByteString],
+      stateRootHash: ByteString,
+      noEmptyAccounts: Boolean,
+      ethCompatibleStorage: Boolean,
+      saveStoragePreimage: (UInt256) => Unit
+  ): TestModeWorldStateProxy = {
+    val accountsStateTrieProxy = createProxiedAccountsStateTrie(nodesKeyValueStorage, stateRootHash)
+    new TestModeWorldStateProxy(
+      nodesKeyValueStorage,
+      accountsStateTrieProxy,
+      Map.empty,
+      evmCodeStorage,
+      Map.empty,
+      getBlockHashByNumber,
+      accountStartNonce,
+      Set.empty,
+      noEmptyAccounts,
+      ethCompatibleStorage,
+      saveStoragePreimage
+    )
+  }
+
+  private def createProxiedAccountsStateTrie(
+      accountsStorage: MptStorage,
+      stateRootHash: ByteString
+  ): InMemorySimpleMapProxy[Address, Account, MerklePatriciaTrie[Address, Account]] = {
+    InMemorySimpleMapProxy.wrap[Address, Account, MerklePatriciaTrie[Address, Account]](
+      MerklePatriciaTrie[Address, Account](
+        stateRootHash.toArray[Byte],
+        accountsStorage
+      )(Address.hashedAddressEncoder, accountSerializer)
+    )
+  }
+}

--- a/src/main/scala/io/iohk/ethereum/testmode/TestmodeConsensus.scala
+++ b/src/main/scala/io/iohk/ethereum/testmode/TestmodeConsensus.scala
@@ -81,7 +81,7 @@ class TestmodeConsensus(
           super.payBlockReward(block, worldStateProxy)
         case SealEngineType.NoReward =>
           worldStateProxy
-    }
+      }
   }
 
   override def blockGenerator: NoOmmersBlockGenerator =

--- a/src/main/scala/io/iohk/ethereum/testmode/TestmodeConsensus.scala
+++ b/src/main/scala/io/iohk/ethereum/testmode/TestmodeConsensus.scala
@@ -114,7 +114,7 @@ class TestmodeConsensus(
 }
 
 trait TestmodeConsensusBuilder extends ConsensusBuilder {
-  self: VmBuilder with BlockchainBuilder with BlockchainConfigBuilder with ConsensusConfigBuilder =>
+  self: VmBuilder with TestBlockchainBuilder with BlockchainConfigBuilder with ConsensusConfigBuilder =>
 
   override lazy val consensus = new TestmodeConsensus(
     vm,

--- a/test-ets.sh
+++ b/test-ets.sh
@@ -4,8 +4,6 @@ git submodule init
 git submodule update
 
 echo "booting Mantis and waiting for RPC API to be up"
-# deleting the state folder in case there is some remaining data from a previous run
-rm -rf ~/.mantis/test
 $SBT -Dconfig.file=./src/main/resources/conf/testmode.conf run &> mantis-log.txt &
 
 while ! nc -z localhost 8546; do   


### PR DESCRIPTION
# Description

This PR is part of the ogoing effort to make ETS pass all tests. The vmArithmeticTest suite did not pass because of several problems : 

 - mining reward: We did not handle the `sealEngine`parameter and were always running with `NoReward` when mantis was running in test mode
 - The output of `getAccountStorage` sometime wrongly had leading zeros due to a sign bit added by BigInt.toByteAray.
 - `storageRangeAt` did not return a range of value and took a key instead of a hash as input. This kind of worked because most test used `0x00` as storage key
 - `getAccountsInRange` did not included the coinbase account. It also depended on some state instead of taking the hash given as a parameter to find the start of its range.

Fixing those problem also fixes lots of other tests

# Important Changes Introduced

Most of the changes are external to the production code. The most impactful change is probably in `BlockchainImpl` where we now remove the leading zeros. I don't think this impact other parts of the application. 

Regarding `TestService.scala`, I removed the variable `accountRangeOffset`. I also added some state in testmode with a map `preimageCache`. This map is used to keep track of what storage address were used during one test run and be able to implement `storageRangeAt`. This is not really elegant so I will be happy for suggestion on how to make it better.

## Important note 
While this PR improves the implementation of `storageRangeAt` and `getAccountsInRange`, they are still not completely functional. They only work in test mode. There are also some edge case not handled : 

 - `getAccountsInRange` is only able to return account known in the genesis state and the account used for coinbase (So it won't return account created in a transaction)
 - `storageRangeAt` should be able to get the state not only on a given block but also after an arbitrary transaction inside the block. We currently only handle the first case. I'm not sure the tests actually need the second part so it might be alright for ETS.
 
 Also the `storageRangeAt` implementation is not really smart. It just iterate over known keys instead of actually reading the Merkle Patricia Trie. For tests with few values in storage It's good enough though. 

