### PR TITLE
[ETCM-893] Add support for chains with ids bigger than 127

### DIFF
--- a/crypto/src/main/scala/io/iohk/ethereum/crypto/ECDSASignature.scala
+++ b/crypto/src/main/scala/io/iohk/ethereum/crypto/ECDSASignature.scala
@@ -68,7 +68,7 @@ object ECDSASignature {
       case Some(id) if v == negativePointSign => id * 2 + newNegativePointSign
       case Some(id) if v == positivePointSign => id * 2 + newPositivePointSign
       case None => BigInt(v)
-      case _ => throw new IllegalStateException(s"Unexpected pointSign. ChainId: ${chainId}, v: ${v}")
+      case _ => throw new IllegalStateException(s"Unexpected pointSign. ChainId: $chainId, v: $v")
     }
 
     ECDSASignature(r, s, pointSign)

--- a/crypto/src/test/scala/io/iohk/ethereum/crypto/ECDSASignatureSpec.scala
+++ b/crypto/src/test/scala/io/iohk/ethereum/crypto/ECDSASignatureSpec.scala
@@ -18,7 +18,7 @@ class ECDSASignatureSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
     val pointSign = 28
 
     val sig =
-      ECDSASignature(BigInt(1, signatureRandom.toArray[Byte]), BigInt(1, signature.toArray[Byte]), pointSign.toByte)
+      ECDSASignature(BigInt(1, signatureRandom.toArray[Byte]), BigInt(1, signature.toArray[Byte]), pointSign)
 
     sig.publicKey(bytesToSign).isEmpty shouldBe false
   }
@@ -30,7 +30,7 @@ class ECDSASignatureSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
     val pointSign = 0x1f
 
     val sig =
-      ECDSASignature(BigInt(1, signatureRandom.toArray[Byte]), BigInt(1, signature.toArray[Byte]), pointSign.toByte)
+      ECDSASignature(BigInt(1, signatureRandom.toArray[Byte]), BigInt(1, signature.toArray[Byte]), pointSign)
 
     sig.publicKey(bytesToSign).isEmpty shouldBe true
   }
@@ -39,7 +39,7 @@ class ECDSASignatureSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
     val sig = ECDSASignature(
       ByteStringUtils.string2hash("149a2046f51f5d043633664d76eef4f99cdba8e53851dcda57224dfe8770f98a"),
       ByteStringUtils.string2hash("a8898478e9aae9fadb71c7ab5451d47d2efa4199fc26ecc1da62ce8fb77e06f1"),
-      28.toByte
+      28
     )
     val messageHash = ByteStringUtils.string2hash("a1ede9cdf0b6fe37a384b265dce6b74a7464f11799dcee022f628450a19cf4eb")
 

--- a/src/benchmark/scala/io/iohk/ethereum/rlp/RLPSpeedSuite.scala
+++ b/src/benchmark/scala/io/iohk/ethereum/rlp/RLPSpeedSuite.scala
@@ -88,7 +88,7 @@ class RLPSpeedSuite
     pointSign = 28,
     signatureRandom = ByteString(Hex.decode("cfe3ad31d6612f8d787c45f115cc5b43fb22bcc210b62ae71dc7cbf0a6bea8df")),
     signature = ByteString(Hex.decode("57db8998114fae3c337e99dbd8573d4085691880f4576c6c1f6c5bbfe67d6cf0")),
-    chainId = 0x3d.toByte
+    chainId = 0x3d
   )
 
   lazy val blockGen: Gen[Block] = for {

--- a/src/it/scala/io/iohk/ethereum/txExecTest/ECIP1017Test.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/ECIP1017Test.scala
@@ -19,7 +19,7 @@ class ECIP1017Test extends AnyFlatSpec with Matchers {
       monetaryPolicyConfig = MonetaryPolicyConfig(EraDuration, 0.2, 5000000000000000000L, 3000000000000000000L),
       // unused
       maxCodeSize = None,
-      chainId = 0x3d.toByte,
+      chainId = 0x3d,
       networkId = 1,
       forkBlockNumbers = ForkBlockNumbers(
         frontierBlockNumber = 0,

--- a/src/it/scala/io/iohk/ethereum/txExecTest/ForksTest.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/ForksTest.scala
@@ -35,7 +35,7 @@ class ForksTest extends AnyFlatSpec with Matchers {
         ecip1099BlockNumber = Long.MaxValue,
         ecip1049BlockNumber = None
       ),
-      chainId = 0x3d.toByte,
+      chainId = 0x3d,
       monetaryPolicyConfig = MonetaryPolicyConfig(5000000, 0.2, 5000000000000000000L, 3000000000000000000L),
       // unused
       bootstrapNodes = Set(),

--- a/src/main/resources/conf/testmode.conf
+++ b/src/main/resources/conf/testmode.conf
@@ -54,3 +54,5 @@ mantis {
   }
 
 }
+
+akka.http.server.request-timeout = 30.seconds

--- a/src/main/scala/io/iohk/ethereum/domain/SignedTransaction.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/SignedTransaction.scala
@@ -45,10 +45,10 @@ object SignedTransaction {
 
   def apply(
       tx: Transaction,
-      pointSign: Byte,
+      pointSign: BigInt,
       signatureRandom: ByteString,
       signature: ByteString,
-      chainId: Byte
+      chainId: BigInt
   ): SignedTransaction = {
     val txSignature = ECDSASignature(
       r = new BigInteger(1, signatureRandom.toArray),
@@ -58,7 +58,12 @@ object SignedTransaction {
     SignedTransaction(tx, txSignature)
   }
 
-  def apply(tx: Transaction, pointSign: Byte, signatureRandom: ByteString, signature: ByteString): SignedTransaction = {
+  def apply(
+      tx: Transaction,
+      pointSign: BigInt,
+      signatureRandom: ByteString,
+      signature: ByteString
+  ): SignedTransaction = {
     val txSignature = ECDSASignature(
       r = new BigInteger(1, signatureRandom.toArray),
       s = new BigInteger(1, signature.toArray),
@@ -67,14 +72,14 @@ object SignedTransaction {
     SignedTransaction(tx, txSignature)
   }
 
-  def sign(tx: Transaction, keyPair: AsymmetricCipherKeyPair, chainId: Option[Byte]): SignedTransactionWithSender = {
+  def sign(tx: Transaction, keyPair: AsymmetricCipherKeyPair, chainId: Option[BigInt]): SignedTransactionWithSender = {
     val bytes = bytesToSign(tx, chainId)
     val sig = ECDSASignature.sign(bytes, keyPair, chainId)
     val address = Address(keyPair)
     SignedTransactionWithSender(tx, sig, address)
   }
 
-  private def bytesToSign(tx: Transaction, chainId: Option[Byte]): Array[Byte] = {
+  private def bytesToSign(tx: Transaction, chainId: Option[BigInt]): Array[Byte] = {
     chainId match {
       case Some(id) =>
         chainSpecificTransactionBytes(tx, id)
@@ -128,7 +133,7 @@ object SignedTransaction {
     crypto.kec256(rlpEncode(RLPList(tx.nonce, tx.gasPrice, tx.gasLimit, receivingAddressAsArray, tx.value, tx.payload)))
   }
 
-  private def chainSpecificTransactionBytes(tx: Transaction, chainId: Byte): Array[Byte] = {
+  private def chainSpecificTransactionBytes(tx: Transaction, chainId: BigInt): Array[Byte] = {
     val receivingAddressAsArray: Array[Byte] = tx.receivingAddress.map(_.toArray).getOrElse(Array.emptyByteArray)
     crypto.kec256(
       rlpEncode(

--- a/src/main/scala/io/iohk/ethereum/extvm/VMServer.scala
+++ b/src/main/scala/io/iohk/ethereum/extvm/VMServer.scala
@@ -192,7 +192,7 @@ class VMServer(messageHandler: MessageHandler) extends Logger {
       aghartaBlockNumber = BigInt(9573000), //TODO include agharta block number in protobuf
       petersburgBlockNumber = BigInt(10000000), //TODO include petersburg block number in protobuf
       phoenixBlockNumber = BigInt(10500839), //TODO include phoenix block number in protobuf
-      chainId = 0x3d.toByte //TODO include chainId in protobuf
+      chainId = 0x3d //TODO include chainId in protobuf
     )
   }
 }

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/EthInfoService.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/EthInfoService.scala
@@ -26,7 +26,7 @@ import io.iohk.ethereum.utils.BlockchainConfig
 
 object EthInfoService {
   case class ChainIdRequest()
-  case class ChainIdResponse(value: Byte)
+  case class ChainIdResponse(value: BigInt)
 
   case class ProtocolVersionRequest()
   case class ProtocolVersionResponse(value: String)
@@ -174,7 +174,7 @@ class EthInfoService(
       val toAddress = req.tx.to.map(Address.apply)
 
       val tx = Transaction(0, req.tx.gasPrice, gasLimit, toAddress, req.tx.value, req.tx.data)
-      val fakeSignature = ECDSASignature(0, 0, 0.toByte)
+      val fakeSignature = ECDSASignature(0, 0, 0)
       SignedTransactionWithSender(tx, fakeSignature, fromAddress)
     }
   }

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/JsonMethodsImplicits.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/JsonMethodsImplicits.scala
@@ -220,7 +220,7 @@ object JsonMethodsImplicits extends JsonMethodsImplicits {
   implicit val personal_sign = new JsonMethodCodec[SignRequest, SignResponse] {
     override def encodeJson(t: SignResponse): JValue = {
       import t.signature._
-      encodeAsHex(ByteString(r.toUnsignedByteArray ++ s.toUnsignedByteArray :+ v))
+      encodeAsHex(ByteString(r.toUnsignedByteArray ++ s.toUnsignedByteArray ++ v.toUnsignedByteArray))
     }
 
     override def decodeJson(params: Option[JArray]): Either[JsonRpcError, SignRequest] =

--- a/src/main/scala/io/iohk/ethereum/keystore/Wallet.scala
+++ b/src/main/scala/io/iohk/ethereum/keystore/Wallet.scala
@@ -8,6 +8,6 @@ import org.bouncycastle.crypto.AsymmetricCipherKeyPair
 case class Wallet(address: Address, prvKey: ByteString) {
   lazy val keyPair: AsymmetricCipherKeyPair = keyPairFromPrvKey(prvKey.toArray)
 
-  def signTx(tx: Transaction, chainId: Option[Byte]): SignedTransactionWithSender =
+  def signTx(tx: Transaction, chainId: Option[BigInt]): SignedTransactionWithSender =
     SignedTransaction.sign(tx, keyPair, chainId)
 }

--- a/src/main/scala/io/iohk/ethereum/network/p2p/messages/CommonMessages.scala
+++ b/src/main/scala/io/iohk/ethereum/network/p2p/messages/CommonMessages.scala
@@ -135,7 +135,7 @@ object CommonMessages {
 
   object SignedTransactions {
 
-    lazy val chainId: Byte = Config.blockchains.blockchainConfig.chainId
+    lazy val chainId: BigInt = Config.blockchains.blockchainConfig.chainId
 
     implicit class SignedTransactionEnc(val signedTx: SignedTransaction) extends RLPSerializable {
       override def toRLPEncodable: RLPEncodeable = {
@@ -187,7 +187,7 @@ object CommonMessages {
           val receivingAddressOpt = if (receivingAddress.bytes.isEmpty) None else Some(Address(receivingAddress.bytes))
           SignedTransaction(
             Transaction(nonce, gasPrice, gasLimit, receivingAddressOpt, value, payload),
-            (pointSign: Int).toByte,
+            pointSign: BigInt,
             signatureRandom,
             signature,
             chainId

--- a/src/main/scala/io/iohk/ethereum/network/rlpx/AuthInitiateEcdsaCodec.scala
+++ b/src/main/scala/io/iohk/ethereum/network/rlpx/AuthInitiateEcdsaCodec.scala
@@ -26,6 +26,6 @@ trait AuthInitiateEcdsaCodec {
     val r = input.take(RLength)
     val s = input.slice(SIndex, SIndex + SLength)
     val v = input(VIndex) + 27
-    ECDSASignature(BigInt(1, r), BigInt(1, s), v.toByte)
+    ECDSASignature(BigInt(1, r), BigInt(1, s), v)
   }
 }

--- a/src/main/scala/io/iohk/ethereum/utils/BlockchainConfig.scala
+++ b/src/main/scala/io/iohk/ethereum/utils/BlockchainConfig.scala
@@ -21,7 +21,7 @@ case class BlockchainConfig(
     customGenesisJsonOpt: Option[String],
     daoForkConfig: Option[DaoForkConfig],
     accountStartNonce: UInt256,
-    chainId: Byte,
+    chainId: BigInt,
     networkId: Int,
     monetaryPolicyConfig: MonetaryPolicyConfig,
     gasTieBreaker: Boolean,
@@ -104,11 +104,9 @@ object BlockchainConfig {
     val daoForkConfig = Try(blockchainConfig.getConfig("dao")).toOption.map(DaoForkConfig(_))
     val accountStartNonce: UInt256 = UInt256(BigInt(blockchainConfig.getString("account-start-nonce")))
 
-    val chainId: Byte = {
+    val chainId: BigInt = {
       val s = blockchainConfig.getString("chain-id")
-      val n = parseHexOrDecNumber(s)
-      require(n >= 0 && n <= 127, "chain-id must be a number in range [0, 127]")
-      n.toByte
+      parseHexOrDecNumber(s)
     }
 
     val networkId: Int = blockchainConfig.getInt("network-id")

--- a/src/main/scala/io/iohk/ethereum/vm/BlockchainConfigForEvm.scala
+++ b/src/main/scala/io/iohk/ethereum/vm/BlockchainConfigForEvm.scala
@@ -34,7 +34,7 @@ case class BlockchainConfigForEvm(
     aghartaBlockNumber: BigInt,
     petersburgBlockNumber: BigInt,
     phoenixBlockNumber: BigInt,
-    chainId: Byte
+    chainId: BigInt
 ) {
   def etcForkForBlockNumber(blockNumber: BigInt): EtcFork = blockNumber match {
     case _ if blockNumber < atlantisBlockNumber => BeforeAtlantis

--- a/src/test/scala/io/iohk/ethereum/Fixtures.scala
+++ b/src/test/scala/io/iohk/ethereum/Fixtures.scala
@@ -56,11 +56,11 @@ object Fixtures {
               value = BigInt("1265230129703017984"),
               payload = ByteString.empty
             ),
-            pointSign = 0x9d.toByte,
+            pointSign = 0x9d,
             signatureRandom =
               ByteString(Hex.decode("5b496e526a65eac3c4312e683361bfdb873741acd3714c3bf1bcd7f01dd57ccb")),
             signature = ByteString(Hex.decode("3a30af5f529c7fc1d43cfed773275290475337c5e499f383afd012edcc8d7299")),
-            chainId = 0x3d.toByte
+            chainId = BigInt(0x3d)
           ),
           SignedTransaction(
             tx = Transaction(
@@ -71,11 +71,11 @@ object Fixtures {
               value = BigInt("656010196207162880"),
               payload = ByteString.empty
             ),
-            pointSign = 0x9d.toByte,
+            pointSign = 0x9d,
             signatureRandom =
               ByteString(Hex.decode("377e542cd9cd0a4414752a18d0862a5d6ced24ee6dba26b583cd85bc435b0ccf")),
             signature = ByteString(Hex.decode("579fee4fd96ecf9a92ec450be3c9a139a687aa3c72c7e43cfac8c1feaf65c4ac")),
-            chainId = 0x3d.toByte
+            chainId = BigInt(0x3d)
           ),
           SignedTransaction(
             tx = Transaction(
@@ -86,11 +86,11 @@ object Fixtures {
               value = BigInt("3725976610361427456"),
               payload = ByteString.empty
             ),
-            pointSign = 0x9d.toByte,
+            pointSign = 0x9d,
             signatureRandom =
               ByteString(Hex.decode("a70267341ba0b33f7e6f122080aa767d52ba4879776b793c35efec31dc70778d")),
             signature = ByteString(Hex.decode("3f66ed7f0197627cbedfe80fd8e525e8bc6c5519aae7955e7493591dcdf1d6d2")),
-            chainId = 0x3d.toByte
+            chainId = BigInt(0x3d)
           ),
           SignedTransaction(
             tx = Transaction(
@@ -101,11 +101,11 @@ object Fixtures {
               value = BigInt("108516826677274384"),
               payload = ByteString.empty
             ),
-            pointSign = 0x9d.toByte,
+            pointSign = 0x9d,
             signatureRandom =
               ByteString(Hex.decode("beb8226bdb90216ca29967871a6663b56bdd7b86cf3788796b52fd1ea3606698")),
             signature = ByteString(Hex.decode("2446994156bc1780cb5806e730b171b38307d5de5b9b0d9ad1f9de82e00316b5")),
-            chainId = 0x3d.toByte
+            chainId = BigInt(0x3d)
           )
         ),
         uncleNodesList = Seq[BlockHeader]()
@@ -178,11 +178,11 @@ object Fixtures {
               value = BigInt("10046680000000000000"),
               payload = ByteString.empty
             ),
-            pointSign = 0x1b.toByte,
+            pointSign = 0x1b,
             signatureRandom =
               ByteString(Hex.decode("8d94a55c7ac7adbfa2285ef7f4b0c955ae1a02647452cd4ead03ee6f449675c6")),
             signature = ByteString(Hex.decode("67149821b74208176d78fc4dffbe37c8b64eecfd47532406b9727c4ae8eb7c9a")),
-            chainId = 0x3d.toByte
+            chainId = 0x3d
           ),
           SignedTransaction(
             tx = Transaction(
@@ -193,11 +193,11 @@ object Fixtures {
               value = BigInt("20093780000000000000"),
               payload = ByteString.empty
             ),
-            pointSign = 0x1c.toByte,
+            pointSign = 0x1c,
             signatureRandom =
               ByteString(Hex.decode("6d31e3d59bfea97a34103d8ce767a8fe7a79b8e2f30af1e918df53f9e78e69ab")),
             signature = ByteString(Hex.decode("098e5b80e1cc436421aa54eb17e96b08fe80d28a2fbd46451b56f2bca7a321e7")),
-            chainId = 0x3d.toByte
+            chainId = 0x3d
           ),
           SignedTransaction(
             tx = Transaction(
@@ -208,11 +208,11 @@ object Fixtures {
               value = BigInt("1502561962583879700"),
               payload = ByteString.empty
             ),
-            pointSign = 0x1b.toByte,
+            pointSign = 0x1b,
             signatureRandom =
               ByteString(Hex.decode("fdbbc462a8a60ac3d8b13ee236b45af9b7991cf4f0f556d3af46aa5aeca242ab")),
             signature = ByteString(Hex.decode("5de5dc03fdcb6cf6d14609dbe6f5ba4300b8ff917c7d190325d9ea2144a7a2fb")),
-            chainId = 0x3d.toByte
+            chainId = 0x3d
           ),
           SignedTransaction(
             tx = Transaction(
@@ -223,11 +223,11 @@ object Fixtures {
               value = BigInt("1022338440000000000"),
               payload = ByteString.empty
             ),
-            pointSign = 0x1b.toByte,
+            pointSign = 0x1b,
             signatureRandom =
               ByteString(Hex.decode("bafb9f71cef873b9e0395b9ed89aac4f2a752e2a4b88ba3c9b6c1fea254eae73")),
             signature = ByteString(Hex.decode("1cef688f6718932f7705d9c1f0dd5a8aad9ddb196b826775f6e5703fdb997706")),
-            chainId = 0x3d.toByte
+            chainId = 0x3d
           )
         ),
         uncleNodesList = Seq[BlockHeader](
@@ -272,11 +272,11 @@ object Fixtures {
               value = BigInt("1502561962583879700"),
               payload = ByteString.empty
             ),
-            pointSign = 0x1b.toByte,
+            pointSign = 0x1b,
             signatureRandom =
               ByteString(Hex.decode("fdbbc462a8a60ac3d8b13ee236b45af9b7991cf4f0f556d3af46aa5aeca242ab")),
             signature = ByteString(Hex.decode("5de5dc03fdcb6cf6d14609dbe6f5ba4300b8ff917c7d190325d9ea2144a7a2fb")),
-            chainId = 0x01.toByte
+            chainId = 0x01
           ),
           SignedTransaction(
             tx = Transaction(
@@ -287,11 +287,11 @@ object Fixtures {
               value = BigInt("10046680000000000000"),
               payload = ByteString.empty
             ),
-            pointSign = 0x1b.toByte,
+            pointSign = 0x1b,
             signatureRandom =
               ByteString(Hex.decode("8d94a55c7ac7adbfa2285ef7f4b0c955ae1a02647452cd4ead03ee6f449675c6")),
             signature = ByteString(Hex.decode("67149821b74208176d78fc4dffbe37c8b64eecfd47532406b9727c4ae8eb7c9a")),
-            chainId = 0x01.toByte
+            chainId = 0x01
           ),
           SignedTransaction(
             tx = Transaction(
@@ -302,11 +302,11 @@ object Fixtures {
               value = BigInt("20093780000000000000"),
               payload = ByteString.empty
             ),
-            pointSign = 0x1c.toByte,
+            pointSign = 0x1c,
             signatureRandom =
               ByteString(Hex.decode("6d31e3d59bfea97a34103d8ce767a8fe7a79b8e2f30af1e918df53f9e78e69ab")),
             signature = ByteString(Hex.decode("098e5b80e1cc436421aa54eb17e96b08fe80d28a2fbd46451b56f2bca7a321e7")),
-            chainId = 0x01.toByte
+            chainId = 0x01
           ),
           SignedTransaction(
             tx = Transaction(
@@ -317,11 +317,11 @@ object Fixtures {
               value = BigInt("1022338440000000000"),
               payload = ByteString.empty
             ),
-            pointSign = 0x1b.toByte,
+            pointSign = 0x1b,
             signatureRandom =
               ByteString(Hex.decode("bafb9f71cef873b9e0395b9ed89aac4f2a752e2a4b88ba3c9b6c1fea254eae73")),
             signature = ByteString(Hex.decode("1cef688f6718932f7705d9c1f0dd5a8aad9ddb196b826775f6e5703fdb997706")),
-            chainId = 0x01.toByte
+            chainId = 0x01
           )
         ),
         uncleNodesList = Seq[BlockHeader]()

--- a/src/test/scala/io/iohk/ethereum/ObjectGenerators.scala
+++ b/src/test/scala/io/iohk/ethereum/ObjectGenerators.scala
@@ -132,7 +132,7 @@ trait ObjectGenerators {
     }
   }
 
-  def signedTxSeqGen(length: Int, secureRandom: SecureRandom, chainId: Option[Byte]): Gen[Seq[SignedTransaction]] = {
+  def signedTxSeqGen(length: Int, secureRandom: SecureRandom, chainId: Option[BigInt]): Gen[Seq[SignedTransaction]] = {
     val senderKeys = crypto.generateKeyPair(secureRandom)
     val txsSeqGen = Gen.listOfN(length, transactionGen())
     txsSeqGen.map { txs =>
@@ -148,14 +148,14 @@ trait ObjectGenerators {
     }
   }
 
-  def newBlockGen(secureRandom: SecureRandom, chainId: Option[Byte]): Gen[NewBlock] = for {
+  def newBlockGen(secureRandom: SecureRandom, chainId: Option[BigInt]): Gen[NewBlock] = for {
     blockHeader <- blockHeaderGen
     stxs <- signedTxSeqGen(10, secureRandom, chainId)
     uncles <- seqBlockHeaderGen
     td <- bigIntGen
   } yield NewBlock(Block(blockHeader, BlockBody(stxs, uncles)), td)
 
-  def newBlock64Gen(secureRandom: SecureRandom, chainId: Option[Byte]): Gen[PV64.NewBlock] = for {
+  def newBlock64Gen(secureRandom: SecureRandom, chainId: Option[BigInt]): Gen[PV64.NewBlock] = for {
     blockHeader <- blockHeaderGen
     stxs <- signedTxSeqGen(10, secureRandom, chainId)
     uncles <- seqBlockHeaderGen
@@ -221,7 +221,7 @@ trait ObjectGenerators {
     for {
       r <- bigIntGen
       s <- bigIntGen
-      v <- byteGen
+      v <- bigIntGen
     } yield ECDSASignature(r, s, v)
 
   def listOfNodes(min: Int, max: Int): Gen[Seq[MptNode]] = for {

--- a/src/test/scala/io/iohk/ethereum/consensus/blocks/BlockGeneratorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/blocks/BlockGeneratorSpec.scala
@@ -168,7 +168,7 @@ class BlockGeneratorSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
       .sign(
         transaction.copy(gasLimit = BigInt(2).pow(100000), nonce = signedTransaction.tx.tx.nonce + 1),
         keyPair,
-        Some(0x3d.toByte)
+        Some(0x3d)
       )
       .tx
 
@@ -206,7 +206,7 @@ class BlockGeneratorSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
       difficultyBombPauseBlockNumber = 3000000,
       difficultyBombContinueBlockNumber = 5000000,
       difficultyBombRemovalBlockNumber = 5900000,
-      chainId = 0x3d.toByte,
+      chainId = 0x3d,
       networkId = 1,
       customGenesisFileOpt = Some("test-genesis.json"),
       customGenesisJsonOpt = None,
@@ -247,7 +247,7 @@ class BlockGeneratorSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
 
     val generalTx = SignedTransaction.sign(transaction, keyPair, None).tx
     val specificTx =
-      SignedTransaction.sign(transaction.copy(nonce = transaction.nonce + 1), keyPair, Some(0x3d.toByte)).tx
+      SignedTransaction.sign(transaction.copy(nonce = transaction.nonce + 1), keyPair, Some(0x3d)).tx
 
     val pendingBlock =
       blockGenerator
@@ -302,7 +302,7 @@ class BlockGeneratorSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
       difficultyBombPauseBlockNumber = 3000000,
       difficultyBombContinueBlockNumber = 5000000,
       difficultyBombRemovalBlockNumber = 5900000,
-      chainId = 0x3d.toByte,
+      chainId = 0x3d,
       networkId = 1,
       customGenesisFileOpt = Some("test-genesis.json"),
       customGenesisJsonOpt = None,
@@ -377,7 +377,7 @@ class BlockGeneratorSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
 
   it should "include consecutive transactions from single sender" in new TestSetup {
     val nextTransaction =
-      SignedTransaction.sign(transaction.copy(nonce = signedTransaction.tx.tx.nonce + 1), keyPair, Some(0x3d.toByte)).tx
+      SignedTransaction.sign(transaction.copy(nonce = signedTransaction.tx.tx.nonce + 1), keyPair, Some(0x3d)).tx
 
     val pendingBlock =
       blockGenerator
@@ -414,7 +414,7 @@ class BlockGeneratorSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
 
   it should "filter out failing transaction from the middle of tx list" in new TestSetup {
     val nextTransaction =
-      SignedTransaction.sign(transaction.copy(nonce = signedTransaction.tx.tx.nonce + 1), keyPair, Some(0x3d.toByte)).tx
+      SignedTransaction.sign(transaction.copy(nonce = signedTransaction.tx.tx.nonce + 1), keyPair, Some(0x3d)).tx
 
     val privateKeyWithNoEthere =
       BigInt(1, Hex.decode("584a31be275195585603ddd05a53d16fae9deafba67213b6060cec9f16e44cae"))
@@ -428,7 +428,7 @@ class BlockGeneratorSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
       payload = ByteString.empty
     )
     val signedFailingTransaction =
-      SignedTransaction.sign(failingTransaction, keyPairFromPrvKey(privateKeyWithNoEthere), Some(0x3d.toByte)).tx
+      SignedTransaction.sign(failingTransaction, keyPairFromPrvKey(privateKeyWithNoEthere), Some(0x3d)).tx
 
     val pendingBlock =
       blockGenerator
@@ -464,7 +464,7 @@ class BlockGeneratorSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
 
   it should "include transaction with higher gas price if nonce is the same" in new TestSetup {
     val txWitSameNonceButLowerGasPrice = SignedTransaction
-      .sign(transaction.copy(gasPrice = signedTransaction.tx.tx.gasPrice - 1), keyPair, Some(0x3d.toByte))
+      .sign(transaction.copy(gasPrice = signedTransaction.tx.tx.gasPrice - 1), keyPair, Some(0x3d))
       .tx
 
     val pendingBlock =
@@ -646,9 +646,9 @@ class BlockGeneratorSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
     val treasuryAccount = Address(0xeeeeee)
     val maliciousAccount = Address(0x123)
 
-    lazy val signedTransaction = SignedTransaction.sign(transaction, keyPair, Some(0x3d.toByte))
+    lazy val signedTransaction = SignedTransaction.sign(transaction, keyPair, Some(0x3d))
     lazy val duplicatedSignedTransaction =
-      SignedTransaction.sign(transaction.copy(gasLimit = 2), keyPair, Some(0x3d.toByte))
+      SignedTransaction.sign(transaction.copy(gasLimit = 2), keyPair, Some(0x3d))
 
     val baseBlockchainConfig = BlockchainConfig(
       forkBlockNumbers = ForkBlockNumbers(
@@ -674,7 +674,7 @@ class BlockGeneratorSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
       difficultyBombPauseBlockNumber = 3000000,
       difficultyBombContinueBlockNumber = 5000000,
       difficultyBombRemovalBlockNumber = 5900000,
-      chainId = 0x3d.toByte,
+      chainId = 0x3d,
       networkId = 1,
       customGenesisFileOpt = Some("test-genesis.json"),
       customGenesisJsonOpt = None,

--- a/src/test/scala/io/iohk/ethereum/consensus/pow/MinerSpecSetup.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/pow/MinerSpecSetup.scala
@@ -53,10 +53,10 @@ trait MinerSpecSetup extends ConsensusConfigBuilder with MockFactory {
       value = BigInt("108516826677274384"),
       payload = ByteString.empty
     ),
-    pointSign = 0x9d.toByte,
+    pointSign = 0x9d,
     signatureRandom = ByteString(Hex.decode("beb8226bdb90216ca29967871a6663b56bdd7b86cf3788796b52fd1ea3606698")),
     signature = ByteString(Hex.decode("2446994156bc1780cb5806e730b171b38307d5de5b9b0d9ad1f9de82e00316b5")),
-    chainId = 0x3d.toByte
+    chainId = 0x3d
   )
 
   lazy val consensus: PoWConsensus = buildPoWConsensus().withBlockGenerator(blockGenerator)

--- a/src/test/scala/io/iohk/ethereum/consensus/pow/validators/EthashBlockHeaderValidatorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/pow/validators/EthashBlockHeaderValidatorSpec.scala
@@ -411,7 +411,7 @@ class EthashBlockHeaderValidatorSpec
       }),
       // unused
       maxCodeSize = None,
-      chainId = 0x3d.toByte,
+      chainId = 0x3d,
       networkId = 1,
       monetaryPolicyConfig = null,
       customGenesisFileOpt = None,

--- a/src/test/scala/io/iohk/ethereum/consensus/pow/validators/RestrictedEthashBlockHeaderValidatorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/pow/validators/RestrictedEthashBlockHeaderValidatorSpec.scala
@@ -94,7 +94,7 @@ class RestrictedEthashBlockHeaderValidatorSpec
         daoForkConfig = None,
         // unused
         maxCodeSize = None,
-        chainId = 0x3d.toByte,
+        chainId = 0x3d,
         networkId = 1,
         monetaryPolicyConfig = null,
         customGenesisFileOpt = None,

--- a/src/test/scala/io/iohk/ethereum/consensus/validators/std/StdBlockValidatorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/validators/std/StdBlockValidatorSpec.scala
@@ -111,10 +111,10 @@ class StdBlockValidatorSpec extends AnyFlatSpec with Matchers with SecureRandomB
           value = BigInt("1265230129703017984"),
           payload = ByteString.empty
         ),
-        pointSign = 0x9d.toByte,
+        pointSign = 0x9d,
         signatureRandom = ByteString(Hex.decode("5b496e526a65eac3c4312e683361bfdb873741acd3714c3bf1bcd7f01dd57ccb")),
         signature = ByteString(Hex.decode("3a30af5f529c7fc1d43cfed773275290475337c5e499f383afd012edcc8d7299")),
-        chainId = 0x3d.toByte
+        chainId = 0x3d
       ),
       SignedTransaction(
         tx = Transaction(
@@ -125,10 +125,10 @@ class StdBlockValidatorSpec extends AnyFlatSpec with Matchers with SecureRandomB
           value = BigInt("656010196207162880"),
           payload = ByteString.empty
         ),
-        pointSign = 0x9d.toByte,
+        pointSign = 0x9d,
         signatureRandom = ByteString(Hex.decode("377e542cd9cd0a4414752a18d0862a5d6ced24ee6dba26b583cd85bc435b0ccf")),
         signature = ByteString(Hex.decode("579fee4fd96ecf9a92ec450be3c9a139a687aa3c72c7e43cfac8c1feaf65c4ac")),
-        chainId = 0x3d.toByte
+        chainId = 0x3d
       ),
       SignedTransaction(
         tx = Transaction(
@@ -139,10 +139,10 @@ class StdBlockValidatorSpec extends AnyFlatSpec with Matchers with SecureRandomB
           value = BigInt("3725976610361427456"),
           payload = ByteString.empty
         ),
-        pointSign = 0x9d.toByte,
+        pointSign = 0x9d,
         signatureRandom = ByteString(Hex.decode("a70267341ba0b33f7e6f122080aa767d52ba4879776b793c35efec31dc70778d")),
         signature = ByteString(Hex.decode("3f66ed7f0197627cbedfe80fd8e525e8bc6c5519aae7955e7493591dcdf1d6d2")),
-        chainId = 0x3d.toByte
+        chainId = 0x3d
       ),
       SignedTransaction(
         tx = Transaction(
@@ -153,10 +153,10 @@ class StdBlockValidatorSpec extends AnyFlatSpec with Matchers with SecureRandomB
           value = BigInt("108516826677274384"),
           payload = ByteString.empty
         ),
-        pointSign = 0x9d.toByte,
+        pointSign = 0x9d,
         signatureRandom = ByteString(Hex.decode("beb8226bdb90216ca29967871a6663b56bdd7b86cf3788796b52fd1ea3606698")),
         signature = ByteString(Hex.decode("2446994156bc1780cb5806e730b171b38307d5de5b9b0d9ad1f9de82e00316b5")),
-        chainId = 0x3d.toByte
+        chainId = 0x3d
       )
     ),
     uncleNodesList = Seq[BlockHeader]()

--- a/src/test/scala/io/iohk/ethereum/consensus/validators/std/StdSignedTransactionValidatorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/validators/std/StdSignedTransactionValidatorSpec.scala
@@ -32,10 +32,10 @@ class StdSignedTransactionValidatorSpec extends AnyFlatSpec with Matchers {
   )
   val signedTxBeforeHomestead = SignedTransaction(
     txBeforeHomestead,
-    pointSign = 0x1b.toByte,
+    pointSign = 0x1b,
     signatureRandom = ByteString(Hex.decode("12bfc6e767e518c50f59006556ecc9911593094cfb6f6ef78c9959e3327137a3")),
     signature = ByteString(Hex.decode("13696dc6b5b601d19960a4f764416d36b271fc292bb87e2c36aea25d52f49064")),
-    chainId = 0x3d.toByte
+    chainId = 0x3d
   )
 
   //From block 0xdc7874d8ea90b63aa0ba122055e514db8bb75c0e7d51a448abd12a31ca3370cf with number 1200003 (tx index 0)
@@ -49,10 +49,10 @@ class StdSignedTransactionValidatorSpec extends AnyFlatSpec with Matchers {
   )
   val signedTxAfterHomestead = SignedTransaction(
     txAfterHomestead,
-    pointSign = 0x1c.toByte,
+    pointSign = 0x1c,
     signatureRandom = ByteString(Hex.decode("f337e8ca3306c131eabb756aa3701ec7b00bef0d6cc21fbf6a6f291463d58baf")),
     signature = ByteString(Hex.decode("72216654137b4b58a4ece0a6df87aa1a4faf18ec4091839dd1c722fa9604fd09")),
-    chainId = 0x3d.toByte
+    chainId = 0x3d
   )
 
   val senderBalance = 100
@@ -228,7 +228,7 @@ class StdSignedTransactionValidatorSpec extends AnyFlatSpec with Matchers {
 
   it should "report as invalid a chain specific tx before eip155" in {
     val keyPair = crypto.generateKeyPair(new SecureRandom)
-    val stx = SignedTransaction.sign(txBeforeHomestead, keyPair, Some(0x03.toByte))
+    val stx = SignedTransaction.sign(txBeforeHomestead, keyPair, Some(0x03))
     signedTransactionValidator.validate(
       stx.tx,
       senderAccount = senderAccountAfterHomestead,
@@ -243,7 +243,7 @@ class StdSignedTransactionValidatorSpec extends AnyFlatSpec with Matchers {
 
   it should "report as valid a chain specific tx after eip155" in {
     val keyPair = crypto.generateKeyPair(new SecureRandom)
-    val stx = SignedTransaction.sign(txAfterHomestead, keyPair, Some(0x03.toByte))
+    val stx = SignedTransaction.sign(txAfterHomestead, keyPair, Some(0x03))
     signedTransactionValidator.validate(
       stx.tx,
       senderAccount = senderAccountAfterHomestead,

--- a/src/test/scala/io/iohk/ethereum/db/storage/BlockBodiesStorageSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/db/storage/BlockBodiesStorageSpec.scala
@@ -16,7 +16,7 @@ class BlockBodiesStorageSpec
     with ObjectGenerators
     with SecureRandomBuilder {
 
-  val chainId: Option[Byte] = Hex.decode("3d").headOption
+  val chainId: Option[BigInt] = Some(1)
 
   "BlockBodiesStorage" should {
 

--- a/src/test/scala/io/iohk/ethereum/domain/SignedTransactionSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/domain/SignedTransactionSpec.scala
@@ -15,8 +15,8 @@ class SignedTransactionSpec extends AnyFlatSpec with Matchers with ScalaCheckPro
   "SignedTransaction" should "correctly set pointSign for chainId with chain specific signing schema" in {
     forAll(Generators.transactionGen(), Arbitrary.arbitrary[Unit].map(_ => generateKeyPair(secureRandom))) {
       (tx, key) =>
-        val chainId: Byte = 0x3d
-        val allowedPointSigns = Set((chainId * 2 + 35).toByte, (chainId * 2 + 36).toByte)
+        val chainId: BigInt = 0x3d
+        val allowedPointSigns = Set(chainId * 2 + 35, chainId * 2 + 36)
         //byte 0 of encoded ECC point indicates that it is uncompressed point, it is part of bouncycastle encoding
         val address = Address(
           crypto

--- a/src/test/scala/io/iohk/ethereum/extvm/VMClientSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/extvm/VMClientSpec.scala
@@ -187,7 +187,7 @@ class VMClientSpec extends AnyFlatSpec with Matchers with MockFactory {
       aghartaBlockNumber = 0,
       petersburgBlockNumber = 0,
       phoenixBlockNumber = 0,
-      chainId = 0x3d.toByte
+      chainId = 0x3d
     )
     val evmConfig = EvmConfig.FrontierConfigBuilder(blockchainConfigForEvm)
 

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/EthTxServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/EthTxServiceSpec.scala
@@ -345,7 +345,7 @@ class EthTxServiceSpec
             value = 0,
             payload = ByteString()
           ),
-          signature = ECDSASignature(0, 0, 0.toByte),
+          signature = ECDSASignature(0, 0, 0),
           sender = Address("0x1234")
         )
         PendingTransaction(fakeTransaction, System.currentTimeMillis)
@@ -422,7 +422,7 @@ class EthTxServiceSpec
       v,
       r,
       s,
-      0x3d.toByte
+      0x3d
     )
 
     val contractCreatingTransactionSender = SignedTransaction.getSender(contractCreatingTransaction).get

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/FilterManagerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/FilterManagerSpec.scala
@@ -81,7 +81,7 @@ class FilterManagerSpec
             value = 0,
             payload = ByteString()
           ),
-          signature = ECDSASignature(0, 0, 0.toByte)
+          signature = ECDSASignature(0, 0, 0)
         )
       ),
       uncleNodesList = Nil
@@ -159,7 +159,7 @@ class FilterManagerSpec
             value = 0,
             payload = ByteString()
           ),
-          signature = ECDSASignature(0, 0, 0.toByte)
+          signature = ECDSASignature(0, 0, 0)
         ),
         SignedTransaction(
           tx = Transaction(
@@ -170,7 +170,7 @@ class FilterManagerSpec
             value = 0,
             payload = ByteString()
           ),
-          signature = ECDSASignature(0, 0, 0.toByte)
+          signature = ECDSASignature(0, 0, 0)
         )
       ),
       uncleNodesList = Nil
@@ -245,7 +245,7 @@ class FilterManagerSpec
             value = 0,
             payload = ByteString()
           ),
-          signature = ECDSASignature(0, 0, 0.toByte)
+          signature = ECDSASignature(0, 0, 0)
         )
       ),
       uncleNodesList = Nil
@@ -285,7 +285,7 @@ class FilterManagerSpec
           value = 0,
           payload = ByteString()
         ),
-        signature = ECDSASignature(0, 0, 0.toByte)
+        signature = ECDSASignature(0, 0, 0)
       )
     )
     val block2 = Block(bh2, BlockBody(blockTransactions2, Nil))

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerEthTransactionSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerEthTransactionSpec.scala
@@ -575,7 +575,7 @@ class JsonRpcControllerEthTransactionSpec
           value = 0,
           payload = ByteString()
         ),
-        signature = ECDSASignature(0, 0, 0.toByte),
+        signature = ECDSASignature(0, 0, 0),
         sender = Address("0x1234")
       )
       PendingTransaction(fakeTransaction, System.currentTimeMillis)

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/MantisServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/MantisServiceSpec.scala
@@ -52,7 +52,7 @@ class MantisServiceSpec
             value = 0,
             payload = ByteString()
           ),
-          signature = ECDSASignature(0, 0, 0.toByte),
+          signature = ECDSASignature(0, 0, 0),
           sender = Address("0x1234")
         )
 

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/PersonalServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/PersonalServiceSpec.scala
@@ -396,7 +396,7 @@ class PersonalServiceSpec
     val txValue = 128000
 
     val blockchainConfig = BlockchainConfig(
-      chainId = 0x03.toByte,
+      chainId = 0x03,
       //unused
       networkId = 1,
       maxCodeSize = None,

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/QAServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/QAServiceSpec.scala
@@ -119,7 +119,6 @@ class QAServiceSpec
     lazy val mineBlocksReq = MineBlocksRequest(1, true, None)
     lazy val mineBlocksMsg =
       MineBlocks(mineBlocksReq.numBlocks, mineBlocksReq.withTransactions, mineBlocksReq.parentBlock)
-    val fakeChainId: Byte = 42.toByte
   }
 
   trait CheckpointsGenerationFixture {

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/QaJRCSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/QaJRCSpec.scala
@@ -340,7 +340,5 @@ class QaJRCSpec
         .expects(mineBlocksReq)
         .returning(Task.now(Right(MineBlocksResponse(resp))))
     }
-
-    val fakeChainId: Byte = 42.toByte
   }
 }

--- a/src/test/scala/io/iohk/ethereum/ledger/BlockExecutionSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/BlockExecutionSpec.scala
@@ -22,7 +22,7 @@ class BlockExecutionSpec extends AnyWordSpec with Matchers with ScalaCheckProper
     "correctly run executeBlocks" when {
 
       "two blocks with txs (that first one has invalid tx)" in new BlockchainSetup {
-        val invalidStx = SignedTransaction(validTx, ECDSASignature(1, 2, 3.toByte))
+        val invalidStx = SignedTransaction(validTx, ECDSASignature(1, 2, 3))
         val block1BodyWithTxs: BlockBody = validBlockBodyWithNoTxs.copy(transactionList = Seq(invalidStx))
         val block1 = Block(validBlockHeader, block1BodyWithTxs)
         val block2BodyWithTxs: BlockBody =
@@ -57,7 +57,7 @@ class BlockExecutionSpec extends AnyWordSpec with Matchers with ScalaCheckProper
       }
 
       "two blocks with txs (that last one has invalid tx)" in new BlockchainSetup {
-        val invalidStx = SignedTransaction(validTx, ECDSASignature(1, 2, 3.toByte))
+        val invalidStx = SignedTransaction(validTx, ECDSASignature(1, 2, 3))
         val block1BodyWithTxs: BlockBody =
           validBlockBodyWithNoTxs.copy(transactionList = Seq(validStxSignedByOrigin.tx))
         val block1 = Block(validBlockHeader, block1BodyWithTxs)
@@ -280,7 +280,7 @@ class BlockExecutionSpec extends AnyWordSpec with Matchers with ScalaCheckProper
       }
 
       "last one wasn't executed correctly" in new BlockExecutionTestSetup {
-        val invalidStx = SignedTransaction(validTx, ECDSASignature(1, 2, 3.toByte))
+        val invalidStx = SignedTransaction(validTx, ECDSASignature(1, 2, 3))
         val blockBodyWithTxs: BlockBody =
           validBlockBodyWithNoTxs.copy(transactionList = Seq(validStxSignedByOrigin.tx, invalidStx))
         val block = Block(validBlockHeader, blockBodyWithTxs)
@@ -292,7 +292,7 @@ class BlockExecutionSpec extends AnyWordSpec with Matchers with ScalaCheckProper
       }
 
       "first one wasn't executed correctly" in new BlockExecutionTestSetup {
-        val invalidStx = SignedTransaction(validTx, ECDSASignature(1, 2, 3.toByte))
+        val invalidStx = SignedTransaction(validTx, ECDSASignature(1, 2, 3))
         val blockBodyWithTxs: BlockBody =
           validBlockBodyWithNoTxs.copy(transactionList = Seq(invalidStx, validStxSignedByOrigin.tx))
         val block = Block(validBlockHeader, blockBodyWithTxs)

--- a/src/test/scala/io/iohk/ethereum/ledger/BlockValidationSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/BlockValidationSpec.scala
@@ -63,10 +63,10 @@ class BlockValidationSpec extends AnyWordSpec with Matchers with MockFactory {
 
     def mkStx(tx: Transaction, random: String, signature: String): SignedTransaction = SignedTransaction(
       tx = tx,
-      pointSign = 0x9d.toByte,
+      pointSign = 0x9d,
       signatureRandom = hash2ByteString(random),
       signature = hash2ByteString(signature),
-      chainId = 0x3d.toByte
+      chainId = 0x3d
     )
 
     val bloomFilter: ByteString = hash2ByteString("0" * 512)

--- a/src/test/scala/io/iohk/ethereum/ledger/LedgerTestSetup.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/LedgerTestSetup.scala
@@ -217,7 +217,7 @@ trait DaoForkTestSetup extends TestSetup with MockFactory {
       )
     )
     .copy(
-      chainId = 0x01.toByte,
+      chainId = 0x01,
       networkId = 1,
       daoForkConfig = Some(supportDaoForkConfig),
       customGenesisFileOpt = None,

--- a/src/test/scala/io/iohk/ethereum/ledger/StxLedgerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/StxLedgerSpec.scala
@@ -27,7 +27,7 @@ class StxLedgerSpec extends AnyFlatSpec with Matchers with Logger {
       */
 
     val tx = Transaction(0, 0, lastBlockGasLimit, existingAddress, 0, sendData)
-    val fakeSignature = ECDSASignature(0, 0, 0.toByte)
+    val fakeSignature = ECDSASignature(0, 0, 0)
     val stx = SignedTransaction(tx, fakeSignature)
     val stxFromAddress = SignedTransactionWithSender(stx, fromAddress)
 
@@ -60,7 +60,7 @@ class StxLedgerSpec extends AnyFlatSpec with Matchers with Logger {
     val transferValue = 2
 
     val tx = Transaction(0, 0, lastBlockGasLimit, existingEmptyAccountAddres, transferValue, ByteString.empty)
-    val fakeSignature = ECDSASignature(0, 0, 0.toByte)
+    val fakeSignature = ECDSASignature(0, 0, 0)
     val stx = SignedTransaction(tx, fakeSignature)
 
     val executionResult: Ledger.TxResult =
@@ -75,7 +75,7 @@ class StxLedgerSpec extends AnyFlatSpec with Matchers with Logger {
     val transferValue = 2
 
     val tx = Transaction(0, 0, lastBlockGasLimit, existingEmptyAccountAddres, transferValue, ByteString.empty)
-    val fakeSignature = ECDSASignature(0, 0, 0.toByte)
+    val fakeSignature = ECDSASignature(0, 0, 0)
     val stxFromAddress = SignedTransactionWithSender(SignedTransaction(tx, fakeSignature), fromAddress)
 
     val newBlock: Block = genesisBlock.copy(header = block.header.copy(number = 1, parentHash = genesisHash))
@@ -126,7 +126,7 @@ trait ScenarioSetup extends EphemBlockchainTestSetup {
       ecip1099BlockNumber = Long.MaxValue,
       ecip1049BlockNumber = None
     ),
-    chainId = 0x03.toByte,
+    chainId = 0x03,
     networkId = 1,
     maxCodeSize = None,
     difficultyBombPauseBlockNumber = 0,

--- a/src/test/scala/io/iohk/ethereum/network/AuthInitiateMessageSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/network/AuthInitiateMessageSpec.scala
@@ -22,7 +22,7 @@ class AuthInitiateMessageSpec extends AnyFlatSpec with Matchers with SecureRando
 
     val nonce = ByteUtils.randomBytes(AuthHandshaker.NonceSize)
 
-    val signature = ECDSASignature(BigInt("123"), BigInt("456"), 0.toByte)
+    val signature = ECDSASignature(BigInt("123"), BigInt("456"), 0)
 
     val msg = AuthInitiateMessage(
       signature,
@@ -43,7 +43,7 @@ class AuthInitiateMessageSpec extends AnyFlatSpec with Matchers with SecureRando
       signature = ECDSASignature(
         r = BigInt("81870901931874412952660009205824222047471672340278145383000560930072854380569"),
         s = BigInt("27900842753040147848386185004093503271309114686926362065982995477587410195214"),
-        v = 27.toByte
+        v = 27
       ),
       ephemeralPublicHash = ByteString(Hex.decode("F30BAC135324F493AEEAF4C9B48DF0F1F9A28A3DEDF9B1D85AF45A27F7B6F054")),
       publicKey = curve.getCurve.decodePoint(

--- a/src/test/scala/io/iohk/ethereum/network/p2p/messages/NewBlockSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/network/p2p/messages/NewBlockSpec.scala
@@ -12,10 +12,17 @@ import org.scalatest.funsuite.AnyFunSuite
 
 class NewBlockSpec extends AnyFunSuite with ScalaCheckPropertyChecks with ObjectGenerators with SecureRandomBuilder {
 
-  val chainId = Hex.decode("3d").head
+  val chainId_1 = 1
+  val chainId_212 = 212
 
   test("NewBlock v63 messages are encoded and decoded properly") {
-    forAll(newBlockGen(secureRandom, Some(chainId))) { newBlock =>
+    forAll(newBlockGen(secureRandom, Some(chainId_1))) { newBlock =>
+      val encoded: Array[Byte] = newBlock.toBytes
+      val decoded: NewBlock = encoded.toNewBlock
+      assert(decoded == newBlock)
+    }
+
+    forAll(newBlockGen(secureRandom, Some(chainId_212))) { newBlock =>
       val encoded: Array[Byte] = newBlock.toBytes
       val decoded: NewBlock = encoded.toNewBlock
       assert(decoded == newBlock)
@@ -24,7 +31,14 @@ class NewBlockSpec extends AnyFunSuite with ScalaCheckPropertyChecks with Object
 
   test("NewBlock v64 messages are encoded and decoded properly") {
     import io.iohk.ethereum.network.p2p.messages.PV64.NewBlock._
-    forAll(newBlock64Gen(secureRandom, Some(chainId))) { newBlock =>
+
+    forAll(newBlock64Gen(secureRandom, Some(chainId_1))) { newBlock =>
+      val encoded: Array[Byte] = newBlock.toBytes
+      val decoded: PV64.NewBlock = encoded.toNewBlock
+      assert(decoded == newBlock)
+    }
+
+    forAll(newBlock64Gen(secureRandom, Some(chainId_212))) { newBlock =>
       val encoded: Array[Byte] = newBlock.toBytes
       val decoded: PV64.NewBlock = encoded.toNewBlock
       assert(decoded == newBlock)

--- a/src/test/scala/io/iohk/ethereum/network/p2p/messages/NewBlockSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/network/p2p/messages/NewBlockSpec.scala
@@ -12,17 +12,17 @@ import org.scalatest.funsuite.AnyFunSuite
 
 class NewBlockSpec extends AnyFunSuite with ScalaCheckPropertyChecks with ObjectGenerators with SecureRandomBuilder {
 
-  val chainId_1 = 1
-  val chainId_212 = 212
+  val chainId1 = 1
+  val chainId212 = 212
 
   test("NewBlock v63 messages are encoded and decoded properly") {
-    forAll(newBlockGen(secureRandom, Some(chainId_1))) { newBlock =>
+    forAll(newBlockGen(secureRandom, Some(chainId1))) { newBlock =>
       val encoded: Array[Byte] = newBlock.toBytes
       val decoded: NewBlock = encoded.toNewBlock
       assert(decoded == newBlock)
     }
 
-    forAll(newBlockGen(secureRandom, Some(chainId_212))) { newBlock =>
+    forAll(newBlockGen(secureRandom, Some(chainId212))) { newBlock =>
       val encoded: Array[Byte] = newBlock.toBytes
       val decoded: NewBlock = encoded.toNewBlock
       assert(decoded == newBlock)
@@ -32,13 +32,13 @@ class NewBlockSpec extends AnyFunSuite with ScalaCheckPropertyChecks with Object
   test("NewBlock v64 messages are encoded and decoded properly") {
     import io.iohk.ethereum.network.p2p.messages.PV64.NewBlock._
 
-    forAll(newBlock64Gen(secureRandom, Some(chainId_1))) { newBlock =>
+    forAll(newBlock64Gen(secureRandom, Some(chainId1))) { newBlock =>
       val encoded: Array[Byte] = newBlock.toBytes
       val decoded: PV64.NewBlock = encoded.toNewBlock
       assert(decoded == newBlock)
     }
 
-    forAll(newBlock64Gen(secureRandom, Some(chainId_212))) { newBlock =>
+    forAll(newBlock64Gen(secureRandom, Some(chainId212))) { newBlock =>
       val encoded: Array[Byte] = newBlock.toBytes
       val decoded: PV64.NewBlock = encoded.toNewBlock
       assert(decoded == newBlock)

--- a/src/test/scala/io/iohk/ethereum/network/p2p/messages/TransactionSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/network/p2p/messages/TransactionSpec.scala
@@ -31,7 +31,7 @@ class TransactionSpec extends AnyFlatSpec with Matchers {
 
   val validTransactionSignatureOldSchema = SignedTransaction(
     validTx,
-    pointSign = 28.toByte,
+    pointSign = 28,
     signatureRandom = ByteString(Hex.decode("cfe3ad31d6612f8d787c45f115cc5b43fb22bcc210b62ae71dc7cbf0a6bea8df")),
     signature = ByteString(Hex.decode("57db8998114fae3c337e99dbd8573d4085691880f4576c6c1f6c5bbfe67d6cf0")),
     chainId = blockchainConfig.chainId
@@ -39,7 +39,7 @@ class TransactionSpec extends AnyFlatSpec with Matchers {
 
   val invalidTransactionSignatureNewSchema = SignedTransaction(
     validTx,
-    pointSign = (-98).toByte,
+    pointSign = -98,
     signatureRandom = ByteString(Hex.decode("cfe3ad31d6612f8d787c45f115cc5b43fb22bcc210b62ae71dc7cbf0a6bea8df")),
     signature = ByteString(Hex.decode("57db8998114fae3c337e99dbd8573d4085691880f4576c6c1f6c5bbfe67d6cf0")),
     chainId = blockchainConfig.chainId
@@ -47,7 +47,7 @@ class TransactionSpec extends AnyFlatSpec with Matchers {
 
   val invalidStx = SignedTransaction(
     validTx.copy(gasPrice = 0),
-    pointSign = (-98).toByte,
+    pointSign = -98,
     signatureRandom = ByteString(Hex.decode("cfe3ad31d6612f8d787c45f115cc5b43fb22bcc210b62ae71dc7cbf0a6bea8df")),
     signature = ByteString(Hex.decode("57db8998114fae3c337e99dbd8573d4085691880f4576c6c1f6c5bbfe67d6cf0")),
     chainId = blockchainConfig.chainId
@@ -71,7 +71,7 @@ class TransactionSpec extends AnyFlatSpec with Matchers {
 
   val validSignedTransactionForNewSigningScheme = SignedTransaction(
     tx = validTransactionForNewSigningScheme,
-    pointSign = (-98).toByte,
+    pointSign = -98,
     signatureRandom = ByteString(Hex.decode("1af423b3608f3b4b35e191c26f07175331de22ed8f60d1735f03210388246ade")),
     signature = ByteString(Hex.decode("4d5b6b9e3955a0db8feec9c518d8e1aae0e1d91a143fbbca36671c3b89b89bc3")),
     blockchainConfig.chainId
@@ -79,7 +79,7 @@ class TransactionSpec extends AnyFlatSpec with Matchers {
 
   val stxWithInvalidPointSign = SignedTransaction(
     validTx,
-    pointSign = 26.toByte,
+    pointSign = 26,
     signatureRandom = ByteString(Hex.decode("cfe3ad31d6612f8d787c45f115cc5b43fb22bcc210b62ae71dc7cbf0a6bea8df")),
     signature = ByteString(Hex.decode("57db8998114fae3c337e99dbd8573d4085691880f4576c6c1f6c5bbfe67d6cf0")),
     blockchainConfig.chainId
@@ -115,7 +115,7 @@ class TransactionSpec extends AnyFlatSpec with Matchers {
         value = BigInt(31337),
         payload = ByteString.empty
       ),
-      pointSign = 28.toByte,
+      pointSign = 28,
       signatureRandom =
         ByteString(BigInt("61965845294689009770156372156374760022787886965323743865986648153755601564112").toByteArray),
       signature =

--- a/src/test/scala/io/iohk/ethereum/vm/Fixtures.scala
+++ b/src/test/scala/io/iohk/ethereum/vm/Fixtures.scala
@@ -23,7 +23,7 @@ object Fixtures {
     aghartaBlockNumber = 0,
     petersburgBlockNumber = PetersburgBlockNumber,
     phoenixBlockNumber = PhoenixBlockNumber,
-    chainId = 0x3d.toByte
+    chainId = 0x3d
   )
 
 }

--- a/src/test/scala/io/iohk/ethereum/vm/VMSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/vm/VMSpec.scala
@@ -160,7 +160,7 @@ class VMSpec extends AnyWordSpec with ScalaCheckPropertyChecks with Matchers {
       aghartaBlockNumber = Long.MaxValue,
       petersburgBlockNumber = Long.MaxValue,
       phoenixBlockNumber = Long.MaxValue,
-      chainId = 0x3d.toByte
+      chainId = 0x3d
     )
 
     val homesteadConfig = EvmConfig.forBlock(0, evmBlockchainConfig.copy(homesteadBlockNumber = 0))

--- a/src/test/scala/io/iohk/ethereum/vm/utils/MockVmInput.scala
+++ b/src/test/scala/io/iohk/ethereum/vm/utils/MockVmInput.scala
@@ -9,7 +9,6 @@ object MockVmInput {
 
   class MockTransaction(
       tx: Transaction,
-      senderAddress: Address,
       pointSign: Byte = 0,
       signatureRandom: BigInt = 0,
       signature: BigInt = 0
@@ -29,7 +28,7 @@ object MockVmInput {
       receivingAddress: Option[Address] = None,
       nonce: BigInt = 0
   ): SignedTransaction =
-    new MockTransaction(Transaction(nonce, gasPrice, gasLimit, receivingAddress, value, payload), senderAddress)
+    new MockTransaction(Transaction(nonce, gasPrice, gasLimit, receivingAddress, value, payload))
 
   def blockHeader: BlockHeader = BlockFixtures.ValidBlock.header
 


### PR DESCRIPTION
# Description

Currently Mantis only supports networks id a chaind id up to 127.
This brought problems syncing with Astor, that has a chainid of 212 


# Proposed Solution

Blockchain config, chainid field from Byte to BigInt
ECDSASignature, v field from Byte to BigInt

# Testing
Synchronization with ETC, Sagano and Astor were successfull
On a private network (network id = 2 / chain id = 61) a new tx was created, included in a block and successfully propagated

