### PR TITLE
[kaizen] remove automatic retry for some steps and add dist zip as artifact

### DIFF
--- a/.buildkite/pipeline.nix
+++ b/.buildkite/pipeline.nix
@@ -25,6 +25,7 @@ in
       command = ''
         nix-shell --run '$SBT scalafmtCheck'
       '';
+      retry.automatic = false;
     };
 
     compile = commonAttrs // {
@@ -33,6 +34,7 @@ in
       command = ''
         nix-shell --run '$SBT compile-all'
       '';
+      retry.automatic = false;
     };
 
     style = commonAttrs // {
@@ -41,6 +43,7 @@ in
       command = ''
         nix-shell --run '$SBT scalastyle test:scalastyle'
       '';
+      retry.automatic = false;
     };
 
     test-bytes = commonAttrs // {
@@ -160,6 +163,9 @@ in
       command = ''
         nix-shell --run '$SBT benchmark:compile dist'
       '';
+      artifactPaths = [
+        "target/universal/mantis-*.zip"
+      ];
     };
 
     publish = commonAttrs // {


### PR DESCRIPTION
# Description

Small improvement for the build pipeline: 

 - Do not retry scalafmt, scalastyle, compilation as there is no reason why these should be flaky. It will allow to get a failure more rapidly
 - allow to download the zip generated in the dist stage
