### PR TITLE
[ETCM-842] Remove ETH61 and ETH62 as possible protocols

### DIFF
--- a/src/it/scala/io/iohk/ethereum/sync/util/CommonFakePeer.scala
+++ b/src/it/scala/io/iohk/ethereum/sync/util/CommonFakePeer.scala
@@ -190,7 +190,6 @@ abstract class CommonFakePeer(peerName: String, fakePeerCustomConfig: FakePeerCu
       peerStatistics,
       handshaker,
       authHandshaker,
-      EthereumMessageDecoder,
       discoveryConfig,
       blacklist,
       blockchainConfig.capabilities

--- a/src/it/scala/io/iohk/ethereum/txExecTest/util/DumpChainApp.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/util/DumpChainApp.scala
@@ -113,7 +113,6 @@ object DumpChainApp extends App with NodeKeyBuilder with SecureRandomBuilder wit
       knownNodesManager = actorSystem.deadLetters, // TODO: fixme
       handshaker = handshaker,
       authHandshaker = authHandshaker,
-      messageDecoder = EthereumMessageDecoder,
       discoveryConfig = discoveryConfig,
       blacklist = blacklist,
       capabilities = blockchainConfig.capabilities

--- a/src/main/scala/io/iohk/ethereum/network/PeerActor.scala
+++ b/src/main/scala/io/iohk/ethereum/network/PeerActor.scala
@@ -320,13 +320,12 @@ object PeerActor {
       incomingConnection: Boolean,
       handshaker: Handshaker[R],
       authHandshaker: AuthHandshaker,
-      messageDecoder: MessageDecoder,
       capabilities: List[Capability]
   ): Props =
     Props(
       new PeerActor(
         peerAddress,
-        rlpxConnectionFactory(authHandshaker, messageDecoder, peerConfiguration.rlpxConfiguration, capabilities),
+        rlpxConnectionFactory(authHandshaker, peerConfiguration.rlpxConfiguration, capabilities),
         peerConfiguration,
         peerEventBus,
         knownNodesManager,
@@ -338,13 +337,12 @@ object PeerActor {
 
   def rlpxConnectionFactory(
       authHandshaker: AuthHandshaker,
-      messageDecoder: MessageDecoder,
       rlpxConfiguration: RLPxConfiguration,
       capabilities: List[Capability]
   ): ActorContext => ActorRef = { ctx =>
     ctx.actorOf(
       RLPxConnectionHandler
-        .props(NetworkMessageDecoder orElse messageDecoder, capabilities, authHandshaker, rlpxConfiguration),
+        .props(capabilities, authHandshaker, rlpxConfiguration),
       "rlpx-connection"
     )
   }

--- a/src/main/scala/io/iohk/ethereum/network/PeerManagerActor.scala
+++ b/src/main/scala/io/iohk/ethereum/network/PeerManagerActor.scala
@@ -421,7 +421,6 @@ object PeerManagerActor {
       peerStatistics: ActorRef,
       handshaker: Handshaker[R],
       authHandshaker: AuthHandshaker,
-      messageDecoder: MessageDecoder,
       discoveryConfig: DiscoveryConfig,
       blacklist: Blacklist,
       capabilities: List[Capability]
@@ -433,7 +432,6 @@ object PeerManagerActor {
         knownNodesManager,
         handshaker,
         authHandshaker,
-        messageDecoder,
         capabilities
       )
 
@@ -458,7 +456,6 @@ object PeerManagerActor {
       knownNodesManager: ActorRef,
       handshaker: Handshaker[R],
       authHandshaker: AuthHandshaker,
-      messageDecoder: MessageDecoder,
       capabilities: List[Capability]
   ): (ActorContext, InetSocketAddress, Boolean) => ActorRef = { (ctx, address, incomingConnection) =>
     val id: String = address.toString.filterNot(_ == '/')
@@ -470,7 +467,6 @@ object PeerManagerActor {
       incomingConnection,
       handshaker,
       authHandshaker,
-      messageDecoder,
       capabilities
     )
     ctx.actorOf(props, id)

--- a/src/main/scala/io/iohk/ethereum/network/p2p/Message.scala
+++ b/src/main/scala/io/iohk/ethereum/network/p2p/Message.scala
@@ -21,11 +21,10 @@ trait MessageSerializable extends Message {
 }
 
 trait MessageDecoder { self =>
-  def fromBytes(`type`: Int, payload: Array[Byte], protocolVersion: Capability): Message
+  def fromBytes(`type`: Int, payload: Array[Byte]): Message
 
-  def orElse(otherMessageDecoder: MessageDecoder): MessageDecoder = new MessageDecoder {
-    override def fromBytes(`type`: Int, payload: Array[Byte], protocolVersion: Capability): Message =
-      Try { self.fromBytes(`type`, payload, protocolVersion) }
-        .getOrElse(otherMessageDecoder.fromBytes(`type`, payload, protocolVersion))
-  }
+  def orElse(otherMessageDecoder: MessageDecoder): MessageDecoder = (`type`: Int, payload: Array[Byte]) =>
+    Try {
+      self.fromBytes(`type`, payload)
+    }.getOrElse(otherMessageDecoder.fromBytes(`type`, payload))
 }

--- a/src/main/scala/io/iohk/ethereum/network/p2p/MessageDecoders.scala
+++ b/src/main/scala/io/iohk/ethereum/network/p2p/MessageDecoders.scala
@@ -21,7 +21,7 @@ import io.iohk.ethereum.network.p2p.messages.WireProtocol._
 
 object NetworkMessageDecoder extends MessageDecoder {
 
-  override def fromBytes(msgCode: Int, payload: Array[Byte], protocolVersion: Capability): Message =
+  override def fromBytes(msgCode: Int, payload: Array[Byte]): Message =
     msgCode match {
       case Disconnect.code => payload.toDisconnect
       case Ping.code => payload.toPing
@@ -32,75 +32,62 @@ object NetworkMessageDecoder extends MessageDecoder {
 
 }
 
-// scalastyle:off
-object EthereumMessageDecoder extends MessageDecoder {
+object ETC64MessageDecoder extends MessageDecoder {
+  import io.iohk.ethereum.network.p2p.messages.ETC64.Status._
+  import io.iohk.ethereum.network.p2p.messages.ETC64.NewBlock._
 
-  override def fromBytes(msgCode: Int, payload: Array[Byte], protocolVersion: Capability): Message = {
-    protocolVersion match {
-      case ETC64 => handleETC64(msgCode, payload)
-      case ETH63 => handleETH63(msgCode, payload)
-      case ETH62 => handleETH62(msgCode, payload)
-      case ETH61 => handleETH61(msgCode, payload)
-      case pv => throw new RuntimeException("Unknown protocol version: " + pv)
-    }
-  }
-
-  private def handleCommonMessages(msgCode: Int, payload: Array[Byte]): Message = {
+  def fromBytes(msgCode: Int, payload: Array[Byte]): Message = {
     msgCode match {
-      case Codes.StatusCode =>
-        import io.iohk.ethereum.network.p2p.messages.BaseETH6XMessages.Status._
-        payload.toStatus
-      case Codes.NewBlockCode =>
-        import io.iohk.ethereum.network.p2p.messages.BaseETH6XMessages.NewBlock._
-        payload.toNewBlock
-      case Codes.SignedTransactionsCode =>
-        payload.toSignedTransactions
-      case _ =>
-        throw new RuntimeException("Unknown message type: " + msgCode)
-    }
-  }
-
-  private def handleETH61(msgCode: Int, payload: Array[Byte]): Message = {
-    msgCode match {
-      case Codes.NewBlockHashesCode =>
-        import io.iohk.ethereum.network.p2p.messages.ETH61.NewBlockHashes._
-        payload.toNewBlockHashes
-      case Codes.BlockHashesFromNumberCode =>
-        payload.toBlockHashesFromNumber
-      case _ => handleCommonMessages(msgCode, payload)
-    }
-  }
-
-  private def handleETH62(msgCode: Int, payload: Array[Byte]): Message = {
-    msgCode match {
+      case Codes.StatusCode => payload.toStatus
+      case Codes.NewBlockCode => payload.toNewBlock
+      case Codes.GetNodeDataCode => payload.toGetNodeData
+      case Codes.NodeDataCode => payload.toNodeData
+      case Codes.GetReceiptsCode => payload.toGetReceipts
+      case Codes.ReceiptsCode => payload.toReceipts
       case Codes.NewBlockHashesCode => payload.toNewBlockHashes
       case Codes.GetBlockHeadersCode => payload.toGetBlockHeaders
       case Codes.BlockHeadersCode => payload.toBlockHeaders
       case Codes.GetBlockBodiesCode => payload.toGetBlockBodies
       case Codes.BlockBodiesCode => payload.toBlockBodies
-      case _ => handleCommonMessages(msgCode, payload)
+      case Codes.BlockHashesFromNumberCode => payload.toBlockHashesFromNumber
+      case Codes.SignedTransactionsCode => payload.toSignedTransactions
+      case _ => throw new RuntimeException(s"Unknown message type: ${msgCode}")
     }
   }
+}
 
-  private def handleETH63(msgCode: Int, payload: Array[Byte]): Message = {
+object ETH63MessageDecoder extends MessageDecoder {
+  import io.iohk.ethereum.network.p2p.messages.BaseETH6XMessages.Status._
+  import io.iohk.ethereum.network.p2p.messages.BaseETH6XMessages.NewBlock._
+
+  def fromBytes(msgCode: Int, payload: Array[Byte]): Message = {
     msgCode match {
       case Codes.GetNodeDataCode => payload.toGetNodeData
       case Codes.NodeDataCode => payload.toNodeData
       case Codes.GetReceiptsCode => payload.toGetReceipts
       case Codes.ReceiptsCode => payload.toReceipts
-      case _ => handleETH62(msgCode, payload)
+      case Codes.NewBlockHashesCode => payload.toNewBlockHashes
+      case Codes.GetBlockHeadersCode => payload.toGetBlockHeaders
+      case Codes.BlockHeadersCode => payload.toBlockHeaders
+      case Codes.GetBlockBodiesCode => payload.toGetBlockBodies
+      case Codes.BlockBodiesCode => payload.toBlockBodies
+      case Codes.BlockHashesFromNumberCode => payload.toBlockHashesFromNumber
+      case Codes.StatusCode => payload.toStatus
+      case Codes.NewBlockCode => payload.toNewBlock
+      case Codes.SignedTransactionsCode => payload.toSignedTransactions
+      case _ => throw new RuntimeException(s"Unknown message type: ${msgCode}")
     }
   }
+}
 
-  private def handleETC64(msgCode: Int, payload: Array[Byte]): Message = {
-    msgCode match {
-      case Codes.StatusCode =>
-        import io.iohk.ethereum.network.p2p.messages.ETC64.Status._
-        payload.toStatus
-      case Codes.NewBlockCode =>
-        import io.iohk.ethereum.network.p2p.messages.ETC64.NewBlock._
-        payload.toNewBlock
-      case _ => handleETH63(msgCode, payload)
+// scalastyle:off
+object EthereumMessageDecoder {
+  type Decoder = (Int, Array[Byte]) => Message
+  def ethMessageDecoder(protocolVersion: Capability): MessageDecoder = {
+    protocolVersion match {
+      case Capability.Capabilities.Etc64Capability => ETC64MessageDecoder.fromBytes
+      case Capability.Capabilities.Eth63Capability => ETH63MessageDecoder.fromBytes
+      case _ => throw new RuntimeException(s"Unsupported Protocol Version $protocolVersion")
     }
   }
 }

--- a/src/main/scala/io/iohk/ethereum/network/p2p/MessageDecoders.scala
+++ b/src/main/scala/io/iohk/ethereum/network/p2p/MessageDecoders.scala
@@ -27,7 +27,7 @@ object NetworkMessageDecoder extends MessageDecoder {
       case Ping.code => payload.toPing
       case Pong.code => payload.toPong
       case Hello.code => payload.toHello
-      case _ => throw new RuntimeException(s"Unknown message type: ${msgCode}")
+      case _ => throw new RuntimeException(s"Unknown message type: $msgCode")
     }
 
 }
@@ -51,7 +51,7 @@ object ETC64MessageDecoder extends MessageDecoder {
       case Codes.BlockBodiesCode => payload.toBlockBodies
       case Codes.BlockHashesFromNumberCode => payload.toBlockHashesFromNumber
       case Codes.SignedTransactionsCode => payload.toSignedTransactions
-      case _ => throw new RuntimeException(s"Unknown message type: ${msgCode}")
+      case _ => throw new RuntimeException(s"Unknown message type: $msgCode")
     }
   }
 }
@@ -75,7 +75,7 @@ object ETH63MessageDecoder extends MessageDecoder {
       case Codes.StatusCode => payload.toStatus
       case Codes.NewBlockCode => payload.toNewBlock
       case Codes.SignedTransactionsCode => payload.toSignedTransactions
-      case _ => throw new RuntimeException(s"Unknown message type: ${msgCode}")
+      case _ => throw new RuntimeException(s"Unknown message type: $msgCode")
     }
   }
 }

--- a/src/main/scala/io/iohk/ethereum/network/p2p/messages/package.scala
+++ b/src/main/scala/io/iohk/ethereum/network/p2p/messages/package.scala
@@ -5,7 +5,13 @@ package object messages {
     val ETH61: Capability = Capability("eth", 61.toByte)
     val ETH62: Capability = Capability("eth", 62.toByte)
     val ETH63: Capability = Capability("eth", 63.toByte)
+    val ETH64: Capability = Capability("eth", 64.toByte)
+    val ETH65: Capability = Capability("eth", 65.toByte)
+    val ETH66: Capability = Capability("eth", 66.toByte)
+
     val ETC64: Capability = Capability("etc", 64.toByte)
+
+    val SNAP1: Capability = Capability("snap", 1.toByte)
 
     val SubProtocolOffset = 0x10
   }

--- a/src/main/scala/io/iohk/ethereum/network/rlpx/MessageCodec.scala
+++ b/src/main/scala/io/iohk/ethereum/network/rlpx/MessageCodec.scala
@@ -19,7 +19,6 @@ object MessageCodec {
 class MessageCodec(
     frameCodec: FrameCodec,
     messageDecoder: MessageDecoder,
-    protocolVersion: Capability,
     val remotePeer2PeerVersion: Long
 ) {
   import MessageCodec._
@@ -43,7 +42,7 @@ class MessageCodec(
         }
 
       payloadTry.map { payload =>
-        messageDecoder.fromBytes(frame.`type`, payload, protocolVersion)
+        messageDecoder.fromBytes(frame.`type`, payload)
       }
     }
   }

--- a/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
@@ -24,7 +24,6 @@ import io.iohk.ethereum.network.EtcPeerManagerActor.PeerInfo
 import io.iohk.ethereum.network.PeerManagerActor.PeerConfiguration
 import io.iohk.ethereum.network.discovery.{DiscoveryConfig, DiscoveryServiceBuilder, PeerDiscoveryManager}
 import io.iohk.ethereum.network.handshaker.{EtcHandshaker, EtcHandshakerConfiguration, Handshaker}
-import io.iohk.ethereum.network.p2p.{EthereumMessageDecoder, NetworkMessageDecoder}
 import io.iohk.ethereum.network.rlpx.AuthHandshaker
 import io.iohk.ethereum.network.{PeerManagerActor, ServerActor, _}
 import io.iohk.ethereum.ommers.OmmersPool

--- a/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
@@ -24,7 +24,7 @@ import io.iohk.ethereum.network.EtcPeerManagerActor.PeerInfo
 import io.iohk.ethereum.network.PeerManagerActor.PeerConfiguration
 import io.iohk.ethereum.network.discovery.{DiscoveryConfig, DiscoveryServiceBuilder, PeerDiscoveryManager}
 import io.iohk.ethereum.network.handshaker.{EtcHandshaker, EtcHandshakerConfiguration, Handshaker}
-import io.iohk.ethereum.network.p2p.EthereumMessageDecoder
+import io.iohk.ethereum.network.p2p.{EthereumMessageDecoder, NetworkMessageDecoder}
 import io.iohk.ethereum.network.rlpx.AuthHandshaker
 import io.iohk.ethereum.network.{PeerManagerActor, ServerActor, _}
 import io.iohk.ethereum.ommers.OmmersPool
@@ -245,7 +245,6 @@ trait PeerManagerActorBuilder {
       peerStatistics,
       handshaker,
       authHandshaker,
-      EthereumMessageDecoder,
       discoveryConfig,
       blacklist,
       blockchainConfig.capabilities

--- a/src/test/scala/io/iohk/ethereum/network/p2p/MessageCodecSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/network/p2p/MessageCodecSpec.scala
@@ -98,10 +98,10 @@ class MessageCodecSpec extends AnyFlatSpec with Matchers {
       genesisHash = ByteString(1)
     )
 
-    val decoder = NetworkMessageDecoder orElse EthereumMessageDecoder
+    val decoder = NetworkMessageDecoder.orElse(EthereumMessageDecoder.ethMessageDecoder(Eth63Capability))
 
-    val messageCodec = new MessageCodec(frameCodec, decoder, ProtocolVersions.ETH63, negotiatedLocalP2PVersion)
-    val remoteMessageCodec = new MessageCodec(remoteFrameCodec, decoder, ProtocolVersions.ETH63, negotiatedRemoteP2PVersion)
+    val messageCodec = new MessageCodec(frameCodec, decoder, negotiatedLocalP2PVersion)
+    val remoteMessageCodec = new MessageCodec(remoteFrameCodec, decoder, negotiatedRemoteP2PVersion)
 
   }
 

--- a/src/test/scala/io/iohk/ethereum/network/p2p/messages/MessagesSerializationSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/network/p2p/messages/MessagesSerializationSpec.scala
@@ -91,9 +91,9 @@ class MessagesSerializationSpec extends AnyWordSpec with ScalaCheckPropertyCheck
     }
   }
 
-  "support ETH61 messages as ETH63" when {
+  "ETH63" when {
     val version = ProtocolVersions.ETH63
-    "encoding and decoding NewBlockHashes" should {
+    "encoding and decoding ETH61.NewBlockHashes" should {
       "throw for unsupported message version" in {
         val msg = ETH61.NewBlockHashes(Seq(ByteString("23"), ByteString("10"), ByteString("36")))
         assertThrows[RuntimeException] {
@@ -108,11 +108,8 @@ class MessagesSerializationSpec extends AnyWordSpec with ScalaCheckPropertyCheck
         verify(msg, (m: BlockHashesFromNumber) => m.toBytes, Codes.BlockHashesFromNumberCode, version)
       }
     }
-  }
 
-  "support ETH62 messages as ETH63" when {
-    val version = ProtocolVersions.ETH63
-    "encoding and decoding NewBlockHashes" should {
+    "encoding and decoding ETH62.NewBlockHashes" should {
       "return same result" in {
         val msg = ETH62.NewBlockHashes(Seq(BlockHash(ByteString("hash1"), 1), BlockHash(ByteString("hash2"), 2)))
         verify(msg, (m: ETH62.NewBlockHashes) => m.toBytes, Codes.NewBlockHashesCode, version)

--- a/src/test/scala/io/iohk/ethereum/network/p2p/messages/NodeDataSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/network/p2p/messages/NodeDataSpec.scala
@@ -79,7 +79,7 @@ class NodeDataSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "be decoded properly" in {
-    val result = EthereumMessageDecoder.fromBytes(Codes.NodeDataCode, encode(encodedNodeData), ProtocolVersions.ETH63)
+    val result = EthereumMessageDecoder.ethMessageDecoder(ProtocolVersions.ETH63).fromBytes(Codes.NodeDataCode, encode(encodedNodeData))
 
     result match {
       case m: NodeData =>
@@ -93,7 +93,7 @@ class NodeDataSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "be decoded previously encoded value" in {
-    EthereumMessageDecoder.fromBytes(Codes.NodeDataCode, nodeData.toBytes, ProtocolVersions.ETH63) shouldBe nodeData
+    EthereumMessageDecoder.ethMessageDecoder(ProtocolVersions.ETH63).fromBytes(Codes.NodeDataCode, nodeData.toBytes) shouldBe nodeData
   }
 
   it should "decode branch node with values in leafs that looks like RLP list" in {

--- a/src/test/scala/io/iohk/ethereum/network/p2p/messages/ReceiptsSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/network/p2p/messages/ReceiptsSpec.scala
@@ -51,14 +51,13 @@ class ReceiptsSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "decode receipts" in {
-    EthereumMessageDecoder.fromBytes(
+    EthereumMessageDecoder.ethMessageDecoder(ProtocolVersions.ETH63).fromBytes(
       Codes.ReceiptsCode,
-      encode(encodedReceipts),
-      ProtocolVersions.ETH63
+      encode(encodedReceipts)
     ) shouldBe receipts
   }
 
   it should "decode encoded receipts" in {
-    EthereumMessageDecoder.fromBytes(Codes.ReceiptsCode, receipts.toBytes, ProtocolVersions.ETH63) shouldBe receipts
+    EthereumMessageDecoder.ethMessageDecoder(ProtocolVersions.ETH63).fromBytes(Codes.ReceiptsCode, receipts.toBytes) shouldBe receipts
   }
 }


### PR DESCRIPTION
Some restructuring in the available protocol versions:
- replaced PV with ETH/ETC prefix
- prepared ETH64, 65, 66 versions
- dropped support for ETH61, ETH62

What's left
- explicit namespaces for ETH61, ETH62
- ETH63 is not marked for deprecation