### PR TITLE
[kaizen] stabilize GeneralStateTests by increasing akka http timeout

### DIFF
--- a/src/main/resources/conf/testmode.conf
+++ b/src/main/resources/conf/testmode.conf
@@ -54,3 +54,5 @@ mantis {
   }
 
 }
+
+akka.http.server.request-timeout = 30.seconds


### PR DESCRIPTION
# Description

This change was initially in #1006. It allows to fix some flaky test in ETS GeneralStateTests (with this change we successfully run the whole GeneralStateTests suite on the CI or on slower computers).

Since the commit was reverted, I think we should at least keep this small configuration change.

