### PR TITLE
ETCM-938 Refactor Blockchain and extract methods getEvmCodeByHash and mptStateSavedKeys

### DIFF
--- a/src/it/scala/io/iohk/ethereum/sync/util/CommonFakePeer.scala
+++ b/src/it/scala/io/iohk/ethereum/sync/util/CommonFakePeer.scala
@@ -116,6 +116,7 @@ abstract class CommonFakePeer(peerName: String, fakePeerCustomConfig: FakePeerCu
   )
 
   val bl = BlockchainImpl(storagesInstance.storages)
+  val evmCodeStorage = storagesInstance.storages.evmCodeStorage
 
   val genesis = Block(
     Fixtures.Blocks.Genesis.header.copy(stateRoot = ByteString(MerklePatriciaTrie.EmptyRootHash)),
@@ -203,7 +204,10 @@ abstract class CommonFakePeer(peerName: String, fakePeerCustomConfig: FakePeerCu
   )
 
   val blockchainHost: ActorRef =
-    system.actorOf(BlockchainHostActor.props(bl, peerConf, peerEventBus, etcPeerManager), "blockchain-host")
+    system.actorOf(
+      BlockchainHostActor.props(bl, storagesInstance.storages.evmCodeStorage, peerConf, peerEventBus, etcPeerManager),
+      "blockchain-host"
+    )
 
   lazy val server: ActorRef = system.actorOf(ServerActor.props(nodeStatusHolder, peerManager), "server")
 

--- a/src/it/scala/io/iohk/ethereum/sync/util/FastSyncItSpecUtils.scala
+++ b/src/it/scala/io/iohk/ethereum/sync/util/FastSyncItSpecUtils.scala
@@ -29,6 +29,8 @@ object FastSyncItSpecUtils {
         storagesInstance.storages.fastSyncStateStorage,
         storagesInstance.storages.appStateStorage,
         bl,
+        storagesInstance.storages.evmCodeStorage,
+        storagesInstance.storages.nodeStorage,
         validators,
         peerEventBus,
         etcPeerManager,
@@ -72,7 +74,7 @@ object FastSyncItSpecUtils {
           val codeHash = kec256(accountExpectedCode)
           val accountExpectedStorageAddresses = (i until i + 20).toList
           val account = bl.getAccount(accountAddress, blockNumber).get
-          val code = bl.getEvmCodeByHash(codeHash).get
+          val code = evmCodeStorage.get(codeHash).get
           val storedData = accountExpectedStorageAddresses.map { addr =>
             ByteUtils.toBigInt(bl.getAccountStorageAt(account.storageRoot, addr, ethCompatibleStorage = true))
           }

--- a/src/it/scala/io/iohk/ethereum/txExecTest/util/DumpChainApp.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/util/DumpChainApp.scala
@@ -180,8 +180,6 @@ class BlockchainMock(genesisHash: ByteString) extends Blockchain {
 
   override def getChainWeightByHash(blockhash: ByteString): Option[ChainWeight] = ???
 
-  override def getEvmCodeByHash(hash: ByteString): Option[ByteString] = ???
-
   override def getReceiptsByHash(blockhash: ByteString): Option[Seq[Receipt]] = ???
 
   def getAccount(address: Address, blockNumber: BigInt): Option[Account] = ???
@@ -219,6 +217,4 @@ class BlockchainMock(genesisHash: ByteString) extends Blockchain {
   override def save(block: Block, receipts: Seq[Receipt], weight: ChainWeight, saveAsBestBlock: Boolean): Unit = ???
 
   override def getLatestCheckpointBlockNumber(): BigInt = ???
-
-  override def mptStateSavedKeys(): Observable[Either[RocksDbDataSource.IterationError, NodeHash]] = ???
 }

--- a/src/it/scala/io/iohk/ethereum/txExecTest/util/FixtureProvider.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/util/FixtureProvider.scala
@@ -46,10 +46,10 @@ object FixtureProvider {
       override val blockBodiesStorage: BlockBodiesStorage = new BlockBodiesStorage(dataSource)
       override val chainWeightStorage: ChainWeightStorage = new ChainWeightStorage(dataSource)
       override val transactionMappingStorage: TransactionMappingStorage = new TransactionMappingStorage(dataSource)
-      override val nodeStorage: NodeStorage = new NodeStorage(dataSource)
-      override val cachedNodeStorage: CachedNodeStorage = new CachedNodeStorage(nodeStorage, caches.nodeCache)
-      override val pruningMode: PruningMode = ArchivePruning
       override val appStateStorage: AppStateStorage = new AppStateStorage(dataSource)
+      val nodeStorage: NodeStorage = new NodeStorage(dataSource)
+      val cachedNodeStorage: CachedNodeStorage = new CachedNodeStorage(nodeStorage, caches.nodeCache)
+      val pruningMode: PruningMode = ArchivePruning
       override val stateStorage: StateStorage =
         StateStorage(
           pruningMode,

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/SyncController.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/SyncController.scala
@@ -4,7 +4,7 @@ import akka.actor.{Actor, ActorLogging, ActorRef, PoisonPill, Props, Scheduler}
 import io.iohk.ethereum.blockchain.sync.fast.FastSync
 import io.iohk.ethereum.blockchain.sync.regular.RegularSync
 import io.iohk.ethereum.consensus.validators.Validators
-import io.iohk.ethereum.db.storage.{AppStateStorage, FastSyncStateStorage}
+import io.iohk.ethereum.db.storage.{AppStateStorage, EvmCodeStorage, FastSyncStateStorage, NodeStorage}
 import io.iohk.ethereum.domain.Blockchain
 import io.iohk.ethereum.ledger.Ledger
 import io.iohk.ethereum.utils.Config.SyncConfig
@@ -12,6 +12,8 @@ import io.iohk.ethereum.utils.Config.SyncConfig
 class SyncController(
     appStateStorage: AppStateStorage,
     blockchain: Blockchain,
+    evmCodeStorage: EvmCodeStorage,
+    nodeStorage: NodeStorage,
     fastSyncStateStorage: FastSyncStateStorage,
     ledger: Ledger,
     validators: Validators,
@@ -77,6 +79,8 @@ class SyncController(
         fastSyncStateStorage,
         appStateStorage,
         blockchain,
+        evmCodeStorage,
+        nodeStorage,
         validators,
         peerEventBus,
         etcPeerManager,
@@ -120,6 +124,8 @@ object SyncController {
   def props(
       appStateStorage: AppStateStorage,
       blockchain: Blockchain,
+      evmCodeStorage: EvmCodeStorage,
+      nodeStorage: NodeStorage,
       syncStateStorage: FastSyncStateStorage,
       ledger: Ledger,
       validators: Validators,
@@ -134,6 +140,8 @@ object SyncController {
       new SyncController(
         appStateStorage,
         blockchain,
+        evmCodeStorage,
+        nodeStorage,
         syncStateStorage,
         ledger,
         validators,

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/fast/FastSync.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/fast/FastSync.scala
@@ -20,7 +20,7 @@ import io.iohk.ethereum.blockchain.sync.fast.SyncStateSchedulerActor.{
   WaitingForNewTargetBlock
 }
 import io.iohk.ethereum.consensus.validators.Validators
-import io.iohk.ethereum.db.storage.{AppStateStorage, FastSyncStateStorage}
+import io.iohk.ethereum.db.storage.{AppStateStorage, EvmCodeStorage, FastSyncStateStorage, NodeStorage}
 import io.iohk.ethereum.domain._
 import io.iohk.ethereum.mpt.MerklePatriciaTrie
 import io.iohk.ethereum.network.EtcPeerManagerActor.PeerInfo
@@ -48,6 +48,8 @@ class FastSync(
     val fastSyncStateStorage: FastSyncStateStorage,
     val appStateStorage: AppStateStorage,
     val blockchain: Blockchain,
+    evmCodeStorage: EvmCodeStorage,
+    nodeStorage: NodeStorage,
     val validators: Validators,
     val peerEventBus: ActorRef,
     val etcPeerManager: ActorRef,
@@ -153,7 +155,7 @@ class FastSync(
     private val syncStateScheduler = context.actorOf(
       SyncStateSchedulerActor
         .props(
-          SyncStateScheduler(blockchain, syncConfig.stateSyncBloomFilterSize),
+          SyncStateScheduler(blockchain, evmCodeStorage, nodeStorage, syncConfig.stateSyncBloomFilterSize),
           syncConfig,
           etcPeerManager,
           peerEventBus,
@@ -1134,6 +1136,8 @@ object FastSync {
       fastSyncStateStorage: FastSyncStateStorage,
       appStateStorage: AppStateStorage,
       blockchain: Blockchain,
+      evmCodeStorage: EvmCodeStorage,
+      nodeStorage: NodeStorage,
       validators: Validators,
       peerEventBus: ActorRef,
       etcPeerManager: ActorRef,
@@ -1146,6 +1150,8 @@ object FastSync {
         fastSyncStateStorage,
         appStateStorage,
         blockchain,
+        evmCodeStorage,
+        nodeStorage,
         validators,
         peerEventBus,
         etcPeerManager,

--- a/src/main/scala/io/iohk/ethereum/domain/Blockchain.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/Blockchain.scala
@@ -115,13 +115,6 @@ trait Blockchain {
   def getReceiptsByHash(blockhash: ByteString): Option[Seq[Receipt]]
 
   /**
-    * Returns EVM code searched by it's hash
-    * @param hash Code Hash
-    * @return EVM code if found
-    */
-  def getEvmCodeByHash(hash: ByteString): Option[ByteString]
-
-  /**
     * Returns MPT node searched by it's hash
     * @param hash Node Hash
     * @return MPT node
@@ -207,8 +200,6 @@ trait Blockchain {
       ethCompatibleStorage: Boolean
   ): WS
 
-  def mptStateSavedKeys(): Observable[Either[IterationError, ByteString]]
-
   /**
     * Strict check if given block hash is in chain
     * Using any of getXXXByHash is not always accurate - after restart the best block is often lower than before restart
@@ -230,7 +221,6 @@ class BlockchainImpl(
     protected val blockNumberMappingStorage: BlockNumberMappingStorage,
     protected val receiptStorage: ReceiptStorage,
     protected val evmCodeStorage: EvmCodeStorage,
-    protected val nodeStorage: NodeStorage,
     protected val chainWeightStorage: ChainWeightStorage,
     protected val transactionMappingStorage: TransactionMappingStorage,
     protected val appStateStorage: AppStateStorage,
@@ -256,8 +246,6 @@ class BlockchainImpl(
     blockBodiesStorage.get(hash)
 
   override def getReceiptsByHash(blockhash: ByteString): Option[Seq[Receipt]] = receiptStorage.get(blockhash)
-
-  override def getEvmCodeByHash(hash: ByteString): Option[ByteString] = evmCodeStorage.get(hash)
 
   override def getChainWeightByHash(blockhash: ByteString): Option[ChainWeight] = chainWeightStorage.get(blockhash)
 
@@ -509,11 +497,6 @@ class BlockchainImpl(
   }
   // scalastyle:on method.length
 
-  def mptStateSavedKeys(): Observable[Either[IterationError, ByteString]] = {
-    (nodeStorage.storageContent.map(c => c.map(_._1)) ++ evmCodeStorage.storageContent.map(c => c.map(_._1)))
-      .takeWhileInclusive(_.isRight)
-  }
-
   /**
     * Recursive function which try to find the previous checkpoint by traversing blocks from top to the bottom.
     * In case of finding the checkpoint block number, the function will finish the job and return result
@@ -596,8 +579,6 @@ trait BlockchainStorages {
   val evmCodeStorage: EvmCodeStorage
   val chainWeightStorage: ChainWeightStorage
   val transactionMappingStorage: TransactionMappingStorage
-  val nodeStorage: NodeStorage
-  val pruningMode: PruningMode
   val appStateStorage: AppStateStorage
   val cachedNodeStorage: CachedNodeStorage
   val stateStorage: StateStorage
@@ -611,7 +592,6 @@ object BlockchainImpl {
       blockNumberMappingStorage = storages.blockNumberMappingStorage,
       receiptStorage = storages.receiptStorage,
       evmCodeStorage = storages.evmCodeStorage,
-      nodeStorage = storages.nodeStorage,
       chainWeightStorage = storages.chainWeightStorage,
       transactionMappingStorage = storages.transactionMappingStorage,
       appStateStorage = storages.appStateStorage,

--- a/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
@@ -7,7 +7,7 @@ import io.iohk.ethereum.blockchain.sync.{Blacklist, BlockchainHostActor, CacheBa
 import io.iohk.ethereum.consensus._
 import io.iohk.ethereum.db.components.Storages.PruningModeComponent
 import io.iohk.ethereum.db.components._
-import io.iohk.ethereum.db.storage.AppStateStorage
+import io.iohk.ethereum.db.storage.{AppStateStorage, EvmCodeStorage}
 import io.iohk.ethereum.db.storage.pruning.PruningMode
 import io.iohk.ethereum.domain._
 import io.iohk.ethereum.jsonrpc.NetService.NetServiceConfig
@@ -270,12 +270,14 @@ trait EtcPeerManagerActorBuilder {
 trait BlockchainHostBuilder {
   self: ActorSystemBuilder
     with BlockchainBuilder
+    with StorageBuilder
     with PeerManagerActorBuilder
     with EtcPeerManagerActorBuilder
     with PeerEventBusBuilder =>
 
   val blockchainHost: ActorRef = system.actorOf(
-    BlockchainHostActor.props(blockchain, peerConfiguration, peerEventBus, etcPeerManager),
+    BlockchainHostActor
+      .props(blockchain, storagesInstance.storages.evmCodeStorage, peerConfiguration, peerEventBus, etcPeerManager),
     "blockchain-host"
   )
 
@@ -715,6 +717,8 @@ trait SyncControllerBuilder {
     SyncController.props(
       storagesInstance.storages.appStateStorage,
       blockchain,
+      storagesInstance.storages.evmCodeStorage,
+      storagesInstance.storages.nodeStorage,
       storagesInstance.storages.fastSyncStateStorage,
       ledger,
       consensus.validators,

--- a/src/main/scala/io/iohk/ethereum/testmode/TestBlockchainBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/testmode/TestBlockchainBuilder.scala
@@ -20,7 +20,6 @@ trait TestBlockchainBuilder extends BlockchainBuilder {
       blockNumberMappingStorage = storages.blockNumberMappingStorage,
       receiptStorage = storages.receiptStorage,
       evmCodeStorage = storages.evmCodeStorage,
-      nodeStorage = storages.nodeStorage,
       chainWeightStorage = storages.chainWeightStorage,
       transactionMappingStorage = storages.transactionMappingStorage,
       appStateStorage = storages.appStateStorage,

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/BlockchainHostActorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/BlockchainHostActorSpec.scala
@@ -305,7 +305,15 @@ class BlockchainHostActorSpec extends AnyFlatSpec with Matchers {
     val etcPeerManager = TestProbe()
 
     val blockchainHost = TestActorRef(
-      Props(new BlockchainHostActor(blockchain, peerConf, peerEventBus.ref, etcPeerManager.ref))
+      Props(
+        new BlockchainHostActor(
+          blockchain,
+          storagesInstance.storages.evmCodeStorage,
+          peerConf,
+          peerEventBus.ref,
+          etcPeerManager.ref
+        )
+      )
     )
   }
 

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/FastSyncSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/FastSyncSpec.scala
@@ -71,6 +71,8 @@ class FastSyncSpec
         fastSyncStateStorage = storagesInstance.storages.fastSyncStateStorage,
         appStateStorage = storagesInstance.storages.appStateStorage,
         blockchain = blockchain,
+        evmCodeStorage = storagesInstance.storages.evmCodeStorage,
+        nodeStorage = storagesInstance.storages.nodeStorage,
         validators = validators,
         peerEventBus = peerEventBus.ref,
         etcPeerManager = etcPeerManager.ref,

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/StateSyncSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/StateSyncSpec.scala
@@ -114,17 +114,11 @@ class StateSyncSpec
         blockNumberMappingStorage = storages.blockNumberMappingStorage,
         receiptStorage = storages.receiptStorage,
         evmCodeStorage = storages.evmCodeStorage,
-        nodeStorage = storages.nodeStorage,
         chainWeightStorage = storages.chainWeightStorage,
         transactionMappingStorage = storages.transactionMappingStorage,
         appStateStorage = storages.appStateStorage,
         stateStorage = storages.stateStorage
-      ) {
-        override def mptStateSavedKeys(): Observable[Either[IterationError, ByteString]] = {
-          Observable.interval(10.milliseconds).map(_ => Right(ByteString(1))).takeWhile(_ => !loadingFinished)
-        }
-      }
-
+      )
     }
     val nodeData = (0 until 1000).map(i => MptNodeData(Address(i), None, Seq(), i))
     val initiator = TestProbe()
@@ -160,7 +154,7 @@ class StateSyncSpec
       bestBlockHash = peerStatus.bestHash
     )
 
-    val trieProvider = new TrieProvider(blockchain, blockchainConfig)
+    val trieProvider = new TrieProvider(blockchain, storagesInstance.storages.evmCodeStorage, blockchainConfig)
 
     val peersMap = (1 to 8).map { i =>
       (
@@ -261,6 +255,8 @@ class StateSyncSpec
       SyncStateSchedulerActor.props(
         SyncStateScheduler(
           buildBlockChain(),
+          getNewStorages.storages.evmCodeStorage,
+          getNewStorages.storages.nodeStorage,
           syncConfig.stateSyncBloomFilterSize
         ),
         syncConfig,

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/SyncControllerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/SyncControllerSpec.scala
@@ -533,6 +533,8 @@ class SyncControllerSpec
         new SyncController(
           storagesInstance.storages.appStateStorage,
           blockchain,
+          storagesInstance.storages.evmCodeStorage,
+          storagesInstance.storages.nodeStorage,
           storagesInstance.storages.fastSyncStateStorage,
           ledger,
           validators,


### PR DESCRIPTION
# Description

In order to simplify the Blockchain complexity, methods `getEvmCodeByHash` and `mptStateSavedKeys` where removed, since they are used in just a few locations
`getEvmCodeByHash` is just a `get` done directly to the EvmCodeStorage
`mptStateSavedKeys` is used only in `SyncStateScheduler` so it was moved there

# Testing
All should work as before
