### PR TITLE
[ETCM-927] enhance BlockchainTests/ValidBlocks/bcMultiChainTest/Chain…

### DIFF
--- a/src/main/scala/io/iohk/ethereum/jsonrpc/TestService.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/TestService.scala
@@ -162,6 +162,9 @@ class TestService(
 
     // remove current genesis (Try because it may not exist)
     Try(blockchain.removeBlock(blockchain.genesisHeader.hash, withState = false))
+    // TODO clear the storage ? When relaunching some tests on the same running test mantis client,
+    // we end up with duplicate blocks because they are still present in the storage layer
+    // for example: bcMultiChainTest/ChainAtoChainB_BlockHash_Istanbul
 
     // load the new genesis
     val genesisDataLoader = new GenesisDataLoader(blockchain, blockchainReader, stateStorage, currentConfig)
@@ -291,7 +294,7 @@ class TestService(
       case BlockImportedToTop(blockImportData) =>
         val blockHash = s"0x${ByteStringUtils.hash2string(blockImportData.head.block.header.hash)}"
         ImportRawBlockResponse(blockHash).rightNow
-      case BlockEnqueued =>
+      case BlockEnqueued | ChainReorganised(_, _, _) =>
         val blockHash = s"0x${ByteStringUtils.hash2string(block.hash)}"
         ImportRawBlockResponse(blockHash).rightNow
       case e =>

--- a/src/main/scala/io/iohk/ethereum/ledger/BlockQueue.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/BlockQueue.scala
@@ -83,6 +83,14 @@ class BlockQueue(blockchain: Blockchain, val maxQueuedBlockNumberAhead: Int, val
     blocks.contains(hash)
 
   /**
+    * Returns the weight of the block corresponding to the hash, or None if not found
+    * @param hash the block's hash to get the weight from
+    * @return the weight of the block corresponding to the hash, or None if not found
+    */
+  def getChainWeightByHash(hash: ByteString): Option[ChainWeight] =
+    blocks.get(hash).flatMap(_.weight)
+
+  /**
     * Takes a branch going from descendant block upwards to the oldest ancestor
     * @param descendant the youngest block to be removed
     * @param dequeue should the branch be removed from the queue. Shared part of branch won't be removed
@@ -123,6 +131,14 @@ class BlockQueue(blockchain: Blockchain, val maxQueuedBlockNumberAhead: Int, val
       blocks -= block.header.hash
       parentToChildren -= block.header.hash
     }
+
+  /**
+    * Clear the BlockQueue
+    */
+  def clear(): Unit = {
+    blocks.clear()
+    parentToChildren.clear()
+  }
 
   /**
     * Removes stale blocks - too old or too young in relation the current best block number
@@ -193,4 +209,5 @@ class BlockQueue(blockchain: Blockchain, val maxQueuedBlockNumberAhead: Int, val
   private def isNumberOutOfRange(blockNumber: BigInt, bestBlockNumber: BigInt): Boolean =
     blockNumber - bestBlockNumber > maxQueuedBlockNumberAhead ||
       bestBlockNumber - blockNumber > maxQueuedBlockNumberBehind
+
 }

--- a/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
@@ -432,8 +432,9 @@ trait TestServiceBuilder {
 }
 
 trait TestEthBlockServiceBuilder extends EthBlocksServiceBuilder {
-  self: TestBlockchainBuilder with TestModeServiceBuilder with ConsensusBuilder =>
-  override lazy val ethBlocksService = new TestEthBlockServiceWrapper(blockchain, blockchainReader, consensus)
+  self: TestBlockchainBuilder with TestModeServiceBuilder with ConsensusBuilder with BlockQueueBuilder =>
+  override lazy val ethBlocksService =
+    new TestEthBlockServiceWrapper(blockchain, blockchainReader, consensus, blockQueue)
 }
 
 trait EthProofServiceBuilder {
@@ -509,9 +510,9 @@ trait EthTxServiceBuilder {
 }
 
 trait EthBlocksServiceBuilder {
-  self: BlockchainBuilder with ConsensusBuilder =>
+  self: BlockchainBuilder with ConsensusBuilder with BlockQueueBuilder =>
 
-  lazy val ethBlocksService = new EthBlocksService(blockchain, blockchainReader, consensus)
+  lazy val ethBlocksService = new EthBlocksService(blockchain, blockchainReader, consensus, blockQueue)
 }
 
 trait EthUserServiceBuilder {

--- a/src/main/scala/io/iohk/ethereum/testmode/TestEthBlockServiceWrapper.scala
+++ b/src/main/scala/io/iohk/ethereum/testmode/TestEthBlockServiceWrapper.scala
@@ -35,10 +35,13 @@ class TestEthBlockServiceWrapper(
     .getByBlockHash(request)
     .map(
       _.map(blockByBlockResponse => {
+        import io.iohk.ethereum.utils.ByteStringUtils._
         blockByBlockResponse.blockResponse
-          .toRight("missing block response")
+          .toRight(s"EthBlockService: unable to find block for hash ${request.blockHash.toHex}")
           .flatMap(baseBlockResponse => baseBlockResponse.hash.toRight(s"missing hash for block $baseBlockResponse"))
-          .flatMap(hash => blockchainReader.getBlockByHash(hash).toRight(s"unable to find block for hash=$hash"))
+          .flatMap(hash =>
+            blockchainReader.getBlockByHash(hash).toRight(s"unable to find block for hash=${hash.toHex}")
+          )
           .map(fullBlock =>
             BlockByBlockHashResponse(
               blockByBlockResponse.blockResponse.map(response => toEthResponse(fullBlock, response))

--- a/src/main/scala/io/iohk/ethereum/testmode/TestEthBlockServiceWrapper.scala
+++ b/src/main/scala/io/iohk/ethereum/testmode/TestEthBlockServiceWrapper.scala
@@ -11,6 +11,7 @@ import io.iohk.ethereum.jsonrpc.{
   TransactionData
 }
 import io.iohk.ethereum.utils.Logger
+import io.iohk.ethereum.utils.ByteStringUtils._
 import akka.util.ByteString
 import io.iohk.ethereum.consensus.Consensus
 import io.iohk.ethereum.ledger.BlockQueue
@@ -34,8 +35,7 @@ class TestEthBlockServiceWrapper(
   ): ServiceResponse[EthBlocksService.BlockByBlockHashResponse] = super
     .getByBlockHash(request)
     .map(
-      _.map(blockByBlockResponse => {
-        import io.iohk.ethereum.utils.ByteStringUtils._
+      _.flatMap { blockByBlockResponse =>
         blockByBlockResponse.blockResponse
           .toRight(s"EthBlockService: unable to find block for hash ${request.blockHash.toHex}")
           .flatMap(baseBlockResponse => baseBlockResponse.hash.toRight(s"missing hash for block $baseBlockResponse"))
@@ -49,7 +49,7 @@ class TestEthBlockServiceWrapper(
           )
           .left
           .map(errorMessage => JsonRpcError.LogicError(errorMessage))
-      }).flatten
+      }
     )
 
   /**

--- a/src/main/scala/io/iohk/ethereum/testmode/TestModeServiceBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/testmode/TestModeServiceBuilder.scala
@@ -1,13 +1,9 @@
 package io.iohk.ethereum.testmode
 
-import akka.util.ByteString
-import cats.data.NonEmptyList
 import io.iohk.ethereum.consensus.difficulty.DifficultyCalculator
 import io.iohk.ethereum.consensus.{Consensus, ConsensusBuilder, ConsensusConfigBuilder}
-import io.iohk.ethereum.domain._
 import io.iohk.ethereum.ledger._
 import io.iohk.ethereum.nodebuilder.{ActorSystemBuilder, _}
-import monix.eval.Task
 import monix.execution.Scheduler
 
 trait TestModeServiceBuilder extends StxLedgerBuilder {
@@ -18,6 +14,7 @@ trait TestModeServiceBuilder extends StxLedgerBuilder {
     with ConsensusBuilder
     with ActorSystemBuilder
     with ConsensusConfigBuilder
+    with BlockQueueBuilder
     with VmBuilder =>
 
   val scheduler = Scheduler(system.dispatchers.lookup("validation-context"))
@@ -34,6 +31,26 @@ trait TestModeServiceBuilder extends StxLedgerBuilder {
       vm
     )
 
+  override lazy val blockQueue: BlockQueue = testModeComponentsProvider.blockQueue();
+
+//<<<<<<< HEAD
+//=======
+//  private def testLedger: Ledger = testModeComponentsProvider.ledger(blockchainConfig, SealEngineType.NoReward)
+//
+//  class TestLedgerProxy extends Ledger {
+//    override def consensus: Consensus = testLedger.consensus
+//    override def checkBlockStatus(blockHash: ByteString): BlockStatus = testLedger.checkBlockStatus(blockHash)
+//    override def getBlockByHash(hash: ByteString): Option[Block] = testLedger.getBlockByHash(hash)
+//    override def importBlock(block: Block)(implicit
+//        blockExecutionScheduler: Scheduler
+//    ): Task[BlockImportResult] = testLedger.importBlock(block)
+//    override def resolveBranch(headers: NonEmptyList[BlockHeader]): BranchResolutionResult =
+//      testLedger.resolveBranch(headers)
+//    override def getChainWeightByHash(hash: ByteString): Option[ChainWeight] = testLedger.getChainWeightByHash(hash)
+//  }
+//
+//  override lazy val ledger: Ledger = new TestLedgerProxy
+//>>>>>>> f521a3125 ([ETCM-927] enhance BlockchainTests/ValidBlocks/bcMultiChainTest/ChainAtoChainB_difficultyB test)
   override lazy val stxLedger: StxLedger =
     testModeComponentsProvider.stxLedger(blockchainConfig, SealEngineType.NoReward)
 }

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/EthBlocksServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/EthBlocksServiceSpec.scala
@@ -397,6 +397,7 @@ class EthBlocksServiceSpec
   class TestSetup(implicit system: ActorSystem) extends MockFactory with EphemBlockchainTestSetup {
     val blockGenerator = mock[PoWBlockGenerator]
     val appStateStorage = mock[AppStateStorage]
+
     override lazy val consensus: TestConsensus = buildTestConsensus().withBlockGenerator(blockGenerator)
     override lazy val consensusConfig = ConsensusConfigs.consensusConfig
 

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/EthBlocksServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/EthBlocksServiceSpec.scala
@@ -404,7 +404,8 @@ class EthBlocksServiceSpec
     lazy val ethBlocksService = new EthBlocksService(
       blockchain,
       blockchainReader,
-      consensus
+      consensus,
+      blockQueue
     )
 
     val blockToRequest = Block(Fixtures.Blocks.Block3125369.header, Fixtures.Blocks.Block3125369.body)

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerFixture.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerFixture.scala
@@ -101,7 +101,7 @@ class JsonRpcControllerFixture(implicit system: ActorSystem)
     getTransactionFromPoolTimeout
   )
 
-  val ethBlocksService = new EthBlocksService(blockchain, blockchainReader, consensus)
+  val ethBlocksService = new EthBlocksService(blockchain, blockchainReader, consensus, blockQueue)
 
   val ethTxService = new EthTxService(
     blockchain,

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerFixture.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerFixture.scala
@@ -15,7 +15,6 @@ import io.iohk.ethereum.domain.{Block, BlockBody, SignedTransaction}
 import io.iohk.ethereum.jsonrpc.server.controllers.JsonRpcBaseController.JsonRpcConfig
 import io.iohk.ethereum.keystore.KeyStore
 import io.iohk.ethereum.ledger.{BloomFilter, InMemoryWorldStateProxy, StxLedger}
-import io.iohk.ethereum.mpt.MerklePatriciaTrie
 import io.iohk.ethereum.network.p2p.messages.Capability
 import io.iohk.ethereum.nodebuilder.ApisBuilder
 import io.iohk.ethereum.utils.{Config, FilterConfig}
@@ -45,6 +44,7 @@ class JsonRpcControllerFixture(implicit system: ActorSystem)
   val blockGenerator = mock[PoWBlockGenerator]
 
   val syncingController = TestProbe()
+
   override lazy val stxLedger = mock[StxLedger]
   override lazy val validators = mock[ValidatorsExecutor]
   (() => validators.signedTransactionValidator)


### PR DESCRIPTION

# Description

Enhance the test ChainAtoChainB_difficultyB.
Currently, the test can't completely pass due to a missing feature: transactions are not executed on blocks that are not part of the canonical blockchain.

# Proposed Solution

- a block insertion on an alternate chain is now valid and queryable by hash
- fields s, r and v in EthTransactionResponse are now pruned from leading 0.

# Testing

The test `BlockchainTests/ValidBlocks/bcMultiChainTest/ChainAtoChainB_difficultyB` fails later, on the storage check, instead at the first insertion of a block on the non-canonical (best) chain.

```
Request: {"jsonrpc":"2.0","method":"debug_storageRangeAt","params":["3", 2, "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b", "0x0000000000000000000000000000000000000000000000000000000000000000", 20],"id":26}
Reply: {"jsonrpc":"2.0","result":{"complete":true,"storage":{}},"id":26}
Error: Compare States: Missing expected address: '0x095e7baea6a6c7c4c2dfeb977efac326af552d87' (bcMultiChainTest/ChainAtoChainB_difficultyB_Istanbul, fork: Istanbul, block: 5)
Error: CompareStates failed with errors: MissingExpectedAccount (bcMultiChainTest/ChainAtoChainB_difficultyB_Istanbul, fork: Istanbul, block: 5)
```
