### PR TITLE
[ETCM-943] partially split reading part of Blockchain

### DIFF
--- a/src/it/scala/io/iohk/ethereum/ledger/BlockImporterItSpec.scala
+++ b/src/it/scala/io/iohk/ethereum/ledger/BlockImporterItSpec.scala
@@ -82,7 +82,7 @@ class BlockImporterItSpec
 
   override lazy val ledger = new TestLedgerImpl(successValidators) {
     override private[ledger] lazy val blockExecution =
-      new BlockExecution(blockchain, blockchainConfig, consensus.blockPreparator, blockValidation) {
+      new BlockExecution(blockchain, blockchainReader, blockchainConfig, consensus.blockPreparator, blockValidation) {
         override def executeAndValidateBlock(
             block: Block,
             alreadyValidated: Boolean = false

--- a/src/it/scala/io/iohk/ethereum/sync/RegularSyncItSpec.scala
+++ b/src/it/scala/io/iohk/ethereum/sync/RegularSyncItSpec.scala
@@ -127,7 +127,7 @@ class RegularSyncItSpec extends FreeSpecBase with Matchers with BeforeAndAfterAl
       _ <- peer2.importBlocksUntil(30)(IdentityUpdate)
       _ <- peer1.startRegularSync()
       _ <- peer2.startRegularSync()
-      _ <- peer2.addCheckpointedBlock(peer2.bl.getBlockByNumber(25).get)
+      _ <- peer2.addCheckpointedBlock(peer2.blockchainReader.getBlockByNumber(25).get)
       _ <- peer2.waitForRegularSyncLoadLastBlock(length)
       _ <- peer1.connectToPeers(Set(peer2.node))
       _ <- peer1.waitForRegularSyncLoadLastBlock(length)
@@ -188,7 +188,10 @@ class RegularSyncItSpec extends FreeSpecBase with Matchers with BeforeAndAfterAl
           peer2.bl.getBestBlock().get.hash
         )
       )
-      (peer1.bl.getBlockByNumber(blockNumer + 1), peer2.bl.getBlockByNumber(blockNumer + 1)) match {
+      (
+        peer1.blockchainReader.getBlockByNumber(blockNumer + 1),
+        peer2.blockchainReader.getBlockByNumber(blockNumer + 1)
+      ) match {
         case (Some(blockP1), Some(blockP2)) =>
           assert(peer1.bl.getChainWeightByHash(blockP1.hash) == peer2.bl.getChainWeightByHash(blockP2.hash))
         case (_, _) => fail("invalid difficulty validation")

--- a/src/it/scala/io/iohk/ethereum/sync/util/CommonFakePeer.scala
+++ b/src/it/scala/io/iohk/ethereum/sync/util/CommonFakePeer.scala
@@ -115,7 +115,8 @@ abstract class CommonFakePeer(peerName: String, fakePeerCustomConfig: FakePeerCu
     )
   )
 
-  val blockchainReader = new BlockchainReader(storagesInstance.storages.blockHeadersStorage)
+  val blockchainReader =
+    new BlockchainReader(storagesInstance.storages.blockHeadersStorage, storagesInstance.storages.blockBodiesStorage)
   val bl = BlockchainImpl(storagesInstance.storages, blockchainReader)
   val evmCodeStorage = storagesInstance.storages.evmCodeStorage
 

--- a/src/it/scala/io/iohk/ethereum/sync/util/CommonFakePeer.scala
+++ b/src/it/scala/io/iohk/ethereum/sync/util/CommonFakePeer.scala
@@ -116,7 +116,11 @@ abstract class CommonFakePeer(peerName: String, fakePeerCustomConfig: FakePeerCu
   )
 
   val blockchainReader =
-    new BlockchainReader(storagesInstance.storages.blockHeadersStorage, storagesInstance.storages.blockBodiesStorage)
+    new BlockchainReader(
+      storagesInstance.storages.blockHeadersStorage,
+      storagesInstance.storages.blockBodiesStorage,
+      storagesInstance.storages.blockNumberMappingStorage
+    )
   val bl = BlockchainImpl(storagesInstance.storages, blockchainReader)
   val evmCodeStorage = storagesInstance.storages.evmCodeStorage
 
@@ -170,7 +174,8 @@ abstract class CommonFakePeer(peerName: String, fakePeerCustomConfig: FakePeerCu
       override val forkResolverOpt: Option[ForkResolver] = None
       override val nodeStatusHolder: AtomicReference[NodeStatus] = nh
       override val peerConfiguration: PeerConfiguration = peerConf
-      override val blockchain: Blockchain = bl
+      override val blockchain: Blockchain = CommonFakePeer.this.bl
+      override val blockchainReader: BlockchainReader = CommonFakePeer.this.blockchainReader
       override val appStateStorage: AppStateStorage = storagesInstance.storages.appStateStorage
       override val capabilities: List[Capability] = blockchainConfig.capabilities
     }

--- a/src/it/scala/io/iohk/ethereum/sync/util/CommonFakePeer.scala
+++ b/src/it/scala/io/iohk/ethereum/sync/util/CommonFakePeer.scala
@@ -208,7 +208,7 @@ abstract class CommonFakePeer(peerName: String, fakePeerCustomConfig: FakePeerCu
   val blockchainHost: ActorRef =
     system.actorOf(
       BlockchainHostActor
-        .props(bl, blockchainReader, storagesInstance.storages.evmCodeStorage, peerConf, peerEventBus, etcPeerManager),
+        .props(blockchainReader, storagesInstance.storages.evmCodeStorage, peerConf, peerEventBus, etcPeerManager),
       "blockchain-host"
     )
 

--- a/src/it/scala/io/iohk/ethereum/sync/util/CommonFakePeer.scala
+++ b/src/it/scala/io/iohk/ethereum/sync/util/CommonFakePeer.scala
@@ -115,12 +115,7 @@ abstract class CommonFakePeer(peerName: String, fakePeerCustomConfig: FakePeerCu
     )
   )
 
-  val blockchainReader =
-    new BlockchainReader(
-      storagesInstance.storages.blockHeadersStorage,
-      storagesInstance.storages.blockBodiesStorage,
-      storagesInstance.storages.blockNumberMappingStorage
-    )
+  val blockchainReader = BlockchainReader(storagesInstance.storages)
   val bl = BlockchainImpl(storagesInstance.storages, blockchainReader)
   val evmCodeStorage = storagesInstance.storages.evmCodeStorage
 

--- a/src/it/scala/io/iohk/ethereum/sync/util/CommonFakePeer.scala
+++ b/src/it/scala/io/iohk/ethereum/sync/util/CommonFakePeer.scala
@@ -14,7 +14,7 @@ import io.iohk.ethereum.db.components.{RocksDbDataSourceComponent, Storages}
 import io.iohk.ethereum.db.dataSource.{RocksDbConfig, RocksDbDataSource}
 import io.iohk.ethereum.db.storage.pruning.{ArchivePruning, PruningMode}
 import io.iohk.ethereum.db.storage.{AppStateStorage, Namespaces}
-import io.iohk.ethereum.domain.{Block, Blockchain, BlockchainImpl, ChainWeight}
+import io.iohk.ethereum.domain.{Block, Blockchain, BlockchainImpl, BlockchainReader, ChainWeight}
 import io.iohk.ethereum.security.SecureRandomBuilder
 import io.iohk.ethereum.ledger.InMemoryWorldStateProxy
 import io.iohk.ethereum.mpt.MerklePatriciaTrie
@@ -115,7 +115,8 @@ abstract class CommonFakePeer(peerName: String, fakePeerCustomConfig: FakePeerCu
     )
   )
 
-  val bl = BlockchainImpl(storagesInstance.storages)
+  val blockchainReader = new BlockchainReader(storagesInstance.storages.blockHeadersStorage)
+  val bl = BlockchainImpl(storagesInstance.storages, blockchainReader)
   val evmCodeStorage = storagesInstance.storages.evmCodeStorage
 
   val genesis = Block(
@@ -205,7 +206,8 @@ abstract class CommonFakePeer(peerName: String, fakePeerCustomConfig: FakePeerCu
 
   val blockchainHost: ActorRef =
     system.actorOf(
-      BlockchainHostActor.props(bl, storagesInstance.storages.evmCodeStorage, peerConf, peerEventBus, etcPeerManager),
+      BlockchainHostActor
+        .props(bl, blockchainReader, storagesInstance.storages.evmCodeStorage, peerConf, peerEventBus, etcPeerManager),
       "blockchain-host"
     )
 

--- a/src/it/scala/io/iohk/ethereum/sync/util/FastSyncItSpecUtils.scala
+++ b/src/it/scala/io/iohk/ethereum/sync/util/FastSyncItSpecUtils.scala
@@ -29,6 +29,7 @@ object FastSyncItSpecUtils {
         storagesInstance.storages.fastSyncStateStorage,
         storagesInstance.storages.appStateStorage,
         bl,
+        blockchainReader,
         storagesInstance.storages.evmCodeStorage,
         storagesInstance.storages.nodeStorage,
         validators,

--- a/src/it/scala/io/iohk/ethereum/sync/util/RegularSyncItSpecUtils.scala
+++ b/src/it/scala/io/iohk/ethereum/sync/util/RegularSyncItSpecUtils.scala
@@ -149,7 +149,9 @@ object RegularSyncItSpecUtils {
     )(updateWorldForBlock: (BigInt, InMemoryWorldStateProxy) => InMemoryWorldStateProxy): Task[Unit] = {
       Task(blockNumber match {
         case Some(bNumber) =>
-          bl.getBlockByNumber(bNumber).getOrElse(throw new RuntimeException(s"block by number: $bNumber doesn't exist"))
+          blockchainReader
+            .getBlockByNumber(bNumber)
+            .getOrElse(throw new RuntimeException(s"block by number: $bNumber doesn't exist"))
         case None => bl.getBestBlock().get
       }).flatMap { block =>
         Task {

--- a/src/it/scala/io/iohk/ethereum/sync/util/RegularSyncItSpecUtils.scala
+++ b/src/it/scala/io/iohk/ethereum/sync/util/RegularSyncItSpecUtils.scala
@@ -61,7 +61,15 @@ object RegularSyncItSpecUtils {
       val fullConfig = FullConsensusConfig(consensusConfig, specificConfig)
       val vm = VmSetup.vm(VmConfig(config), blockchainConfig, testMode = false)
       val consensus =
-        PoWConsensus(vm, bl, blockchainConfig, fullConfig, ValidatorsExecutorAlwaysSucceed, NoAdditionalPoWData)
+        PoWConsensus(
+          vm,
+          bl,
+          blockchainReader,
+          blockchainConfig,
+          fullConfig,
+          ValidatorsExecutorAlwaysSucceed,
+          NoAdditionalPoWData
+        )
       consensus
     }
 
@@ -73,9 +81,9 @@ object RegularSyncItSpecUtils {
       )
 
     lazy val ledger: Ledger =
-      new LedgerImpl(bl, blockchainConfig, syncConfig, buildEthashConsensus(), Scheduler.global)
+      new LedgerImpl(bl, blockchainReader, blockchainConfig, syncConfig, buildEthashConsensus(), Scheduler.global)
 
-    lazy val ommersPool: ActorRef = system.actorOf(OmmersPool.props(bl, 1), "ommers-pool")
+    lazy val ommersPool: ActorRef = system.actorOf(OmmersPool.props(blockchainReader, 1), "ommers-pool")
 
     lazy val pendingTransactionsManager: ActorRef = system.actorOf(
       PendingTransactionsManager.props(TxPoolConfig(config), peerManager, etcPeerManager, peerEventBus),

--- a/src/it/scala/io/iohk/ethereum/txExecTest/ContractTest.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/ContractTest.scala
@@ -25,7 +25,7 @@ class ContractTest extends AnyFlatSpec with Matchers {
 
     //block only with ether transfers
     val blockValidation =
-      new BlockValidation(consensus, blockchain, blockchainReader, BlockQueue(blockchain, syncConfig))
+      new BlockValidation(consensus, blockchainReader, BlockQueue(blockchain, syncConfig))
     val blockExecution =
       new BlockExecution(blockchain, blockchainReader, blockchainConfig, consensus.blockPreparator, blockValidation)
     blockExecution.executeAndValidateBlock(fixtures.blockByNumber(1)) shouldBe noErrors
@@ -38,7 +38,7 @@ class ContractTest extends AnyFlatSpec with Matchers {
 
     //contract creation
     val blockValidation =
-      new BlockValidation(consensus, blockchain, blockchainReader, BlockQueue(blockchain, syncConfig))
+      new BlockValidation(consensus, blockchainReader, BlockQueue(blockchain, syncConfig))
     val blockExecution =
       new BlockExecution(blockchain, blockchainReader, blockchainConfig, consensus.blockPreparator, blockValidation)
     blockExecution.executeAndValidateBlock(fixtures.blockByNumber(2)) shouldBe noErrors
@@ -51,7 +51,7 @@ class ContractTest extends AnyFlatSpec with Matchers {
 
     //block with ether transfers and contract call
     val blockValidation =
-      new BlockValidation(consensus, blockchain, blockchainReader, BlockQueue(blockchain, syncConfig))
+      new BlockValidation(consensus, blockchainReader, BlockQueue(blockchain, syncConfig))
     val blockExecution =
       new BlockExecution(blockchain, blockchainReader, blockchainConfig, consensus.blockPreparator, blockValidation)
     blockExecution.executeAndValidateBlock(fixtures.blockByNumber(3)) shouldBe noErrors
@@ -64,7 +64,7 @@ class ContractTest extends AnyFlatSpec with Matchers {
 
     //block contains contract paying 2 accounts
     val blockValidation =
-      new BlockValidation(consensus, blockchain, blockchainReader, BlockQueue(blockchain, syncConfig))
+      new BlockValidation(consensus, blockchainReader, BlockQueue(blockchain, syncConfig))
     val blockExecution =
       new BlockExecution(blockchain, blockchainReader, blockchainConfig, consensus.blockPreparator, blockValidation)
     blockExecution.executeAndValidateBlock(fixtures.blockByNumber(3)) shouldBe noErrors

--- a/src/it/scala/io/iohk/ethereum/txExecTest/ContractTest.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/ContractTest.scala
@@ -24,8 +24,10 @@ class ContractTest extends AnyFlatSpec with Matchers {
     val testBlockchainStorages = FixtureProvider.prepareStorages(0, fixtures)
 
     //block only with ether transfers
-    val blockValidation = new BlockValidation(consensus, blockchain, BlockQueue(blockchain, syncConfig))
-    val blockExecution = new BlockExecution(blockchain, blockchainConfig, consensus.blockPreparator, blockValidation)
+    val blockValidation =
+      new BlockValidation(consensus, blockchain, blockchainReader, BlockQueue(blockchain, syncConfig))
+    val blockExecution =
+      new BlockExecution(blockchain, blockchainReader, blockchainConfig, consensus.blockPreparator, blockValidation)
     blockExecution.executeAndValidateBlock(fixtures.blockByNumber(1)) shouldBe noErrors
   }
 
@@ -35,8 +37,10 @@ class ContractTest extends AnyFlatSpec with Matchers {
     val testBlockchainStorages = FixtureProvider.prepareStorages(1, fixtures)
 
     //contract creation
-    val blockValidation = new BlockValidation(consensus, blockchain, BlockQueue(blockchain, syncConfig))
-    val blockExecution = new BlockExecution(blockchain, blockchainConfig, consensus.blockPreparator, blockValidation)
+    val blockValidation =
+      new BlockValidation(consensus, blockchain, blockchainReader, BlockQueue(blockchain, syncConfig))
+    val blockExecution =
+      new BlockExecution(blockchain, blockchainReader, blockchainConfig, consensus.blockPreparator, blockValidation)
     blockExecution.executeAndValidateBlock(fixtures.blockByNumber(2)) shouldBe noErrors
   }
 
@@ -46,8 +50,10 @@ class ContractTest extends AnyFlatSpec with Matchers {
     val testBlockchainStorages = FixtureProvider.prepareStorages(2, fixtures)
 
     //block with ether transfers and contract call
-    val blockValidation = new BlockValidation(consensus, blockchain, BlockQueue(blockchain, syncConfig))
-    val blockExecution = new BlockExecution(blockchain, blockchainConfig, consensus.blockPreparator, blockValidation)
+    val blockValidation =
+      new BlockValidation(consensus, blockchain, blockchainReader, BlockQueue(blockchain, syncConfig))
+    val blockExecution =
+      new BlockExecution(blockchain, blockchainReader, blockchainConfig, consensus.blockPreparator, blockValidation)
     blockExecution.executeAndValidateBlock(fixtures.blockByNumber(3)) shouldBe noErrors
   }
 
@@ -57,8 +63,10 @@ class ContractTest extends AnyFlatSpec with Matchers {
     val testBlockchainStorages = FixtureProvider.prepareStorages(2, fixtures)
 
     //block contains contract paying 2 accounts
-    val blockValidation = new BlockValidation(consensus, blockchain, BlockQueue(blockchain, syncConfig))
-    val blockExecution = new BlockExecution(blockchain, blockchainConfig, consensus.blockPreparator, blockValidation)
+    val blockValidation =
+      new BlockValidation(consensus, blockchain, blockchainReader, BlockQueue(blockchain, syncConfig))
+    val blockExecution =
+      new BlockExecution(blockchain, blockchainReader, blockchainConfig, consensus.blockPreparator, blockValidation)
     blockExecution.executeAndValidateBlock(fixtures.blockByNumber(3)) shouldBe noErrors
   }
 }

--- a/src/it/scala/io/iohk/ethereum/txExecTest/ECIP1017Test.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/ECIP1017Test.scala
@@ -79,7 +79,7 @@ class ECIP1017Test extends AnyFlatSpec with Matchers {
       val blockchainReader = BlockchainReader(storages)
       val blockchain = BlockchainImpl(storages, blockchainReader)
       val blockValidation =
-        new BlockValidation(consensus, blockchain, blockchainReader, BlockQueue(blockchain, syncConfig))
+        new BlockValidation(consensus, blockchainReader, BlockQueue(blockchain, syncConfig))
       val blockExecution =
         new BlockExecution(blockchain, blockchainReader, blockchainConfig, consensus.blockPreparator, blockValidation)
       blockExecution.executeAndValidateBlock(fixtures.blockByNumber(blockToExecute)) shouldBe noErrors

--- a/src/it/scala/io/iohk/ethereum/txExecTest/ECIP1017Test.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/ECIP1017Test.scala
@@ -76,11 +76,7 @@ class ECIP1017Test extends AnyFlatSpec with Matchers {
 
     (startBlock to endBlock) foreach { blockToExecute =>
       val storages = FixtureProvider.prepareStorages(blockToExecute - 1, fixtures)
-      val blockchainReader = new BlockchainReader(
-        storages.blockHeadersStorage,
-        storages.blockBodiesStorage,
-        storages.blockNumberMappingStorage
-      )
+      val blockchainReader = BlockchainReader(storages)
       val blockchain = BlockchainImpl(storages, blockchainReader)
       val blockValidation =
         new BlockValidation(consensus, blockchain, blockchainReader, BlockQueue(blockchain, syncConfig))

--- a/src/it/scala/io/iohk/ethereum/txExecTest/ECIP1017Test.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/ECIP1017Test.scala
@@ -76,7 +76,11 @@ class ECIP1017Test extends AnyFlatSpec with Matchers {
 
     (startBlock to endBlock) foreach { blockToExecute =>
       val storages = FixtureProvider.prepareStorages(blockToExecute - 1, fixtures)
-      val blockchainReader = new BlockchainReader(storages.blockHeadersStorage, storages.blockBodiesStorage)
+      val blockchainReader = new BlockchainReader(
+        storages.blockHeadersStorage,
+        storages.blockBodiesStorage,
+        storages.blockNumberMappingStorage
+      )
       val blockchain = BlockchainImpl(storages, blockchainReader)
       val blockValidation =
         new BlockValidation(consensus, blockchain, blockchainReader, BlockQueue(blockchain, syncConfig))

--- a/src/it/scala/io/iohk/ethereum/txExecTest/ECIP1017Test.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/ECIP1017Test.scala
@@ -76,7 +76,7 @@ class ECIP1017Test extends AnyFlatSpec with Matchers {
 
     (startBlock to endBlock) foreach { blockToExecute =>
       val storages = FixtureProvider.prepareStorages(blockToExecute - 1, fixtures)
-      val blockchainReader = new BlockchainReader(storages.blockHeadersStorage)
+      val blockchainReader = new BlockchainReader(storages.blockHeadersStorage, storages.blockBodiesStorage)
       val blockchain = BlockchainImpl(storages, blockchainReader)
       val blockValidation =
         new BlockValidation(consensus, blockchain, blockchainReader, BlockQueue(blockchain, syncConfig))

--- a/src/it/scala/io/iohk/ethereum/txExecTest/ForksTest.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/ForksTest.scala
@@ -67,11 +67,7 @@ class ForksTest extends AnyFlatSpec with Matchers {
 
     (startBlock to endBlock) foreach { blockToExecute =>
       val storages = FixtureProvider.prepareStorages(blockToExecute - 1, fixtures)
-      val blockchainReader = new BlockchainReader(
-        storages.blockHeadersStorage,
-        storages.blockBodiesStorage,
-        storages.blockNumberMappingStorage
-      )
+      val blockchainReader = BlockchainReader(storages)
       val blockchain = BlockchainImpl(storages, blockchainReader)
       val blockValidation =
         new BlockValidation(consensus, blockchain, blockchainReader, BlockQueue(blockchain, syncConfig))

--- a/src/it/scala/io/iohk/ethereum/txExecTest/ForksTest.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/ForksTest.scala
@@ -67,7 +67,11 @@ class ForksTest extends AnyFlatSpec with Matchers {
 
     (startBlock to endBlock) foreach { blockToExecute =>
       val storages = FixtureProvider.prepareStorages(blockToExecute - 1, fixtures)
-      val blockchainReader = new BlockchainReader(storages.blockHeadersStorage, storages.blockBodiesStorage)
+      val blockchainReader = new BlockchainReader(
+        storages.blockHeadersStorage,
+        storages.blockBodiesStorage,
+        storages.blockNumberMappingStorage
+      )
       val blockchain = BlockchainImpl(storages, blockchainReader)
       val blockValidation =
         new BlockValidation(consensus, blockchain, blockchainReader, BlockQueue(blockchain, syncConfig))

--- a/src/it/scala/io/iohk/ethereum/txExecTest/ForksTest.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/ForksTest.scala
@@ -70,7 +70,7 @@ class ForksTest extends AnyFlatSpec with Matchers {
       val blockchainReader = BlockchainReader(storages)
       val blockchain = BlockchainImpl(storages, blockchainReader)
       val blockValidation =
-        new BlockValidation(consensus, blockchain, blockchainReader, BlockQueue(blockchain, syncConfig))
+        new BlockValidation(consensus, blockchainReader, BlockQueue(blockchain, syncConfig))
       val blockExecution =
         new BlockExecution(blockchain, blockchainReader, blockchainConfig, consensus.blockPreparator, blockValidation)
       blockExecution.executeAndValidateBlock(fixtures.blockByNumber(blockToExecute)) shouldBe noErrors

--- a/src/it/scala/io/iohk/ethereum/txExecTest/ForksTest.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/ForksTest.scala
@@ -67,7 +67,7 @@ class ForksTest extends AnyFlatSpec with Matchers {
 
     (startBlock to endBlock) foreach { blockToExecute =>
       val storages = FixtureProvider.prepareStorages(blockToExecute - 1, fixtures)
-      val blockchainReader = new BlockchainReader(storages.blockHeadersStorage)
+      val blockchainReader = new BlockchainReader(storages.blockHeadersStorage, storages.blockBodiesStorage)
       val blockchain = BlockchainImpl(storages, blockchainReader)
       val blockValidation =
         new BlockValidation(consensus, blockchain, blockchainReader, BlockQueue(blockchain, syncConfig))

--- a/src/it/scala/io/iohk/ethereum/txExecTest/ForksTest.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/ForksTest.scala
@@ -1,7 +1,7 @@
 package io.iohk.ethereum.txExecTest
 
 import java.util.concurrent.Executors
-import io.iohk.ethereum.domain.{Address, BlockchainImpl, Receipt, UInt256}
+import io.iohk.ethereum.domain.{Address, BlockchainImpl, BlockchainReader, Receipt, UInt256}
 import io.iohk.ethereum.ledger.{BlockExecution, BlockQueue, BlockValidation}
 import io.iohk.ethereum.txExecTest.util.FixtureProvider
 import io.iohk.ethereum.utils.{BlockchainConfig, ForkBlockNumbers, MonetaryPolicyConfig}
@@ -67,9 +67,12 @@ class ForksTest extends AnyFlatSpec with Matchers {
 
     (startBlock to endBlock) foreach { blockToExecute =>
       val storages = FixtureProvider.prepareStorages(blockToExecute - 1, fixtures)
-      val blockchain = BlockchainImpl(storages)
-      val blockValidation = new BlockValidation(consensus, blockchain, BlockQueue(blockchain, syncConfig))
-      val blockExecution = new BlockExecution(blockchain, blockchainConfig, consensus.blockPreparator, blockValidation)
+      val blockchainReader = new BlockchainReader(storages.blockHeadersStorage)
+      val blockchain = BlockchainImpl(storages, blockchainReader)
+      val blockValidation =
+        new BlockValidation(consensus, blockchain, blockchainReader, BlockQueue(blockchain, syncConfig))
+      val blockExecution =
+        new BlockExecution(blockchain, blockchainReader, blockchainConfig, consensus.blockPreparator, blockValidation)
       blockExecution.executeAndValidateBlock(fixtures.blockByNumber(blockToExecute)) shouldBe noErrors
     }
   }

--- a/src/it/scala/io/iohk/ethereum/txExecTest/ScenarioSetup.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/ScenarioSetup.scala
@@ -7,11 +7,7 @@ import io.iohk.ethereum.ledger.Ledger.VMImpl
 trait ScenarioSetup extends sync.ScenarioSetup {
   protected val testBlockchainStorages: BlockchainStorages
 
-  override lazy val blockchainReader: BlockchainReader = new BlockchainReader(
-    testBlockchainStorages.blockHeadersStorage,
-    testBlockchainStorages.blockBodiesStorage,
-    testBlockchainStorages.blockNumberMappingStorage
-  )
+  override lazy val blockchainReader: BlockchainReader = BlockchainReader(testBlockchainStorages)
   override lazy val blockchain: BlockchainImpl = BlockchainImpl(testBlockchainStorages, blockchainReader)
   override lazy val vm: VMImpl = new VMImpl
 }

--- a/src/it/scala/io/iohk/ethereum/txExecTest/ScenarioSetup.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/ScenarioSetup.scala
@@ -9,7 +9,8 @@ trait ScenarioSetup extends sync.ScenarioSetup {
 
   override lazy val blockchainReader: BlockchainReader = new BlockchainReader(
     testBlockchainStorages.blockHeadersStorage,
-    testBlockchainStorages.blockBodiesStorage
+    testBlockchainStorages.blockBodiesStorage,
+    testBlockchainStorages.blockNumberMappingStorage
   )
   override lazy val blockchain: BlockchainImpl = BlockchainImpl(testBlockchainStorages, blockchainReader)
   override lazy val vm: VMImpl = new VMImpl

--- a/src/it/scala/io/iohk/ethereum/txExecTest/ScenarioSetup.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/ScenarioSetup.scala
@@ -8,7 +8,8 @@ trait ScenarioSetup extends sync.ScenarioSetup {
   protected val testBlockchainStorages: BlockchainStorages
 
   override lazy val blockchainReader: BlockchainReader = new BlockchainReader(
-    testBlockchainStorages.blockHeadersStorage
+    testBlockchainStorages.blockHeadersStorage,
+    testBlockchainStorages.blockBodiesStorage
   )
   override lazy val blockchain: BlockchainImpl = BlockchainImpl(testBlockchainStorages, blockchainReader)
   override lazy val vm: VMImpl = new VMImpl

--- a/src/it/scala/io/iohk/ethereum/txExecTest/ScenarioSetup.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/ScenarioSetup.scala
@@ -1,12 +1,15 @@
 package io.iohk.ethereum.txExecTest
 
 import io.iohk.ethereum.blockchain.sync
-import io.iohk.ethereum.domain.{BlockchainImpl, BlockchainStorages}
+import io.iohk.ethereum.domain.{BlockchainImpl, BlockchainReader, BlockchainStorages}
 import io.iohk.ethereum.ledger.Ledger.VMImpl
 
 trait ScenarioSetup extends sync.ScenarioSetup {
   protected val testBlockchainStorages: BlockchainStorages
 
-  override lazy val blockchain: BlockchainImpl = BlockchainImpl(testBlockchainStorages)
+  override lazy val blockchainReader: BlockchainReader = new BlockchainReader(
+    testBlockchainStorages.blockHeadersStorage
+  )
+  override lazy val blockchain: BlockchainImpl = BlockchainImpl(testBlockchainStorages, blockchainReader)
   override lazy val vm: VMImpl = new VMImpl
 }

--- a/src/it/scala/io/iohk/ethereum/txExecTest/util/DumpChainApp.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/util/DumpChainApp.scala
@@ -8,14 +8,13 @@ import com.typesafe.config.ConfigFactory
 import io.iohk.ethereum.blockchain.sync.CacheBasedBlacklist
 import io.iohk.ethereum.db.components.Storages.PruningModeComponent
 import io.iohk.ethereum.db.components.{RocksDbDataSourceComponent, Storages}
-import io.iohk.ethereum.db.dataSource.{DataSourceBatchUpdate, RocksDbDataSource}
+import io.iohk.ethereum.db.dataSource.{DataSourceBatchUpdate}
 import io.iohk.ethereum.db.storage.NodeStorage.{NodeEncoded, NodeHash}
-import io.iohk.ethereum.db.storage.TransactionMappingStorage.TransactionLocation
 import io.iohk.ethereum.db.storage.pruning.{ArchivePruning, PruningMode}
-import io.iohk.ethereum.db.storage.{AppStateStorage, StateStorage}
+import io.iohk.ethereum.db.storage.AppStateStorage
 import io.iohk.ethereum.domain.BlockHeader.HeaderExtraFields.HefEmpty
 import io.iohk.ethereum.domain.{Blockchain, UInt256, _}
-import io.iohk.ethereum.jsonrpc.ProofService.{EmptyStorageValueProof, StorageProof, StorageProofKey, StorageValueProof}
+import io.iohk.ethereum.jsonrpc.ProofService.{EmptyStorageValueProof, StorageProof, StorageProofKey}
 import io.iohk.ethereum.ledger.{InMemoryWorldStateProxy, InMemoryWorldStateProxyStorage}
 import io.iohk.ethereum.mpt.MptNode
 import io.iohk.ethereum.network.EtcPeerManagerActor.PeerInfo
@@ -23,16 +22,13 @@ import io.iohk.ethereum.network.PeerManagerActor.PeerConfiguration
 import io.iohk.ethereum.network.PeerStatisticsActor
 import io.iohk.ethereum.network.discovery.DiscoveryConfig
 import io.iohk.ethereum.network.handshaker.{EtcHandshaker, EtcHandshakerConfiguration, Handshaker}
-import io.iohk.ethereum.network.p2p.EthereumMessageDecoder
 import io.iohk.ethereum.network.p2p.messages.Capability
 import io.iohk.ethereum.network.rlpx.RLPxConnectionHandler.RLPxConfiguration
 import io.iohk.ethereum.network.{ForkResolver, PeerEventBusActor, PeerManagerActor}
 import io.iohk.ethereum.nodebuilder.{AuthHandshakerBuilder, NodeKeyBuilder}
 import io.iohk.ethereum.security.SecureRandomBuilder
 import io.iohk.ethereum.utils.{Config, NodeStatus, ServerStatus}
-import monix.reactive.Observable
 import org.bouncycastle.util.encoders.Hex
-import org.scalamock.clazz.Mock
 import org.scalamock.scalatest.MockFactory
 
 import scala.concurrent.duration._

--- a/src/it/scala/io/iohk/ethereum/txExecTest/util/DumpChainApp.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/util/DumpChainApp.scala
@@ -182,8 +182,6 @@ class BlockchainMock(genesisHash: ByteString) extends Blockchain {
 
   override def getChainWeightByHash(blockhash: ByteString): Option[ChainWeight] = ???
 
-  override def getReceiptsByHash(blockhash: ByteString): Option[Seq[Receipt]] = ???
-
   def getAccount(address: Address, blockNumber: BigInt): Option[Account] = ???
 
   override def getAccountStorageAt(rootHash: ByteString, position: BigInt, ethCompatibleStorage: Boolean): ByteString =

--- a/src/it/scala/io/iohk/ethereum/txExecTest/util/DumpChainApp.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/util/DumpChainApp.scala
@@ -158,8 +158,6 @@ class BlockchainMock(genesisHash: ByteString) extends Blockchain {
 
   override protected def getHashByBlockNumber(number: BigInt): Option[ByteString] = Some(genesisHash)
 
-  override def getBlockHeaderByHash(hash: ByteString): Option[BlockHeader] = Some(new FakeHeader())
-
   override def getBlockBodyByHash(hash: ByteString): Option[BlockBody] = ???
 
   override def getMptNodeByHash(hash: ByteString): Option[MptNode] = ???
@@ -217,4 +215,10 @@ class BlockchainMock(genesisHash: ByteString) extends Blockchain {
   override def save(block: Block, receipts: Seq[Receipt], weight: ChainWeight, saveAsBestBlock: Boolean): Unit = ???
 
   override def getLatestCheckpointBlockNumber(): BigInt = ???
+
+  override def getBlockHeaderByNumber(number: BigInt): Option[BlockHeader] = ???
+
+  override def getBlockByHash(hash: NodeHash): Option[Block] = ???
+
+  override def isInChain(hash: NodeHash): Boolean = ???
 }

--- a/src/it/scala/io/iohk/ethereum/txExecTest/util/DumpChainApp.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/util/DumpChainApp.scala
@@ -158,8 +158,6 @@ class BlockchainMock(genesisHash: ByteString) extends Blockchain {
 
   override protected def getHashByBlockNumber(number: BigInt): Option[ByteString] = Some(genesisHash)
 
-  override def getBlockBodyByHash(hash: ByteString): Option[BlockBody] = ???
-
   override def getMptNodeByHash(hash: ByteString): Option[MptNode] = ???
 
   override def storeBlockHeader(blockHeader: BlockHeader): DataSourceBatchUpdate = ???
@@ -218,7 +216,7 @@ class BlockchainMock(genesisHash: ByteString) extends Blockchain {
 
   override def getBlockHeaderByNumber(number: BigInt): Option[BlockHeader] = ???
 
-  override def getBlockByHash(hash: NodeHash): Option[Block] = ???
-
   override def isInChain(hash: NodeHash): Boolean = ???
+
+  override def getBlockByNumber(number: BigInt): Option[Block] = ???
 }

--- a/src/it/scala/io/iohk/ethereum/txExecTest/util/DumpChainApp.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/util/DumpChainApp.scala
@@ -166,8 +166,6 @@ class BlockchainMock(genesisHash: ByteString) extends Blockchain {
       ethCompatibleStorage: Boolean
   ): StorageProof = EmptyStorageValueProof(StorageProofKey(position))
 
-  override def getMptNodeByHash(hash: ByteString): Option[MptNode] = ???
-
   override def storeBlockHeader(blockHeader: BlockHeader): DataSourceBatchUpdate = ???
 
   override def storeBlockBody(blockHash: ByteString, blockBody: BlockBody): DataSourceBatchUpdate = ???

--- a/src/it/scala/io/iohk/ethereum/txExecTest/util/FixtureProvider.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/util/FixtureProvider.scala
@@ -65,7 +65,6 @@ object FixtureProvider {
     val blocksToInclude = fixtures.blockByNumber.toSeq.sortBy { case (number, _) => number }.takeWhile {
       case (number, _) => number <= blockNumber
     }
-    val blockchain = BlockchainImpl(storages)
 
     blocksToInclude.foreach { case (_, block) =>
       val receiptsUpdates = fixtures.receipts

--- a/src/main/scala/io/iohk/ethereum/blockchain/data/GenesisDataLoader.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/data/GenesisDataLoader.scala
@@ -23,8 +23,12 @@ import org.bouncycastle.util.encoders.Hex
 import scala.io.Source
 import scala.util.{Failure, Success, Try}
 
-class GenesisDataLoader(blockchain: Blockchain, stateStorage: StateStorage, blockchainConfig: BlockchainConfig)
-    extends Logger {
+class GenesisDataLoader(
+    blockchain: Blockchain,
+    blockchainReader: BlockchainReader,
+    stateStorage: StateStorage,
+    blockchainConfig: BlockchainConfig
+) extends Logger {
 
   private val bloomLength = 512
   private val hashLength = 64
@@ -99,7 +103,7 @@ class GenesisDataLoader(blockchain: Blockchain, stateStorage: StateStorage, bloc
 
     log.debug(s"Prepared genesis header: $header")
 
-    blockchain.getBlockHeaderByNumber(0) match {
+    blockchainReader.getBlockHeaderByNumber(0) match {
       case Some(existingGenesisHeader) if existingGenesisHeader.hash == header.hash =>
         log.debug("Genesis data already in the database")
         Success(())

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/BlockchainHostActor.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/BlockchainHostActor.scala
@@ -100,7 +100,7 @@ class BlockchainHostActor(
             startBlockNumber to (startBlockNumber + (request.skip + 1) * headersCount - 1) by (request.skip + 1)
           }
 
-          val blockHeaders: Seq[BlockHeader] = range.flatMap { a: BigInt => blockchain.getBlockHeaderByNumber(a) }
+          val blockHeaders: Seq[BlockHeader] = range.flatMap { a: BigInt => blockchainReader.getBlockHeaderByNumber(a) }
 
           Some(BlockHeaders(blockHeaders))
 

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/BlockchainHostActor.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/BlockchainHostActor.scala
@@ -54,7 +54,7 @@ class BlockchainHostActor(
 
       val nodeData: Seq[ByteString] = hashesRequested.flatMap { hash =>
         //Fetch mpt node by hash
-        val maybeMptNodeData = blockchain.getMptNodeByHash(hash).map(e => e.toBytes: ByteString)
+        val maybeMptNodeData = blockchainReader.getMptNodeByHash(hash).map(e => e.toBytes: ByteString)
 
         //If no mpt node was found, fetch evm by hash
         maybeMptNodeData.orElse(evmCodeStorage.get(hash))

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/BlockchainHostActor.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/BlockchainHostActor.scala
@@ -82,7 +82,7 @@ class BlockchainHostActor(
     case request: GetBlockBodies =>
       val blockBodies = request.hashes
         .take(peerConfiguration.fastSyncHostConfiguration.maxBlocksBodiesPerMessage)
-        .flatMap(hash => blockchain.getBlockBodyByHash(hash))
+        .flatMap(hash => blockchainReader.getBlockBodyByHash(hash))
 
       Some(BlockBodies(blockBodies))
 

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/BlockchainHostActor.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/BlockchainHostActor.scala
@@ -20,7 +20,6 @@ import io.iohk.ethereum.network.p2p.messages.Codes
   * node and block data.
   */
 class BlockchainHostActor(
-    blockchain: Blockchain,
     blockchainReader: BlockchainReader,
     evmCodeStorage: EvmCodeStorage,
     peerConfiguration: PeerConfiguration,
@@ -75,7 +74,7 @@ class BlockchainHostActor(
     case request: GetReceipts =>
       val receipts = request.blockHashes
         .take(peerConfiguration.fastSyncHostConfiguration.maxReceiptsPerMessage)
-        .flatMap(hash => blockchain.getReceiptsByHash(hash))
+        .flatMap(hash => blockchainReader.getReceiptsByHash(hash))
 
       Some(Receipts(receipts))
 
@@ -118,7 +117,6 @@ class BlockchainHostActor(
 object BlockchainHostActor {
 
   def props(
-      blockchain: Blockchain,
       blockchainReader: BlockchainReader,
       evmCodeStorage: EvmCodeStorage,
       peerConfiguration: PeerConfiguration,
@@ -127,7 +125,6 @@ object BlockchainHostActor {
   ): Props =
     Props(
       new BlockchainHostActor(
-        blockchain,
         blockchainReader,
         evmCodeStorage,
         peerConfiguration,

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/SyncController.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/SyncController.scala
@@ -5,13 +5,14 @@ import io.iohk.ethereum.blockchain.sync.fast.FastSync
 import io.iohk.ethereum.blockchain.sync.regular.RegularSync
 import io.iohk.ethereum.consensus.validators.Validators
 import io.iohk.ethereum.db.storage.{AppStateStorage, EvmCodeStorage, FastSyncStateStorage, NodeStorage}
-import io.iohk.ethereum.domain.Blockchain
+import io.iohk.ethereum.domain.{Blockchain, BlockchainReader}
 import io.iohk.ethereum.ledger.Ledger
 import io.iohk.ethereum.utils.Config.SyncConfig
 
 class SyncController(
     appStateStorage: AppStateStorage,
     blockchain: Blockchain,
+    blockchainReader: BlockchainReader,
     evmCodeStorage: EvmCodeStorage,
     nodeStorage: NodeStorage,
     fastSyncStateStorage: FastSyncStateStorage,
@@ -79,6 +80,7 @@ class SyncController(
         fastSyncStateStorage,
         appStateStorage,
         blockchain,
+        blockchainReader,
         evmCodeStorage,
         nodeStorage,
         validators,
@@ -124,6 +126,7 @@ object SyncController {
   def props(
       appStateStorage: AppStateStorage,
       blockchain: Blockchain,
+      blockchainReader: BlockchainReader,
       evmCodeStorage: EvmCodeStorage,
       nodeStorage: NodeStorage,
       syncStateStorage: FastSyncStateStorage,
@@ -140,6 +143,7 @@ object SyncController {
       new SyncController(
         appStateStorage,
         blockchain,
+        blockchainReader,
         evmCodeStorage,
         nodeStorage,
         syncStateStorage,

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/fast/FastSync.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/fast/FastSync.scala
@@ -149,7 +149,17 @@ class FastSync(
 
     private val branchResolver = context.actorOf(
       FastSyncBranchResolverActor
-        .props(self, peerEventBus, etcPeerManager, blockchain, blacklist, syncConfig, appStateStorage, scheduler),
+        .props(
+          self,
+          peerEventBus,
+          etcPeerManager,
+          blockchain,
+          blockchainReader,
+          blacklist,
+          syncConfig,
+          appStateStorage,
+          scheduler
+        ),
       s"$countActor-fast-sync-branch-resolver"
     )
 
@@ -543,7 +553,7 @@ class FastSync(
     // TODO [ETCM-676]: Move to blockchain and make sure it's atomic
     private def discardLastBlocks(startBlock: BigInt, blocksToDiscard: Int): Unit = {
       (startBlock to ((startBlock - blocksToDiscard) max 1) by -1).foreach { n =>
-        blockchain.getBlockHeaderByNumber(n).foreach { headerToRemove =>
+        blockchainReader.getBlockHeaderByNumber(n).foreach { headerToRemove =>
           blockchain.removeBlock(headerToRemove.hash, withState = false)
         }
       }

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/fast/FastSync.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/fast/FastSync.scala
@@ -48,6 +48,7 @@ class FastSync(
     val fastSyncStateStorage: FastSyncStateStorage,
     val appStateStorage: AppStateStorage,
     val blockchain: Blockchain,
+    val blockchainReader: BlockchainReader,
     evmCodeStorage: EvmCodeStorage,
     nodeStorage: NodeStorage,
     val validators: Validators,
@@ -554,7 +555,7 @@ class FastSync(
       val shouldValidate = header.number >= syncState.nextBlockToFullyValidate
 
       if (shouldValidate) {
-        validators.blockHeaderValidator.validate(header, blockchain.getBlockHeaderByHash) match {
+        validators.blockHeaderValidator.validate(header, blockchainReader.getBlockHeaderByHash) match {
           case Right(_) =>
             updateValidationState(header)
             Right(header)
@@ -1109,7 +1110,7 @@ class FastSync(
     private def updateBestBlockIfNeeded(receivedHashes: Seq[ByteString]): Unit = {
       val fullBlocks = receivedHashes.flatMap { hash =>
         for {
-          header <- blockchain.getBlockHeaderByHash(hash)
+          header <- blockchainReader.getBlockHeaderByHash(hash)
           _ <- blockchain.getBlockBodyByHash(hash)
           _ <- blockchain.getReceiptsByHash(hash)
         } yield header
@@ -1136,6 +1137,7 @@ object FastSync {
       fastSyncStateStorage: FastSyncStateStorage,
       appStateStorage: AppStateStorage,
       blockchain: Blockchain,
+      blockchainReader: BlockchainReader,
       evmCodeStorage: EvmCodeStorage,
       nodeStorage: NodeStorage,
       validators: Validators,
@@ -1150,6 +1152,7 @@ object FastSync {
         fastSyncStateStorage,
         appStateStorage,
         blockchain,
+        blockchainReader,
         evmCodeStorage,
         nodeStorage,
         validators,

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/fast/FastSync.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/fast/FastSync.scala
@@ -1111,7 +1111,7 @@ class FastSync(
       val fullBlocks = receivedHashes.flatMap { hash =>
         for {
           header <- blockchainReader.getBlockHeaderByHash(hash)
-          _ <- blockchain.getBlockBodyByHash(hash)
+          _ <- blockchainReader.getBlockBodyByHash(hash)
           _ <- blockchain.getReceiptsByHash(hash)
         } yield header
       }

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/fast/FastSync.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/fast/FastSync.scala
@@ -166,7 +166,13 @@ class FastSync(
     private val syncStateScheduler = context.actorOf(
       SyncStateSchedulerActor
         .props(
-          SyncStateScheduler(blockchain, evmCodeStorage, nodeStorage, syncConfig.stateSyncBloomFilterSize),
+          SyncStateScheduler(
+            blockchain,
+            blockchainReader,
+            evmCodeStorage,
+            nodeStorage,
+            syncConfig.stateSyncBloomFilterSize
+          ),
           syncConfig,
           etcPeerManager,
           peerEventBus,

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/fast/FastSync.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/fast/FastSync.scala
@@ -1128,7 +1128,7 @@ class FastSync(
         for {
           header <- blockchainReader.getBlockHeaderByHash(hash)
           _ <- blockchainReader.getBlockBodyByHash(hash)
-          _ <- blockchain.getReceiptsByHash(hash)
+          _ <- blockchainReader.getReceiptsByHash(hash)
         } yield header
       }
 

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/fast/ReceiptsValidator.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/fast/ReceiptsValidator.scala
@@ -3,14 +3,14 @@ package io.iohk.ethereum.blockchain.sync.fast
 import akka.util.ByteString
 import io.iohk.ethereum.consensus.validators.Validators
 import io.iohk.ethereum.consensus.validators.std.StdBlockValidator.BlockError
-import io.iohk.ethereum.domain.{Blockchain, Receipt}
+import io.iohk.ethereum.domain.{Blockchain, BlockchainReader, Receipt}
 
 trait ReceiptsValidator {
 
   import ReceiptsValidator._
   import ReceiptsValidationResult._
 
-  def blockchain: Blockchain
+  def blockchainReader: BlockchainReader
   def validators: Validators
 
   /**
@@ -24,7 +24,7 @@ trait ReceiptsValidator {
   def validateReceipts(requestedHashes: Seq[ByteString], receipts: Seq[Seq[Receipt]]): ReceiptsValidationResult = {
     val blockHashesWithReceipts = requestedHashes.zip(receipts)
     val blockHeadersWithReceipts = blockHashesWithReceipts.map { case (hash, blockReceipts) =>
-      blockchain.getBlockHeaderByHash(hash) -> blockReceipts
+      blockchainReader.getBlockHeaderByHash(hash) -> blockReceipts
     }
 
     val errorIterator = blockHeadersWithReceipts.iterator.map {

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/fast/SyncBlocksValidator.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/fast/SyncBlocksValidator.scala
@@ -3,9 +3,7 @@ package io.iohk.ethereum.blockchain.sync.fast
 import akka.actor.ActorLogging
 import akka.util.ByteString
 import io.iohk.ethereum.consensus.validators.{BlockHeaderError, BlockHeaderValid, Validators}
-import io.iohk.ethereum.consensus.validators.std.StdBlockValidator
-import io.iohk.ethereum.consensus.validators.std.StdBlockValidator.BlockValid
-import io.iohk.ethereum.domain.{BlockBody, BlockHeader, Blockchain, BlockchainReader}
+import io.iohk.ethereum.domain.{BlockBody, BlockHeader, BlockchainReader}
 
 trait SyncBlocksValidator { this: ActorLogging =>
 

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/fast/SyncBlocksValidator.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/fast/SyncBlocksValidator.scala
@@ -5,19 +5,19 @@ import akka.util.ByteString
 import io.iohk.ethereum.consensus.validators.{BlockHeaderError, BlockHeaderValid, Validators}
 import io.iohk.ethereum.consensus.validators.std.StdBlockValidator
 import io.iohk.ethereum.consensus.validators.std.StdBlockValidator.BlockValid
-import io.iohk.ethereum.domain.{BlockBody, BlockHeader, Blockchain}
+import io.iohk.ethereum.domain.{BlockBody, BlockHeader, Blockchain, BlockchainReader}
 
 trait SyncBlocksValidator { this: ActorLogging =>
 
   import SyncBlocksValidator._
   import BlockBodyValidationResult._
 
-  def blockchain: Blockchain
+  def blockchainReader: BlockchainReader
   def validators: Validators
 
   def validateBlocks(requestedHashes: Seq[ByteString], blockBodies: Seq[BlockBody]): BlockBodyValidationResult =
     (requestedHashes zip blockBodies)
-      .map { case (hash, body) => (blockchain.getBlockHeaderByHash(hash), body) }
+      .map { case (hash, body) => (blockchainReader.getBlockHeaderByHash(hash), body) }
       .foldLeft[BlockBodyValidationResult](Valid) {
         case (Valid, (Some(header), body)) =>
           validators.blockValidator

--- a/src/main/scala/io/iohk/ethereum/consensus/ConsensusBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/ConsensusBuilder.scala
@@ -43,7 +43,8 @@ trait StdConsensusBuilder extends ConsensusBuilder {
       case Protocol.PoW | Protocol.MockedPow => NoAdditionalPoWData
       case Protocol.RestrictedPoW => RestrictedPoWMinerData(nodeKey)
     }
-    val consensus = PoWConsensus(vm, blockchain, blockchainConfig, fullConfig, validators, additionalPoWData)
+    val consensus =
+      PoWConsensus(vm, blockchain, blockchainReader, blockchainConfig, fullConfig, validators, additionalPoWData)
     consensus
   }
 

--- a/src/main/scala/io/iohk/ethereum/consensus/blocks/BlockGeneratorSkeleton.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/blocks/BlockGeneratorSkeleton.scala
@@ -22,7 +22,6 @@ import io.iohk.ethereum.utils.ByteUtils.or
   * This is a skeleton for a generic [[io.iohk.ethereum.consensus.blocks.BlockGenerator BlockGenerator]].
   */
 abstract class BlockGeneratorSkeleton(
-    blockchain: Blockchain,
     blockchainConfig: BlockchainConfig,
     consensusConfig: ConsensusConfig,
     difficultyCalc: DifficultyCalculator,

--- a/src/main/scala/io/iohk/ethereum/consensus/blocks/NoOmmersBlockGenerator.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/blocks/NoOmmersBlockGenerator.scala
@@ -15,7 +15,6 @@ abstract class NoOmmersBlockGenerator(
     difficultyCalc: DifficultyCalculator,
     blockTimestampProvider: BlockTimestampProvider = DefaultBlockTimestampProvider
 ) extends BlockGeneratorSkeleton(
-      blockchain,
       blockchainConfig,
       consensusConfig,
       difficultyCalc,

--- a/src/main/scala/io/iohk/ethereum/consensus/pow/PoWConsensus.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/pow/PoWConsensus.scala
@@ -162,7 +162,6 @@ class PoWConsensus private (
 
         new PoWBlockGeneratorImpl(
           validators = _validators,
-          blockchain = blockchain,
           blockchainReader = blockchainReader,
           blockchainConfig = blockchainConfig,
           consensusConfig = config.generic,
@@ -246,7 +245,6 @@ object PoWConsensus {
     )
 
     val blockGenerator: PoWBlockGeneratorImpl = buildBlockGenerator(
-      blockchain,
       blockchainReader,
       blockchainConfig,
       config,
@@ -269,7 +267,6 @@ object PoWConsensus {
   }
 
   private def buildBlockGenerator(
-      blockchain: BlockchainImpl,
       blockchainReader: BlockchainReader,
       blockchainConfig: BlockchainConfig,
       config: FullConsensusConfig[EthashConfig],
@@ -281,7 +278,6 @@ object PoWConsensus {
     case RestrictedPoWMinerData(key) =>
       new RestrictedPoWBlockGeneratorImpl(
         validators = validators,
-        blockchain = blockchain,
         blockchainReader = blockchainReader,
         blockchainConfig = blockchainConfig,
         consensusConfig = config.generic,
@@ -293,7 +289,6 @@ object PoWConsensus {
     case NoAdditionalPoWData =>
       new PoWBlockGeneratorImpl(
         validators = validators,
-        blockchain = blockchain,
         blockchainReader = blockchainReader,
         blockchainConfig = blockchainConfig,
         consensusConfig = config.generic,

--- a/src/main/scala/io/iohk/ethereum/consensus/pow/blocks/PoWBlockGenerator.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/pow/blocks/PoWBlockGenerator.scala
@@ -24,7 +24,6 @@ trait PoWBlockGenerator extends TestBlockGenerator {
 
 class PoWBlockGeneratorImpl(
     validators: ValidatorsExecutor,
-    blockchain: Blockchain,
     blockchainReader: BlockchainReader,
     blockchainConfig: BlockchainConfig,
     consensusConfig: ConsensusConfig,
@@ -32,7 +31,6 @@ class PoWBlockGeneratorImpl(
     difficultyCalc: DifficultyCalculator,
     blockTimestampProvider: BlockTimestampProvider = DefaultBlockTimestampProvider
 ) extends BlockGeneratorSkeleton(
-      blockchain,
       blockchainConfig,
       consensusConfig,
       difficultyCalc,
@@ -81,7 +79,7 @@ class PoWBlockGeneratorImpl(
     val blockNumber = pHeader.number + 1
     val parentHash = pHeader.hash
 
-    val ommers = validators.ommersValidator.validate(parentHash, blockNumber, x, blockchain, blockchainReader) match {
+    val ommers = validators.ommersValidator.validate(parentHash, blockNumber, x, blockchainReader) match {
       case Left(_) => emptyX
       case Right(_) => x
     }
@@ -106,7 +104,6 @@ class PoWBlockGeneratorImpl(
   def withBlockTimestampProvider(blockTimestampProvider: BlockTimestampProvider): PoWBlockGeneratorImpl =
     new PoWBlockGeneratorImpl(
       validators,
-      blockchain,
       blockchainReader,
       blockchainConfig,
       consensusConfig,

--- a/src/main/scala/io/iohk/ethereum/consensus/pow/blocks/PoWBlockGenerator.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/pow/blocks/PoWBlockGenerator.scala
@@ -25,6 +25,7 @@ trait PoWBlockGenerator extends TestBlockGenerator {
 class PoWBlockGeneratorImpl(
     validators: ValidatorsExecutor,
     blockchain: Blockchain,
+    blockchainReader: BlockchainReader,
     blockchainConfig: BlockchainConfig,
     consensusConfig: ConsensusConfig,
     val blockPreparator: BlockPreparator,
@@ -80,7 +81,7 @@ class PoWBlockGeneratorImpl(
     val blockNumber = pHeader.number + 1
     val parentHash = pHeader.hash
 
-    val ommers = validators.ommersValidator.validate(parentHash, blockNumber, x, blockchain) match {
+    val ommers = validators.ommersValidator.validate(parentHash, blockNumber, x, blockchain, blockchainReader) match {
       case Left(_) => emptyX
       case Right(_) => x
     }
@@ -106,6 +107,7 @@ class PoWBlockGeneratorImpl(
     new PoWBlockGeneratorImpl(
       validators,
       blockchain,
+      blockchainReader,
       blockchainConfig,
       consensusConfig,
       blockPreparator,

--- a/src/main/scala/io/iohk/ethereum/consensus/pow/blocks/RestrictedPoWBlockGeneratorImpl.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/pow/blocks/RestrictedPoWBlockGeneratorImpl.scala
@@ -5,7 +5,7 @@ import io.iohk.ethereum.consensus.blocks.{BlockTimestampProvider, DefaultBlockTi
 import io.iohk.ethereum.consensus.difficulty.DifficultyCalculator
 import io.iohk.ethereum.consensus.pow.RestrictedPoWSigner
 import io.iohk.ethereum.consensus.pow.validators.ValidatorsExecutor
-import io.iohk.ethereum.domain.{Address, Block, Blockchain, BlockchainReader, SignedTransaction}
+import io.iohk.ethereum.domain.{Address, Block, BlockchainReader, SignedTransaction}
 import io.iohk.ethereum.ledger.{BlockPreparator, InMemoryWorldStateProxy}
 import io.iohk.ethereum.utils.BlockchainConfig
 import org.bouncycastle.crypto.AsymmetricCipherKeyPair
@@ -13,7 +13,6 @@ import io.iohk.ethereum.consensus.ConsensusMetrics
 
 class RestrictedPoWBlockGeneratorImpl(
     validators: ValidatorsExecutor,
-    blockchain: Blockchain,
     blockchainReader: BlockchainReader,
     blockchainConfig: BlockchainConfig,
     consensusConfig: ConsensusConfig,
@@ -23,7 +22,6 @@ class RestrictedPoWBlockGeneratorImpl(
     blockTimestampProvider: BlockTimestampProvider = DefaultBlockTimestampProvider
 ) extends PoWBlockGeneratorImpl(
       validators,
-      blockchain,
       blockchainReader,
       blockchainConfig,
       consensusConfig,
@@ -44,7 +42,7 @@ class RestrictedPoWBlockGeneratorImpl(
     val parentHash = pHeader.hash
 
     val validatedOmmers =
-      validators.ommersValidator.validate(parentHash, blockNumber, ommers, blockchain, blockchainReader) match {
+      validators.ommersValidator.validate(parentHash, blockNumber, ommers, blockchainReader) match {
         case Left(_) => emptyX
         case Right(_) => ommers
       }

--- a/src/main/scala/io/iohk/ethereum/consensus/pow/blocks/RestrictedPoWBlockGeneratorImpl.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/pow/blocks/RestrictedPoWBlockGeneratorImpl.scala
@@ -5,7 +5,7 @@ import io.iohk.ethereum.consensus.blocks.{BlockTimestampProvider, DefaultBlockTi
 import io.iohk.ethereum.consensus.difficulty.DifficultyCalculator
 import io.iohk.ethereum.consensus.pow.RestrictedPoWSigner
 import io.iohk.ethereum.consensus.pow.validators.ValidatorsExecutor
-import io.iohk.ethereum.domain.{Address, Block, Blockchain, SignedTransaction}
+import io.iohk.ethereum.domain.{Address, Block, Blockchain, BlockchainReader, SignedTransaction}
 import io.iohk.ethereum.ledger.{BlockPreparator, InMemoryWorldStateProxy}
 import io.iohk.ethereum.utils.BlockchainConfig
 import org.bouncycastle.crypto.AsymmetricCipherKeyPair
@@ -14,6 +14,7 @@ import io.iohk.ethereum.consensus.ConsensusMetrics
 class RestrictedPoWBlockGeneratorImpl(
     validators: ValidatorsExecutor,
     blockchain: Blockchain,
+    blockchainReader: BlockchainReader,
     blockchainConfig: BlockchainConfig,
     consensusConfig: ConsensusConfig,
     override val blockPreparator: BlockPreparator,
@@ -23,6 +24,7 @@ class RestrictedPoWBlockGeneratorImpl(
 ) extends PoWBlockGeneratorImpl(
       validators,
       blockchain,
+      blockchainReader,
       blockchainConfig,
       consensusConfig,
       blockPreparator,
@@ -41,10 +43,11 @@ class RestrictedPoWBlockGeneratorImpl(
     val blockNumber = pHeader.number + 1
     val parentHash = pHeader.hash
 
-    val validatedOmmers = validators.ommersValidator.validate(parentHash, blockNumber, ommers, blockchain) match {
-      case Left(_) => emptyX
-      case Right(_) => ommers
-    }
+    val validatedOmmers =
+      validators.ommersValidator.validate(parentHash, blockNumber, ommers, blockchain, blockchainReader) match {
+        case Left(_) => emptyX
+        case Right(_) => ommers
+      }
     val prepared = prepareBlock(
       parent,
       transactions,

--- a/src/main/scala/io/iohk/ethereum/consensus/pow/validators/OmmersValidator.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/pow/validators/OmmersValidator.scala
@@ -26,7 +26,7 @@ trait OmmersValidator {
 
     val getBlockHeaderByHash: ByteString => Option[BlockHeader] = blockchainReader.getBlockHeaderByHash
     val getNBlocksBack: (ByteString, Int) => List[Block] =
-      (_, n) => ((blockNumber - n) until blockNumber).toList.flatMap(blockchain.getBlockByNumber)
+      (_, n) => ((blockNumber - n) until blockNumber).toList.flatMap(blockchainReader.getBlockByNumber)
 
     validate(parentHash, blockNumber, ommers, getBlockHeaderByHash, getNBlocksBack)
   }

--- a/src/main/scala/io/iohk/ethereum/consensus/pow/validators/OmmersValidator.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/pow/validators/OmmersValidator.scala
@@ -4,7 +4,7 @@ import akka.util.ByteString
 import io.iohk.ethereum.consensus.pow.validators.OmmersValidator.{OmmersError, OmmersValid}
 import io.iohk.ethereum.consensus.validators.BlockHeaderError
 import io.iohk.ethereum.consensus.{GetBlockHeaderByHash, GetNBlocksBack}
-import io.iohk.ethereum.domain.{Block, BlockHeader, Blockchain, BlockchainReader}
+import io.iohk.ethereum.domain.{Block, BlockHeader, BlockchainReader}
 
 trait OmmersValidator {
 
@@ -20,7 +20,6 @@ trait OmmersValidator {
       parentHash: ByteString,
       blockNumber: BigInt,
       ommers: Seq[BlockHeader],
-      blockchain: Blockchain,
       blockchainReader: BlockchainReader
   ): Either[OmmersError, OmmersValid] = {
 

--- a/src/main/scala/io/iohk/ethereum/consensus/pow/validators/OmmersValidator.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/pow/validators/OmmersValidator.scala
@@ -4,7 +4,7 @@ import akka.util.ByteString
 import io.iohk.ethereum.consensus.pow.validators.OmmersValidator.{OmmersError, OmmersValid}
 import io.iohk.ethereum.consensus.validators.BlockHeaderError
 import io.iohk.ethereum.consensus.{GetBlockHeaderByHash, GetNBlocksBack}
-import io.iohk.ethereum.domain.{Block, BlockHeader, Blockchain}
+import io.iohk.ethereum.domain.{Block, BlockHeader, Blockchain, BlockchainReader}
 
 trait OmmersValidator {
 
@@ -20,10 +20,11 @@ trait OmmersValidator {
       parentHash: ByteString,
       blockNumber: BigInt,
       ommers: Seq[BlockHeader],
-      blockchain: Blockchain
+      blockchain: Blockchain,
+      blockchainReader: BlockchainReader
   ): Either[OmmersError, OmmersValid] = {
 
-    val getBlockHeaderByHash: ByteString => Option[BlockHeader] = blockchain.getBlockHeaderByHash
+    val getBlockHeaderByHash: ByteString => Option[BlockHeader] = blockchainReader.getBlockHeaderByHash
     val getNBlocksBack: (ByteString, Int) => List[Block] =
       (_, n) => ((blockNumber - n) until blockNumber).toList.flatMap(blockchain.getBlockByNumber)
 

--- a/src/main/scala/io/iohk/ethereum/domain/Blockchain.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/Blockchain.scala
@@ -68,13 +68,6 @@ trait Blockchain {
   def getReceiptsByHash(blockhash: ByteString): Option[Seq[Receipt]]
 
   /**
-    * Returns MPT node searched by it's hash
-    * @param hash Node Hash
-    * @return MPT node
-    */
-  def getMptNodeByHash(hash: ByteString): Option[MptNode]
-
-  /**
     * Looks up ChainWeight for a given chain
     * @param blockhash Hash of top block in the chain
     * @return ChainWeight if found
@@ -316,9 +309,6 @@ class BlockchainImpl(
     val hash = blockHeader.hash
     blockHeadersStorage.put(hash, blockHeader).and(saveBlockNumberMapping(blockHeader.number, hash))
   }
-
-  override def getMptNodeByHash(hash: ByteString): Option[MptNode] =
-    stateStorage.getNode(hash)
 
   override def storeBlockBody(blockHash: ByteString, blockBody: BlockBody): DataSourceBatchUpdate = {
     blockBodiesStorage.put(blockHash, blockBody).and(saveTxsLocations(blockHash, blockBody))

--- a/src/main/scala/io/iohk/ethereum/domain/Blockchain.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/Blockchain.scala
@@ -61,13 +61,6 @@ trait Blockchain {
   ): StorageProof
 
   /**
-    * Returns the receipts based on a block hash
-    * @param blockhash
-    * @return Receipts if found
-    */
-  def getReceiptsByHash(blockhash: ByteString): Option[Seq[Receipt]]
-
-  /**
     * Looks up ChainWeight for a given chain
     * @param blockhash Hash of top block in the chain
     * @return ChainWeight if found
@@ -179,8 +172,6 @@ class BlockchainImpl(
       hash <- blockchainReader.getHashByBlockNumber(header.number)
     } yield header.hash == hash).getOrElse(false)
   }
-
-  override def getReceiptsByHash(blockhash: ByteString): Option[Seq[Receipt]] = receiptStorage.get(blockhash)
 
   override def getChainWeightByHash(blockhash: ByteString): Option[ChainWeight] = chainWeightStorage.get(blockhash)
 

--- a/src/main/scala/io/iohk/ethereum/domain/BlockchainReader.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/BlockchainReader.scala
@@ -1,9 +1,9 @@
 package io.iohk.ethereum.domain
 
 import akka.util.ByteString
-import io.iohk.ethereum.db.storage.BlockHeadersStorage
+import io.iohk.ethereum.db.storage.{BlockBodiesStorage, BlockHeadersStorage}
 
-class BlockchainReader(blockHeadersStorage: BlockHeadersStorage) {
+class BlockchainReader(blockHeadersStorage: BlockHeadersStorage, blockBodiesStorage: BlockBodiesStorage) {
 
   /**
     * Allows to query a blockHeader by block hash
@@ -14,4 +14,24 @@ class BlockchainReader(blockHeadersStorage: BlockHeadersStorage) {
   def getBlockHeaderByHash(hash: ByteString): Option[BlockHeader] =
     blockHeadersStorage.get(hash)
 
+  /**
+    * Allows to query a blockBody by block hash
+    *
+    * @param hash of the block that's being searched
+    * @return [[io.iohk.ethereum.domain.BlockBody]] if found
+    */
+  def getBlockBodyByHash(hash: ByteString): Option[BlockBody] =
+    blockBodiesStorage.get(hash)
+
+  /**
+    * Allows to query for a block based on it's hash
+    *
+    * @param hash of the block that's being searched
+    * @return Block if found
+    */
+  def getBlockByHash(hash: ByteString): Option[Block] =
+    for {
+      header <- getBlockHeaderByHash(hash)
+      body <- getBlockBodyByHash(hash)
+    } yield Block(header, body)
 }

--- a/src/main/scala/io/iohk/ethereum/domain/BlockchainReader.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/BlockchainReader.scala
@@ -1,12 +1,14 @@
 package io.iohk.ethereum.domain
 
 import akka.util.ByteString
-import io.iohk.ethereum.db.storage.{BlockBodiesStorage, BlockHeadersStorage, BlockNumberMappingStorage}
+import io.iohk.ethereum.db.storage.{BlockBodiesStorage, BlockHeadersStorage, BlockNumberMappingStorage, StateStorage}
+import io.iohk.ethereum.mpt.MptNode
 
 class BlockchainReader(
     blockHeadersStorage: BlockHeadersStorage,
     blockBodiesStorage: BlockBodiesStorage,
-    blockNumberMappingStorage: BlockNumberMappingStorage
+    blockNumberMappingStorage: BlockNumberMappingStorage,
+    stateStorage: StateStorage
 ) {
 
   /**
@@ -66,4 +68,23 @@ class BlockchainReader(
       hash <- getHashByBlockNumber(number)
       block <- getBlockByHash(hash)
     } yield block
+
+  /**
+    * Returns MPT node searched by it's hash
+    * @param hash Node Hash
+    * @return MPT node
+    */
+  def getMptNodeByHash(hash: ByteString): Option[MptNode] =
+    stateStorage.getNode(hash)
+}
+
+object BlockchainReader {
+
+  def apply(blockchainStorages: BlockchainStorages): BlockchainReader = new BlockchainReader(
+    blockchainStorages.blockHeadersStorage,
+    blockchainStorages.blockBodiesStorage,
+    blockchainStorages.blockNumberMappingStorage,
+    blockchainStorages.stateStorage
+  )
+
 }

--- a/src/main/scala/io/iohk/ethereum/domain/BlockchainReader.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/BlockchainReader.scala
@@ -1,0 +1,17 @@
+package io.iohk.ethereum.domain
+
+import akka.util.ByteString
+import io.iohk.ethereum.db.storage.BlockHeadersStorage
+
+class BlockchainReader(blockHeadersStorage: BlockHeadersStorage) {
+
+  /**
+    * Allows to query a blockHeader by block hash
+    *
+    * @param hash of the block that's being searched
+    * @return [[BlockHeader]] if found
+    */
+  def getBlockHeaderByHash(hash: ByteString): Option[BlockHeader] =
+    blockHeadersStorage.get(hash)
+
+}

--- a/src/main/scala/io/iohk/ethereum/domain/BlockchainReader.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/BlockchainReader.scala
@@ -1,14 +1,21 @@
 package io.iohk.ethereum.domain
 
 import akka.util.ByteString
-import io.iohk.ethereum.db.storage.{BlockBodiesStorage, BlockHeadersStorage, BlockNumberMappingStorage, StateStorage}
+import io.iohk.ethereum.db.storage.{
+  BlockBodiesStorage,
+  BlockHeadersStorage,
+  BlockNumberMappingStorage,
+  ReceiptStorage,
+  StateStorage
+}
 import io.iohk.ethereum.mpt.MptNode
 
 class BlockchainReader(
     blockHeadersStorage: BlockHeadersStorage,
     blockBodiesStorage: BlockBodiesStorage,
     blockNumberMappingStorage: BlockNumberMappingStorage,
-    stateStorage: StateStorage
+    stateStorage: StateStorage,
+    receiptStorage: ReceiptStorage
 ) {
 
   /**
@@ -76,15 +83,23 @@ class BlockchainReader(
     */
   def getMptNodeByHash(hash: ByteString): Option[MptNode] =
     stateStorage.getNode(hash)
+
+  /**
+    * Returns the receipts based on a block hash
+    * @param blockhash
+    * @return Receipts if found
+    */
+  def getReceiptsByHash(blockhash: ByteString): Option[Seq[Receipt]] = receiptStorage.get(blockhash)
 }
 
 object BlockchainReader {
 
-  def apply(blockchainStorages: BlockchainStorages): BlockchainReader = new BlockchainReader(
-    blockchainStorages.blockHeadersStorage,
-    blockchainStorages.blockBodiesStorage,
-    blockchainStorages.blockNumberMappingStorage,
-    blockchainStorages.stateStorage
+  def apply(storages: BlockchainStorages): BlockchainReader = new BlockchainReader(
+    storages.blockHeadersStorage,
+    storages.blockBodiesStorage,
+    storages.blockNumberMappingStorage,
+    storages.stateStorage,
+    storages.receiptStorage
   )
 
 }

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/CheckpointingService.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/CheckpointingService.scala
@@ -5,13 +5,14 @@ import akka.util.ByteString
 import io.iohk.ethereum.blockchain.sync.regular.RegularSync.NewCheckpoint
 import io.iohk.ethereum.consensus.blocks.CheckpointBlockGenerator
 import io.iohk.ethereum.crypto.ECDSASignature
-import io.iohk.ethereum.domain.{Block, Blockchain, Checkpoint}
+import io.iohk.ethereum.domain.{Block, Blockchain, BlockchainReader, Checkpoint}
 import io.iohk.ethereum.ledger.Ledger
 import io.iohk.ethereum.utils.{ByteStringUtils, Logger}
 import monix.eval.Task
 
 class CheckpointingService(
     blockchain: Blockchain,
+    blockchainReader: BlockchainReader,
     ledger: Ledger,
     checkpointBlockGenerator: CheckpointBlockGenerator,
     syncController: ActorRef
@@ -26,7 +27,7 @@ class CheckpointingService(
         bestBlockNum - bestBlockNum % req.checkpointingInterval
       else bestBlockNum
     lazy val isValidParent =
-      req.parentCheckpoint.forall(blockchain.getBlockHeaderByHash(_).exists(_.number < blockToReturnNum))
+      req.parentCheckpoint.forall(blockchainReader.getBlockHeaderByHash(_).exists(_.number < blockToReturnNum))
 
     Task {
       blockchain.getBlockByNumber(blockToReturnNum)

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/CheckpointingService.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/CheckpointingService.scala
@@ -30,7 +30,7 @@ class CheckpointingService(
       req.parentCheckpoint.forall(blockchainReader.getBlockHeaderByHash(_).exists(_.number < blockToReturnNum))
 
     Task {
-      blockchain.getBlockByNumber(blockToReturnNum)
+      blockchainReader.getBlockByNumber(blockToReturnNum)
     }.flatMap {
       case Some(b) if isValidParent =>
         Task.now(Right(GetLatestBlockResponse(Some(BlockInfo(b.hash, b.number)))))

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/EthBlocksService.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/EthBlocksService.scala
@@ -1,7 +1,7 @@
 package io.iohk.ethereum.jsonrpc
 
 import akka.util.ByteString
-import io.iohk.ethereum.domain.Blockchain
+import io.iohk.ethereum.domain.{Blockchain, BlockchainReader}
 import io.iohk.ethereum.ledger.Ledger
 import monix.eval.Task
 import org.bouncycastle.util.encoders.Hex
@@ -35,7 +35,8 @@ object EthBlocksService {
   case class GetUncleCountByBlockHashResponse(result: BigInt)
 }
 
-class EthBlocksService(val blockchain: Blockchain, val ledger: Ledger) extends ResolveBlock {
+class EthBlocksService(val blockchain: Blockchain, blockchainReader: BlockchainReader, val ledger: Ledger)
+    extends ResolveBlock {
   import EthBlocksService._
 
   private[jsonrpc] def consensus = ledger.consensus
@@ -58,7 +59,7 @@ class EthBlocksService(val blockchain: Blockchain, val ledger: Ledger) extends R
     */
   def getBlockTransactionCountByHash(request: TxCountByBlockHashRequest): ServiceResponse[TxCountByBlockHashResponse] =
     Task {
-      val txsCount = blockchain.getBlockBodyByHash(request.blockHash).map(_.transactionList.size)
+      val txsCount = blockchainReader.getBlockBodyByHash(request.blockHash).map(_.transactionList.size)
       Right(TxCountByBlockHashResponse(txsCount))
     }
 
@@ -70,7 +71,7 @@ class EthBlocksService(val blockchain: Blockchain, val ledger: Ledger) extends R
     */
   def getByBlockHash(request: BlockByBlockHashRequest): ServiceResponse[BlockByBlockHashResponse] = Task {
     val BlockByBlockHashRequest(blockHash, fullTxs) = request
-    val blockOpt = blockchain.getBlockByHash(blockHash)
+    val blockOpt = blockchainReader.getBlockByHash(blockHash)
     val weight = blockchain.getChainWeightByHash(blockHash)
 
     val blockResponseOpt = blockOpt.map(block => BlockResponse(block, weight, fullTxs = fullTxs))
@@ -113,7 +114,7 @@ class EthBlocksService(val blockchain: Blockchain, val ledger: Ledger) extends R
       request: UncleByBlockHashAndIndexRequest
   ): ServiceResponse[UncleByBlockHashAndIndexResponse] = Task {
     val UncleByBlockHashAndIndexRequest(blockHash, uncleIndex) = request
-    val uncleHeaderOpt = blockchain
+    val uncleHeaderOpt = blockchainReader
       .getBlockBodyByHash(blockHash)
       .flatMap { body =>
         if (uncleIndex >= 0 && uncleIndex < body.uncleNodesList.size)
@@ -175,7 +176,7 @@ class EthBlocksService(val blockchain: Blockchain, val ledger: Ledger) extends R
       req: GetUncleCountByBlockHashRequest
   ): ServiceResponse[GetUncleCountByBlockHashResponse] = {
     Task {
-      blockchain.getBlockBodyByHash(req.blockHash) match {
+      blockchainReader.getBlockBodyByHash(req.blockHash) match {
         case Some(blockBody) =>
           Right(GetUncleCountByBlockHashResponse(blockBody.uncleNodesList.size))
         case None =>

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/EthBlocksService.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/EthBlocksService.scala
@@ -35,8 +35,11 @@ object EthBlocksService {
   case class GetUncleCountByBlockHashResponse(result: BigInt)
 }
 
-class EthBlocksService(val blockchain: Blockchain, blockchainReader: BlockchainReader, val ledger: Ledger)
-    extends ResolveBlock {
+class EthBlocksService(
+    val blockchain: Blockchain,
+    val blockchainReader: BlockchainReader,
+    val ledger: Ledger
+) extends ResolveBlock {
   import EthBlocksService._
 
   private[jsonrpc] def consensus = ledger.consensus

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/EthInfoService.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/EthInfoService.scala
@@ -71,6 +71,7 @@ object EthInfoService {
 
 class EthInfoService(
     val blockchain: Blockchain,
+    val blockchainReader: BlockchainReader,
     blockchainConfig: BlockchainConfig,
     val ledger: Ledger,
     stxLedger: StxLedger,

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/EthProofService.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/EthProofService.scala
@@ -3,7 +3,7 @@ package io.iohk.ethereum.jsonrpc
 import akka.util.ByteString
 import cats.implicits._
 import io.iohk.ethereum.consensus.blocks.BlockGenerator
-import io.iohk.ethereum.domain.{Account, Address, Block, Blockchain, UInt256}
+import io.iohk.ethereum.domain.{Account, Address, Block, Blockchain, BlockchainReader, UInt256}
 import io.iohk.ethereum.jsonrpc.ProofService.StorageProof.asRlpSerializedNode
 import io.iohk.ethereum.jsonrpc.ProofService.{
   GetProofRequest,
@@ -140,8 +140,12 @@ trait ProofService {
   * parity: https://github.com/openethereum/parity-ethereum/pull/9001
   * geth: https://github.com/ethereum/go-ethereum/pull/17737
   */
-class EthProofService(blockchain: Blockchain, blockGenerator: BlockGenerator, ethCompatibleStorage: Boolean)
-    extends ProofService {
+class EthProofService(
+    blockchain: Blockchain,
+    blockchainReader: BlockchainReader,
+    blockGenerator: BlockGenerator,
+    ethCompatibleStorage: Boolean
+) extends ProofService {
 
   def getProof(req: GetProofRequest): ServiceResponse[GetProofResponse] = {
     getProofAccount(req.address, req.storageKeys, req.blockNumber)
@@ -201,7 +205,7 @@ class EthProofService(blockchain: Blockchain, blockGenerator: BlockGenerator, et
 
   private def resolveBlock(blockParam: BlockParam): Either[JsonRpcError, ResolvedBlock] = {
     def getBlock(number: BigInt): Either[JsonRpcError, Block] =
-      blockchain
+      blockchainReader
         .getBlockByNumber(number)
         .toRight(JsonRpcError.InvalidParams(s"Block $number not found"))
 

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/EthTxService.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/EthTxService.scala
@@ -106,7 +106,7 @@ class EthTxService(
         TransactionLocation(blockHash, txIndex) <- transactionMappingStorage.get(req.txHash)
         Block(header, body) <- blockchainReader.getBlockByHash(blockHash)
         stx <- body.transactionList.lift(txIndex)
-        receipts <- blockchain.getReceiptsByHash(blockHash)
+        receipts <- blockchainReader.getReceiptsByHash(blockHash)
         receipt: Receipt <- receipts.lift(txIndex)
         // another possibility would be to throw an exception and fail hard, as if we cannot calculate sender for transaction
         // included in blockchain it means that something is terribly wrong

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/EthTxService.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/EthTxService.scala
@@ -37,7 +37,7 @@ object EthTxService {
 
 class EthTxService(
     val blockchain: Blockchain,
-    blockchainReader: BlockchainReader,
+    val blockchainReader: BlockchainReader,
     val ledger: Ledger,
     val pendingTransactionsManager: ActorRef,
     val getTransactionFromPoolTimeout: FiniteDuration,
@@ -157,7 +157,7 @@ class EthTxService(
 
     Task {
       val gasPrice = ((bestBlock - blockDifference) to bestBlock)
-        .flatMap(blockchain.getBlockByNumber)
+        .flatMap(blockchainReader.getBlockByNumber)
         .flatMap(_.body.transactionList)
         .map(_.tx.gasPrice)
       if (gasPrice.nonEmpty) {

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/EthUserService.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/EthUserService.scala
@@ -22,6 +22,7 @@ object EthUserService {
 
 class EthUserService(
     val blockchain: Blockchain,
+    val blockchainReader: BlockchainReader,
     val ledger: Ledger,
     blockchainConfig: BlockchainConfig
 ) extends ResolveBlock {

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/FilterManager.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/FilterManager.scala
@@ -17,6 +17,7 @@ import scala.util.Random
 
 class FilterManager(
     blockchain: Blockchain,
+    blockchainReader: BlockchainReader,
     blockGenerator: BlockGenerator,
     appStateStorage: AppStateStorage,
     keyStore: KeyStore,
@@ -133,7 +134,7 @@ class FilterManager(
                   toBlockNumber,
                   logsSoFar ++ getLogsFromBlock(
                     filter,
-                    Block(header, blockchain.getBlockBodyByHash(header.hash).get),
+                    Block(header, blockchainReader.getBlockBodyByHash(header.hash).get),
                     receipts
                   )
                 )
@@ -275,6 +276,7 @@ class FilterManager(
 object FilterManager {
   def props(
       blockchain: Blockchain,
+      blockchainReader: BlockchainReader,
       blockGenerator: BlockGenerator,
       appStateStorage: AppStateStorage,
       keyStore: KeyStore,
@@ -285,6 +287,7 @@ object FilterManager {
     Props(
       new FilterManager(
         blockchain,
+        blockchainReader,
         blockGenerator,
         appStateStorage,
         keyStore,

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/FilterManager.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/FilterManager.scala
@@ -121,7 +121,7 @@ class FilterManager(
       if (currentBlockNumber > toBlockNumber) {
         logsSoFar
       } else {
-        blockchain.getBlockHeaderByNumber(currentBlockNumber) match {
+        blockchainReader.getBlockHeaderByNumber(currentBlockNumber) match {
           case Some(header)
               if bytesToCheckInBloomFilter.isEmpty || BloomFilter.containsAnyOf(
                 header.logsBloom,
@@ -238,7 +238,7 @@ class FilterManager(
       if (currentBlockNumber > bestBlock) {
         hashesSoFar
       } else
-        blockchain.getBlockHeaderByNumber(currentBlockNumber) match {
+        blockchainReader.getBlockHeaderByNumber(currentBlockNumber) match {
           case Some(header) => recur(currentBlockNumber + 1, hashesSoFar :+ header.hash)
           case None => hashesSoFar
         }

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/FilterManager.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/FilterManager.scala
@@ -19,7 +19,6 @@ class FilterManager(
     blockchain: Blockchain,
     blockchainReader: BlockchainReader,
     blockGenerator: BlockGenerator,
-    appStateStorage: AppStateStorage,
     keyStore: KeyStore,
     pendingTransactionsManager: ActorRef,
     filterConfig: FilterConfig,
@@ -127,7 +126,7 @@ class FilterManager(
                 header.logsBloom,
                 bytesToCheckInBloomFilter
               ) =>
-            blockchain.getReceiptsByHash(header.hash) match {
+            blockchainReader.getReceiptsByHash(header.hash) match {
               case Some(receipts) =>
                 recur(
                   currentBlockNumber + 1,
@@ -278,7 +277,6 @@ object FilterManager {
       blockchain: Blockchain,
       blockchainReader: BlockchainReader,
       blockGenerator: BlockGenerator,
-      appStateStorage: AppStateStorage,
       keyStore: KeyStore,
       pendingTransactionsManager: ActorRef,
       filterConfig: FilterConfig,
@@ -289,7 +287,6 @@ object FilterManager {
         blockchain,
         blockchainReader,
         blockGenerator,
-        appStateStorage,
         keyStore,
         pendingTransactionsManager,
         filterConfig,

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/ResolveBlock.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/ResolveBlock.scala
@@ -16,6 +16,7 @@ case class ResolvedBlock(block: Block, pendingState: Option[InMemoryWorldStatePr
 
 trait ResolveBlock {
   def blockchain: Blockchain
+  def blockchainReader: BlockchainReader
   def ledger: Ledger
 
   def resolveBlock(blockParam: BlockParam): Either[JsonRpcError, ResolvedBlock] = {
@@ -32,7 +33,7 @@ trait ResolveBlock {
   }
 
   private def getBlock(number: BigInt): Either[JsonRpcError, Block] = {
-    blockchain
+    blockchainReader
       .getBlockByNumber(number)
       .toRight(JsonRpcError.InvalidParams(s"Block $number not found"))
   }

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/TestService.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/TestService.scala
@@ -419,7 +419,7 @@ class TestService(
       transactionLocation <- transactionMappingStorage.get(request.transactionHash)
       block <- blockchainReader.getBlockByHash(transactionLocation.blockHash)
       _ <- block.body.transactionList.lift(transactionLocation.txIndex)
-      receipts <- blockchain.getReceiptsByHash(block.header.hash)
+      receipts <- blockchainReader.getReceiptsByHash(block.header.hash)
       logs = receipts.flatMap(receipt => receipt.logs)
       rlpList: RLPList = RLPList(logs.map(_.toRLPEncodable).toList: _*)
     } yield ByteString(crypto.kec256(rlp.encode(rlpList)))

--- a/src/main/scala/io/iohk/ethereum/ledger/BlockExecution.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/BlockExecution.scala
@@ -12,6 +12,7 @@ import io.iohk.ethereum.mpt.MerklePatriciaTrie.MPTException
 
 class BlockExecution(
     blockchain: BlockchainImpl,
+    blockchainReader: BlockchainReader,
     blockchainConfig: BlockchainConfig,
     blockPreparator: BlockPreparator,
     blockValidation: BlockValidation
@@ -57,7 +58,7 @@ class BlockExecution(
   /** Executes a block (executes transactions and pays rewards) */
   private def executeBlock(block: Block): Either[BlockExecutionError, BlockResult] = {
     for {
-      parent <- blockchain
+      parent <- blockchainReader
         .getBlockHeaderByHash(block.header.parentHash)
         .toRight(MissingParentError) // Should not never occur because validated earlier
       execResult <- executeBlockTransactions(block, parent)

--- a/src/main/scala/io/iohk/ethereum/ledger/BlockImport.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/BlockImport.scala
@@ -16,6 +16,7 @@ import scala.concurrent.ExecutionContext
 
 class BlockImport(
     blockchain: BlockchainImpl,
+    blockchainReader: BlockchainReader,
     blockQueue: BlockQueue,
     blockValidation: BlockValidation,
     blockExecution: BlockExecution,
@@ -239,7 +240,7 @@ class BlockImport(
   private def removeBlocksUntil(parent: ByteString, fromNumber: BigInt): List[BlockData] = {
     @tailrec
     def removeBlocksUntil(parent: ByteString, fromNumber: BigInt, acc: List[BlockData]): List[BlockData] = {
-      blockchain.getBlockByNumber(fromNumber) match {
+      blockchainReader.getBlockByNumber(fromNumber) match {
         case Some(block) if block.header.hash == parent || fromNumber == 0 =>
           acc
 

--- a/src/main/scala/io/iohk/ethereum/ledger/BlockImport.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/BlockImport.scala
@@ -248,7 +248,7 @@ class BlockImport(
           val hash = block.header.hash
 
           val blockDataOpt = for {
-            receipts <- blockchain.getReceiptsByHash(hash)
+            receipts <- blockchainReader.getReceiptsByHash(hash)
             weight <- blockchain.getChainWeightByHash(hash)
           } yield BlockData(block, receipts, weight)
 

--- a/src/main/scala/io/iohk/ethereum/ledger/BlockValidation.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/BlockValidation.scala
@@ -40,7 +40,7 @@ class BlockValidation(
           val remaining = n - queuedBlocks.length - 1
 
           val numbers = (block.header.number - remaining) until block.header.number
-          val blocks = (numbers.toList.flatMap(blockchain.getBlockByNumber) :+ block) ::: queuedBlocks
+          val blocks = (numbers.toList.flatMap(blockchainReader.getBlockByNumber) :+ block) ::: queuedBlocks
           blocks
       }
     }

--- a/src/main/scala/io/iohk/ethereum/ledger/BlockValidation.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/BlockValidation.scala
@@ -2,12 +2,11 @@ package io.iohk.ethereum.ledger
 
 import akka.util.ByteString
 import io.iohk.ethereum.consensus.Consensus
-import io.iohk.ethereum.domain.{Block, BlockHeader, Blockchain, BlockchainReader, Receipt}
+import io.iohk.ethereum.domain.{Block, BlockHeader, BlockchainReader, Receipt}
 import io.iohk.ethereum.ledger.BlockExecutionError.ValidationBeforeExecError
 
 class BlockValidation(
     consensus: Consensus,
-    blockchain: Blockchain,
     blockchainReader: BlockchainReader,
     blockQueue: BlockQueue
 ) {

--- a/src/main/scala/io/iohk/ethereum/ledger/BlockValidation.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/BlockValidation.scala
@@ -30,7 +30,7 @@ class BlockValidation(
       queuedBlocks
     } else {
       val chainedBlockHash = queuedBlocks.headOption.map(_.header.parentHash).getOrElse(hash)
-      blockchain.getBlockByHash(chainedBlockHash) match {
+      blockchainReader.getBlockByHash(chainedBlockHash) match {
         case None =>
           // The in memory blocks aren't connected to the db ones, we don't have n blocks to return so we return none
           Nil

--- a/src/main/scala/io/iohk/ethereum/ledger/BlockValidation.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/BlockValidation.scala
@@ -2,10 +2,15 @@ package io.iohk.ethereum.ledger
 
 import akka.util.ByteString
 import io.iohk.ethereum.consensus.Consensus
-import io.iohk.ethereum.domain.{Block, BlockHeader, Blockchain, Receipt}
+import io.iohk.ethereum.domain.{Block, BlockHeader, Blockchain, BlockchainReader, Receipt}
 import io.iohk.ethereum.ledger.BlockExecutionError.ValidationBeforeExecError
 
-class BlockValidation(consensus: Consensus, blockchain: Blockchain, blockQueue: BlockQueue) {
+class BlockValidation(
+    consensus: Consensus,
+    blockchain: Blockchain,
+    blockchainReader: BlockchainReader,
+    blockQueue: BlockQueue
+) {
 
   def validateBlockBeforeExecution(block: Block): Either[ValidationBeforeExecError, BlockExecutionSuccess] = {
     consensus.validators.validateBlockBeforeExecution(
@@ -16,7 +21,7 @@ class BlockValidation(consensus: Consensus, blockchain: Blockchain, blockQueue: 
   }
 
   private def getBlockHeaderFromChainOrQueue(hash: ByteString): Option[BlockHeader] = {
-    blockchain.getBlockHeaderByHash(hash).orElse(blockQueue.getBlockByHash(hash).map(_.header))
+    blockchainReader.getBlockHeaderByHash(hash).orElse(blockQueue.getBlockByHash(hash).map(_.header))
   }
 
   private def getNBlocksBackFromChainOrQueue(hash: ByteString, n: Int): List[Block] = {

--- a/src/main/scala/io/iohk/ethereum/ledger/BranchResolution.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/BranchResolution.scala
@@ -1,10 +1,10 @@
 package io.iohk.ethereum.ledger
 
 import cats.data.NonEmptyList
-import io.iohk.ethereum.domain.{Block, BlockHeader, Blockchain, ChainWeight}
+import io.iohk.ethereum.domain.{Block, BlockHeader, Blockchain, BlockchainReader, ChainWeight}
 import io.iohk.ethereum.utils.Logger
 
-class BranchResolution(blockchain: Blockchain) extends Logger {
+class BranchResolution(blockchain: Blockchain, blockchainReader: BlockchainReader) extends Logger {
 
   def resolveBranch(headers: NonEmptyList[BlockHeader]): BranchResolutionResult = {
     if (!doHeadersFormChain(headers)) {
@@ -70,7 +70,7 @@ class BranchResolution(blockchain: Blockchain) extends Logger {
 
   private def getTopBlocksFromNumber(from: BigInt): List[Block] =
     (from to blockchain.getBestBlockNumber())
-      .flatMap(blockchain.getBlockByNumber)
+      .flatMap(blockchainReader.getBlockByNumber)
       .toList
 }
 

--- a/src/main/scala/io/iohk/ethereum/ledger/Ledger.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/Ledger.scala
@@ -71,6 +71,7 @@ trait Ledger {
   */
 class LedgerImpl(
     blockchain: BlockchainImpl,
+    blockchainReader: BlockchainReader,
     blockQueue: BlockQueue,
     blockchainConfig: BlockchainConfig,
     theConsensus: Consensus,
@@ -80,11 +81,19 @@ class LedgerImpl(
 
   def this(
       blockchain: BlockchainImpl,
+      blockchainReader: BlockchainReader,
       blockchainConfig: BlockchainConfig,
       syncConfig: SyncConfig,
       theConsensus: Consensus,
       validationContext: Scheduler
-  ) = this(blockchain, BlockQueue(blockchain, syncConfig), blockchainConfig, theConsensus, validationContext)
+  ) = this(
+    blockchain,
+    blockchainReader,
+    BlockQueue(blockchain, syncConfig),
+    blockchainConfig,
+    theConsensus,
+    validationContext
+  )
 
   val consensus: Consensus = theConsensus
 
@@ -92,9 +101,9 @@ class LedgerImpl(
 
   private[ledger] val blockRewardCalculator = _blockPreparator.blockRewardCalculator
 
-  private[ledger] lazy val blockValidation = new BlockValidation(consensus, blockchain, blockQueue)
+  private[ledger] lazy val blockValidation = new BlockValidation(consensus, blockchain, blockchainReader, blockQueue)
   private[ledger] lazy val blockExecution =
-    new BlockExecution(blockchain, blockchainConfig, consensus.blockPreparator, blockValidation)
+    new BlockExecution(blockchain, blockchainReader, blockchainConfig, consensus.blockPreparator, blockValidation)
   private[ledger] val branchResolution = new BranchResolution(blockchain)
   private[ledger] val blockImport =
     new BlockImport(

--- a/src/main/scala/io/iohk/ethereum/ledger/Ledger.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/Ledger.scala
@@ -101,7 +101,7 @@ class LedgerImpl(
 
   private[ledger] val blockRewardCalculator = _blockPreparator.blockRewardCalculator
 
-  private[ledger] lazy val blockValidation = new BlockValidation(consensus, blockchain, blockchainReader, blockQueue)
+  private[ledger] lazy val blockValidation = new BlockValidation(consensus, blockchainReader, blockQueue)
   private[ledger] lazy val blockExecution =
     new BlockExecution(blockchain, blockchainReader, blockchainConfig, consensus.blockPreparator, blockValidation)
   private[ledger] val branchResolution = new BranchResolution(blockchain, blockchainReader)

--- a/src/main/scala/io/iohk/ethereum/ledger/Ledger.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/Ledger.scala
@@ -104,10 +104,11 @@ class LedgerImpl(
   private[ledger] lazy val blockValidation = new BlockValidation(consensus, blockchain, blockchainReader, blockQueue)
   private[ledger] lazy val blockExecution =
     new BlockExecution(blockchain, blockchainReader, blockchainConfig, consensus.blockPreparator, blockValidation)
-  private[ledger] val branchResolution = new BranchResolution(blockchain)
+  private[ledger] val branchResolution = new BranchResolution(blockchain, blockchainReader)
   private[ledger] val blockImport =
     new BlockImport(
       blockchain,
+      blockchainReader,
       blockQueue,
       blockValidation,
       blockExecution,

--- a/src/main/scala/io/iohk/ethereum/network/handshaker/EtcForkBlockExchangeState.scala
+++ b/src/main/scala/io/iohk/ethereum/network/handshaker/EtcForkBlockExchangeState.scala
@@ -52,7 +52,7 @@ case class EtcForkBlockExchangeState(
 
     case GetBlockHeaders(Left(number), numHeaders, _, _) if number == forkResolver.forkBlockNumber && numHeaders == 1 =>
       log.debug("Received request for fork block")
-      blockchain.getBlockHeaderByNumber(number) match {
+      blockchainReader.getBlockHeaderByNumber(number) match {
         case Some(header) => Some(BlockHeaders(Seq(header)))
         case None => Some(BlockHeaders(Nil))
       }

--- a/src/main/scala/io/iohk/ethereum/network/handshaker/EtcHandshaker.scala
+++ b/src/main/scala/io/iohk/ethereum/network/handshaker/EtcHandshaker.scala
@@ -2,7 +2,7 @@ package io.iohk.ethereum.network.handshaker
 
 import java.util.concurrent.atomic.AtomicReference
 import io.iohk.ethereum.db.storage.AppStateStorage
-import io.iohk.ethereum.domain.Blockchain
+import io.iohk.ethereum.domain.{Blockchain, BlockchainReader}
 import io.iohk.ethereum.network.EtcPeerManagerActor.PeerInfo
 import io.iohk.ethereum.network.ForkResolver
 import io.iohk.ethereum.network.PeerManagerActor.PeerConfiguration
@@ -32,6 +32,7 @@ object EtcHandshaker {
 trait EtcHandshakerConfiguration {
   val nodeStatusHolder: AtomicReference[NodeStatus]
   val blockchain: Blockchain
+  val blockchainReader: BlockchainReader
   val appStateStorage: AppStateStorage
   val peerConfiguration: PeerConfiguration
   val forkResolverOpt: Option[ForkResolver]

--- a/src/main/scala/io/iohk/ethereum/network/handshaker/EtcNodeStatusExchangeState.scala
+++ b/src/main/scala/io/iohk/ethereum/network/handshaker/EtcNodeStatusExchangeState.scala
@@ -43,7 +43,7 @@ trait EtcNodeStatusExchangeState[T <: Message] extends InProgressState[PeerInfo]
 
   protected def getBestBlockHeader() = {
     val bestBlockNumber = blockchain.getBestBlockNumber()
-    blockchain.getBlockHeaderByNumber(bestBlockNumber).getOrElse(blockchain.genesisHeader)
+    blockchainReader.getBlockHeaderByNumber(bestBlockNumber).getOrElse(blockchain.genesisHeader)
   }
 
   protected def createStatusMsg(): MessageSerializable

--- a/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
@@ -158,12 +158,7 @@ trait NodeStatusBuilder {
 trait BlockchainBuilder {
   self: StorageBuilder =>
 
-  lazy val blockchainReader: BlockchainReader =
-    new BlockchainReader(
-      storagesInstance.storages.blockHeadersStorage,
-      storagesInstance.storages.blockBodiesStorage,
-      storagesInstance.storages.blockNumberMappingStorage
-    )
+  lazy val blockchainReader: BlockchainReader = BlockchainReader(storagesInstance.storages)
   lazy val blockchain: BlockchainImpl = BlockchainImpl(storagesInstance.storages, blockchainReader)
 }
 

--- a/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
@@ -279,7 +279,6 @@ trait BlockchainHostBuilder {
 
   val blockchainHost: ActorRef = system.actorOf(
     BlockchainHostActor.props(
-      blockchain,
       blockchainReader,
       storagesInstance.storages.evmCodeStorage,
       peerConfiguration,
@@ -361,7 +360,6 @@ trait FilterManagerBuilder {
         blockchain,
         blockchainReader,
         consensus.blockGenerator,
-        storagesInstance.storages.appStateStorage,
         keyStore,
         pendingTransactionsManager,
         filterConfig,

--- a/src/main/scala/io/iohk/ethereum/testmode/TestBlockchainBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/testmode/TestBlockchainBuilder.scala
@@ -37,7 +37,7 @@ trait TestBlockchainBuilder extends BlockchainBuilder {
           evmCodeStorage,
           stateStorage.getBackingStorage(blockNumber),
           accountStartNonce,
-          (number: BigInt) => getBlockHeaderByNumber(number).map(_.hash),
+          (number: BigInt) => blockchainReader.getBlockHeaderByNumber(number).map(_.hash),
           stateRootHash,
           noEmptyAccounts,
           ethCompatibleStorage,

--- a/src/main/scala/io/iohk/ethereum/testmode/TestBlockchainBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/testmode/TestBlockchainBuilder.scala
@@ -23,7 +23,8 @@ trait TestBlockchainBuilder extends BlockchainBuilder {
       chainWeightStorage = storages.chainWeightStorage,
       transactionMappingStorage = storages.transactionMappingStorage,
       appStateStorage = storages.appStateStorage,
-      stateStorage = storages.stateStorage
+      stateStorage = storages.stateStorage,
+      blockchainReader = blockchainReader
     ) {
       override def getWorldStateProxy(
           blockNumber: BigInt,

--- a/src/main/scala/io/iohk/ethereum/testmode/TestEthBlockServiceWrapper.scala
+++ b/src/main/scala/io/iohk/ethereum/testmode/TestEthBlockServiceWrapper.scala
@@ -32,7 +32,7 @@ class TestEthBlockServiceWrapper(
     .getByBlockHash(request)
     .map(
       _.map(blockByBlockResponse => {
-        val fullBlock = blockchain.getBlockByNumber(blockByBlockResponse.blockResponse.get.number).get
+        val fullBlock = blockchainReader.getBlockByNumber(blockByBlockResponse.blockResponse.get.number).get
         BlockByBlockHashResponse(blockByBlockResponse.blockResponse.map(response => toEthResponse(fullBlock, response)))
       })
     )
@@ -49,7 +49,7 @@ class TestEthBlockServiceWrapper(
     .getBlockByNumber(request)
     .map(
       _.map(blockByBlockResponse => {
-        val fullBlock = blockchain.getBlockByNumber(blockByBlockResponse.blockResponse.get.number).get
+        val fullBlock = blockchainReader.getBlockByNumber(blockByBlockResponse.blockResponse.get.number).get
         BlockByNumberResponse(blockByBlockResponse.blockResponse.map(response => toEthResponse(fullBlock, response)))
       })
     )

--- a/src/main/scala/io/iohk/ethereum/testmode/TestEthBlockServiceWrapper.scala
+++ b/src/main/scala/io/iohk/ethereum/testmode/TestEthBlockServiceWrapper.scala
@@ -1,6 +1,6 @@
 package io.iohk.ethereum.testmode
 
-import io.iohk.ethereum.domain.{Block, BlockHeader, Blockchain, SignedTransaction, UInt256}
+import io.iohk.ethereum.domain.{Block, BlockHeader, Blockchain, BlockchainReader, SignedTransaction, UInt256}
 import io.iohk.ethereum.jsonrpc.EthBlocksService.{BlockByBlockHashResponse, BlockByNumberResponse}
 import io.iohk.ethereum.jsonrpc.{
   BaseBlockResponse,
@@ -11,11 +11,13 @@ import io.iohk.ethereum.jsonrpc.{
 }
 import io.iohk.ethereum.ledger.Ledger
 import io.iohk.ethereum.utils.Logger
-import io.iohk.ethereum.consensus.Consensus
 import akka.util.ByteString
 
-class TestEthBlockServiceWrapper(blockchain: Blockchain, ledger: Ledger, consensus: Consensus)
-    extends EthBlocksService(blockchain, ledger)
+class TestEthBlockServiceWrapper(
+    blockchain: Blockchain,
+    blockchainReader: BlockchainReader,
+    ledger: Ledger
+) extends EthBlocksService(blockchain, blockchainReader, ledger)
     with Logger {
 
   /**

--- a/src/main/scala/io/iohk/ethereum/testmode/TestModeComponentsProvider.scala
+++ b/src/main/scala/io/iohk/ethereum/testmode/TestModeComponentsProvider.scala
@@ -2,7 +2,7 @@ package io.iohk.ethereum.testmode
 
 import io.iohk.ethereum.consensus.difficulty.DifficultyCalculator
 import io.iohk.ethereum.consensus.{Consensus, ConsensusConfig}
-import io.iohk.ethereum.domain.BlockchainImpl
+import io.iohk.ethereum.domain.{BlockchainImpl, BlockchainReader}
 import io.iohk.ethereum.ledger.Ledger.VMImpl
 import io.iohk.ethereum.ledger.{Ledger, LedgerImpl, StxLedger}
 import io.iohk.ethereum.utils.BlockchainConfig
@@ -12,6 +12,7 @@ import monix.execution.Scheduler
 /** Provides a ledger or consensus instances with modifiable blockchain config (used in test mode). */
 class TestModeComponentsProvider(
     blockchain: BlockchainImpl,
+    blockchainReader: BlockchainReader,
     syncConfig: SyncConfig,
     validationExecutionContext: Scheduler,
     consensusConfig: ConsensusConfig,
@@ -22,6 +23,7 @@ class TestModeComponentsProvider(
   def ledger(blockchainConfig: BlockchainConfig, sealEngine: SealEngineType): Ledger =
     new LedgerImpl(
       blockchain,
+      blockchainReader,
       blockchainConfig,
       syncConfig,
       consensus(blockchainConfig, sealEngine),

--- a/src/main/scala/io/iohk/ethereum/testmode/TestModeServiceBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/testmode/TestModeServiceBuilder.scala
@@ -24,6 +24,7 @@ trait TestModeServiceBuilder extends LedgerBuilder {
   lazy val testModeComponentsProvider: TestModeComponentsProvider =
     new TestModeComponentsProvider(
       blockchain,
+      blockchainReader,
       syncConfig,
       scheduler,
       consensusConfig,

--- a/src/main/scala/io/iohk/ethereum/transactions/TransactionHistoryService.scala
+++ b/src/main/scala/io/iohk/ethereum/transactions/TransactionHistoryService.scala
@@ -37,7 +37,7 @@ class TransactionHistoryService(
       .collect { case Some(block) => block }
       .concatMap { block =>
         val getBlockReceipts = Task {
-          blockchain.getReceiptsByHash(block.hash).map(_.toVector).getOrElse(Vector.empty)
+          blockchainReader.getReceiptsByHash(block.hash).map(_.toVector).getOrElse(Vector.empty)
         }.memoizeOnSuccess
 
         Observable

--- a/src/main/scala/io/iohk/ethereum/transactions/TransactionHistoryService.scala
+++ b/src/main/scala/io/iohk/ethereum/transactions/TransactionHistoryService.scala
@@ -20,6 +20,7 @@ import scala.concurrent.duration.FiniteDuration
 
 class TransactionHistoryService(
     blockchain: Blockchain,
+    blockchainReader: BlockchainReader,
     pendingTransactionsManager: ActorRef,
     getTransactionFromPoolTimeout: FiniteDuration
 ) extends Logger {
@@ -30,7 +31,9 @@ class TransactionHistoryService(
     val getLastCheckpoint = Task { blockchain.getLatestCheckpointBlockNumber() }.memoizeOnSuccess
     val txnsFromBlocks = Observable
       .from(fromBlocks.reverse)
-      .mapParallelOrdered(10)(blockNr => Task { blockchain.getBlockByNumber(blockNr) })(OverflowStrategy.Unbounded)
+      .mapParallelOrdered(10)(blockNr => Task { blockchainReader.getBlockByNumber(blockNr) })(
+        OverflowStrategy.Unbounded
+      )
       .collect { case Some(block) => block }
       .concatMap { block =>
         val getBlockReceipts = Task {

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/BlockchainHostActorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/BlockchainHostActorSpec.scala
@@ -308,6 +308,7 @@ class BlockchainHostActorSpec extends AnyFlatSpec with Matchers {
       Props(
         new BlockchainHostActor(
           blockchain,
+          blockchainReader,
           storagesInstance.storages.evmCodeStorage,
           peerConf,
           peerEventBus.ref,

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/BlockchainHostActorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/BlockchainHostActorSpec.scala
@@ -307,7 +307,6 @@ class BlockchainHostActorSpec extends AnyFlatSpec with Matchers {
     val blockchainHost = TestActorRef(
       Props(
         new BlockchainHostActor(
-          blockchain,
           blockchainReader,
           storagesInstance.storages.evmCodeStorage,
           peerConf,

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/FastSyncSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/FastSyncSpec.scala
@@ -71,6 +71,7 @@ class FastSyncSpec
         fastSyncStateStorage = storagesInstance.storages.fastSyncStateStorage,
         appStateStorage = storagesInstance.storages.appStateStorage,
         blockchain = blockchain,
+        blockchainReader = blockchainReader,
         evmCodeStorage = storagesInstance.storages.evmCodeStorage,
         nodeStorage = storagesInstance.storages.nodeStorage,
         validators = validators,

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/ScenarioSetup.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/ScenarioSetup.scala
@@ -5,7 +5,7 @@ import io.iohk.ethereum.Mocks.MockVM
 import io.iohk.ethereum.consensus.pow.validators.ValidatorsExecutor
 import io.iohk.ethereum.consensus.validators.Validators
 import io.iohk.ethereum.consensus.{Consensus, Protocol, StdTestConsensusBuilder, TestConsensus}
-import io.iohk.ethereum.domain.BlockchainImpl
+import io.iohk.ethereum.domain.{BlockchainImpl, BlockchainReader}
 import io.iohk.ethereum.ledger.Ledger.VMImpl
 import io.iohk.ethereum.ledger.LedgerImpl
 import io.iohk.ethereum.nodebuilder._
@@ -86,24 +86,31 @@ trait ScenarioSetup extends StdTestConsensusBuilder with SyncConfigBuilder with 
   protected def newTestLedger(consensus: Consensus): LedgerImpl =
     new LedgerImpl(
       blockchain = blockchain,
+      blockchainReader = blockchainReader,
       blockchainConfig = blockchainConfig,
       syncConfig = syncConfig,
       theConsensus = consensus,
       validationContext = monixScheduler
     )
 
-  protected def newTestLedger(blockchain: BlockchainImpl): LedgerImpl =
+  protected def newTestLedger(blockchain: BlockchainImpl, blockchainReader: BlockchainReader): LedgerImpl =
     new LedgerImpl(
       blockchain = blockchain,
+      blockchainReader = blockchainReader,
       blockchainConfig = blockchainConfig,
       syncConfig = syncConfig,
       theConsensus = consensus,
       validationContext = monixScheduler
     )
 
-  protected def newTestLedger(blockchain: BlockchainImpl, blockchainConfig: BlockchainConfig): LedgerImpl =
+  protected def newTestLedger(
+      blockchain: BlockchainImpl,
+      blockchainReader: BlockchainReader,
+      blockchainConfig: BlockchainConfig
+  ): LedgerImpl =
     new LedgerImpl(
       blockchain = blockchain,
+      blockchainReader = blockchainReader,
       blockchainConfig = blockchainConfig,
       syncConfig = syncConfig,
       theConsensus = consensus,

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/StateSyncSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/StateSyncSpec.scala
@@ -118,7 +118,11 @@ class StateSyncSpec
         transactionMappingStorage = storages.transactionMappingStorage,
         appStateStorage = storages.appStateStorage,
         stateStorage = storages.stateStorage,
-        blockchainReader = new BlockchainReader(storages.blockHeadersStorage, storages.blockBodiesStorage)
+        blockchainReader = new BlockchainReader(
+          storages.blockHeadersStorage,
+          storages.blockBodiesStorage,
+          storages.blockNumberMappingStorage
+        )
       )
     }
     val nodeData = (0 until 1000).map(i => MptNodeData(Address(i), None, Seq(), i))
@@ -240,7 +244,14 @@ class StateSyncSpec
 
     def buildBlockChain() = {
       val storages = getNewStorages.storages
-      BlockchainImpl(storages, new BlockchainReader(storages.blockHeadersStorage, storages.blockBodiesStorage))
+      BlockchainImpl(
+        storages,
+        new BlockchainReader(
+          storages.blockHeadersStorage,
+          storages.blockBodiesStorage,
+          storages.blockNumberMappingStorage
+        )
+      )
     }
 
     def genRandomArray(): Array[Byte] = {

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/StateSyncSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/StateSyncSpec.scala
@@ -18,7 +18,7 @@ import io.iohk.ethereum.blockchain.sync.fast.SyncStateSchedulerActor.{
   WaitingForNewTargetBlock
 }
 import io.iohk.ethereum.db.dataSource.RocksDbDataSource.IterationError
-import io.iohk.ethereum.domain.{Address, BlockchainImpl, ChainWeight}
+import io.iohk.ethereum.domain.{Address, BlockchainImpl, BlockchainReader, ChainWeight}
 import io.iohk.ethereum.network.EtcPeerManagerActor._
 import io.iohk.ethereum.network.PeerEventBusActor.PeerEvent.MessageFromPeer
 import io.iohk.ethereum.network.p2p.messages.ETH63.GetNodeData.GetNodeDataEnc
@@ -117,7 +117,8 @@ class StateSyncSpec
         chainWeightStorage = storages.chainWeightStorage,
         transactionMappingStorage = storages.transactionMappingStorage,
         appStateStorage = storages.appStateStorage,
-        stateStorage = storages.stateStorage
+        stateStorage = storages.stateStorage,
+        blockchainReader = new BlockchainReader(storages.blockHeadersStorage)
       )
     }
     val nodeData = (0 until 1000).map(i => MptNodeData(Address(i), None, Seq(), i))
@@ -238,7 +239,8 @@ class StateSyncSpec
     )
 
     def buildBlockChain() = {
-      BlockchainImpl(getNewStorages.storages)
+      val storages = getNewStorages.storages
+      BlockchainImpl(storages, new BlockchainReader(storages.blockHeadersStorage))
     }
 
     def genRandomArray(): Array[Byte] = {

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/StateSyncSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/StateSyncSpec.scala
@@ -118,7 +118,7 @@ class StateSyncSpec
         transactionMappingStorage = storages.transactionMappingStorage,
         appStateStorage = storages.appStateStorage,
         stateStorage = storages.stateStorage,
-        blockchainReader = new BlockchainReader(storages.blockHeadersStorage)
+        blockchainReader = new BlockchainReader(storages.blockHeadersStorage, storages.blockBodiesStorage)
       )
     }
     val nodeData = (0 until 1000).map(i => MptNodeData(Address(i), None, Seq(), i))
@@ -240,7 +240,7 @@ class StateSyncSpec
 
     def buildBlockChain() = {
       val storages = getNewStorages.storages
-      BlockchainImpl(storages, new BlockchainReader(storages.blockHeadersStorage))
+      BlockchainImpl(storages, new BlockchainReader(storages.blockHeadersStorage, storages.blockBodiesStorage))
     }
 
     def genRandomArray(): Array[Byte] = {

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/StateSyncUtils.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/StateSyncUtils.scala
@@ -3,7 +3,7 @@ package io.iohk.ethereum.blockchain.sync
 import akka.util.ByteString
 import io.iohk.ethereum.blockchain.sync.fast.SyncStateScheduler.SyncResponse
 import io.iohk.ethereum.db.storage.EvmCodeStorage
-import io.iohk.ethereum.domain.{Account, Address, Blockchain, BlockchainImpl}
+import io.iohk.ethereum.domain.{Account, Address, Blockchain, BlockchainImpl, BlockchainReader}
 import io.iohk.ethereum.ledger.InMemoryWorldStateProxy
 import io.iohk.ethereum.mpt.MerklePatriciaTrie
 import io.iohk.ethereum.utils.{BlockchainConfig, ByteUtils}
@@ -68,7 +68,11 @@ object StateSyncUtils extends EphemBlockchainTestSetup {
   object TrieProvider {
     def apply(): TrieProvider = {
       val freshStorage = getNewStorages
-      new TrieProvider(BlockchainImpl(freshStorage.storages), freshStorage.storages.evmCodeStorage, blockchainConfig)
+      new TrieProvider(
+        BlockchainImpl(freshStorage.storages, new BlockchainReader(freshStorage.storages.blockHeadersStorage)),
+        freshStorage.storages.evmCodeStorage,
+        blockchainConfig
+      )
     }
   }
 

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/StateSyncUtils.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/StateSyncUtils.scala
@@ -69,7 +69,10 @@ object StateSyncUtils extends EphemBlockchainTestSetup {
     def apply(): TrieProvider = {
       val freshStorage = getNewStorages
       new TrieProvider(
-        BlockchainImpl(freshStorage.storages, new BlockchainReader(freshStorage.storages.blockHeadersStorage)),
+        BlockchainImpl(
+          freshStorage.storages,
+          new BlockchainReader(freshStorage.storages.blockHeadersStorage, freshStorage.storages.blockBodiesStorage)
+        ),
         freshStorage.storages.evmCodeStorage,
         blockchainConfig
       )

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/StateSyncUtils.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/StateSyncUtils.scala
@@ -71,7 +71,11 @@ object StateSyncUtils extends EphemBlockchainTestSetup {
       new TrieProvider(
         BlockchainImpl(
           freshStorage.storages,
-          new BlockchainReader(freshStorage.storages.blockHeadersStorage, freshStorage.storages.blockBodiesStorage)
+          new BlockchainReader(
+            freshStorage.storages.blockHeadersStorage,
+            freshStorage.storages.blockBodiesStorage,
+            freshStorage.storages.blockNumberMappingStorage
+          )
         ),
         freshStorage.storages.evmCodeStorage,
         blockchainConfig

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/SyncControllerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/SyncControllerSpec.scala
@@ -533,6 +533,7 @@ class SyncControllerSpec
         new SyncController(
           storagesInstance.storages.appStateStorage,
           blockchain,
+          blockchainReader,
           storagesInstance.storages.evmCodeStorage,
           storagesInstance.storages.nodeStorage,
           storagesInstance.storages.fastSyncStateStorage,

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/SyncStateSchedulerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/SyncStateSchedulerSpec.scala
@@ -263,14 +263,9 @@ class SyncStateSchedulerSpec
   trait TestSetup extends EphemBlockchainTestSetup {
     def getTrieProvider: TrieProvider = {
       val freshStorage = getNewStorages
-      val freshBlockchainReader =
-        new BlockchainReader(
-          freshStorage.storages.blockHeadersStorage,
-          freshStorage.storages.blockBodiesStorage,
-          freshStorage.storages.blockNumberMappingStorage
-        )
+      val freshBlockchainReader = BlockchainReader(freshStorage.storages)
       val freshBlockchain = BlockchainImpl(freshStorage.storages, freshBlockchainReader)
-      new TrieProvider(freshBlockchain, freshStorage.storages.evmCodeStorage, blockchainConfig)
+      new TrieProvider(freshBlockchain, freshBlockchainReader, freshStorage.storages.evmCodeStorage, blockchainConfig)
     }
     val bloomFilterSize = 1000
 
@@ -295,16 +290,12 @@ class SyncStateSchedulerSpec
         EphemDataSourceComponent with LocalPruningConfigBuilder with Storages.DefaultStorages
     ) = {
       val freshStorage = getNewStorages
-      val freshBlockchainReader =
-        new BlockchainReader(
-          freshStorage.storages.blockHeadersStorage,
-          freshStorage.storages.blockBodiesStorage,
-          freshStorage.storages.blockNumberMappingStorage
-        )
+      val freshBlockchainReader = BlockchainReader(freshStorage.storages)
       val freshBlockchain = BlockchainImpl(freshStorage.storages, freshBlockchainReader)
       (
         SyncStateScheduler(
           freshBlockchain,
+          freshBlockchainReader,
           freshStorage.storages.evmCodeStorage,
           freshStorage.storages.nodeStorage,
           bloomFilterSize

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/SyncStateSchedulerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/SyncStateSchedulerSpec.scala
@@ -264,7 +264,11 @@ class SyncStateSchedulerSpec
     def getTrieProvider: TrieProvider = {
       val freshStorage = getNewStorages
       val freshBlockchainReader =
-        new BlockchainReader(freshStorage.storages.blockHeadersStorage, freshStorage.storages.blockBodiesStorage)
+        new BlockchainReader(
+          freshStorage.storages.blockHeadersStorage,
+          freshStorage.storages.blockBodiesStorage,
+          freshStorage.storages.blockNumberMappingStorage
+        )
       val freshBlockchain = BlockchainImpl(freshStorage.storages, freshBlockchainReader)
       new TrieProvider(freshBlockchain, freshStorage.storages.evmCodeStorage, blockchainConfig)
     }
@@ -292,7 +296,11 @@ class SyncStateSchedulerSpec
     ) = {
       val freshStorage = getNewStorages
       val freshBlockchainReader =
-        new BlockchainReader(freshStorage.storages.blockHeadersStorage, freshStorage.storages.blockBodiesStorage)
+        new BlockchainReader(
+          freshStorage.storages.blockHeadersStorage,
+          freshStorage.storages.blockBodiesStorage,
+          freshStorage.storages.blockNumberMappingStorage
+        )
       val freshBlockchain = BlockchainImpl(freshStorage.storages, freshBlockchainReader)
       (
         SyncStateScheduler(

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/SyncStateSchedulerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/SyncStateSchedulerSpec.scala
@@ -12,7 +12,7 @@ import io.iohk.ethereum.blockchain.sync.fast.SyncStateScheduler.{
   SyncResponse
 }
 import io.iohk.ethereum.db.components.{EphemDataSourceComponent, Storages}
-import io.iohk.ethereum.domain.{Address, BlockchainImpl}
+import io.iohk.ethereum.domain.{Address, BlockchainImpl, BlockchainReader}
 import io.iohk.ethereum.vm.Generators.genMultipleNodeData
 import org.scalactic.anyvals.PosInt
 import org.scalatest.EitherValues
@@ -263,7 +263,8 @@ class SyncStateSchedulerSpec
   trait TestSetup extends EphemBlockchainTestSetup {
     def getTrieProvider: TrieProvider = {
       val freshStorage = getNewStorages
-      val freshBlockchain = BlockchainImpl(freshStorage.storages)
+      val freshBlockchainReader = new BlockchainReader(freshStorage.storages.blockHeadersStorage)
+      val freshBlockchain = BlockchainImpl(freshStorage.storages, freshBlockchainReader)
       new TrieProvider(freshBlockchain, freshStorage.storages.evmCodeStorage, blockchainConfig)
     }
     val bloomFilterSize = 1000
@@ -289,7 +290,8 @@ class SyncStateSchedulerSpec
         EphemDataSourceComponent with LocalPruningConfigBuilder with Storages.DefaultStorages
     ) = {
       val freshStorage = getNewStorages
-      val freshBlockchain = BlockchainImpl(freshStorage.storages)
+      val freshBlockchainReader = new BlockchainReader(freshStorage.storages.blockHeadersStorage)
+      val freshBlockchain = BlockchainImpl(freshStorage.storages, freshBlockchainReader)
       (
         SyncStateScheduler(
           freshBlockchain,

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/SyncStateSchedulerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/SyncStateSchedulerSpec.scala
@@ -263,7 +263,8 @@ class SyncStateSchedulerSpec
   trait TestSetup extends EphemBlockchainTestSetup {
     def getTrieProvider: TrieProvider = {
       val freshStorage = getNewStorages
-      val freshBlockchainReader = new BlockchainReader(freshStorage.storages.blockHeadersStorage)
+      val freshBlockchainReader =
+        new BlockchainReader(freshStorage.storages.blockHeadersStorage, freshStorage.storages.blockBodiesStorage)
       val freshBlockchain = BlockchainImpl(freshStorage.storages, freshBlockchainReader)
       new TrieProvider(freshBlockchain, freshStorage.storages.evmCodeStorage, blockchainConfig)
     }
@@ -290,7 +291,8 @@ class SyncStateSchedulerSpec
         EphemDataSourceComponent with LocalPruningConfigBuilder with Storages.DefaultStorages
     ) = {
       val freshStorage = getNewStorages
-      val freshBlockchainReader = new BlockchainReader(freshStorage.storages.blockHeadersStorage)
+      val freshBlockchainReader =
+        new BlockchainReader(freshStorage.storages.blockHeadersStorage, freshStorage.storages.blockBodiesStorage)
       val freshBlockchain = BlockchainImpl(freshStorage.storages, freshBlockchainReader)
       (
         SyncStateScheduler(

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/fast/FastSyncBranchResolverActorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/fast/FastSyncBranchResolverActorSpec.scala
@@ -293,6 +293,7 @@ class FastSyncBranchResolverActorSpec
           peerEventBus = TestProbe("peer_event_bus").ref,
           etcPeerManager = etcPeerManager,
           blockchain = blockchain,
+          blockchainReader = blockchainReader,
           blacklist = blacklist,
           syncConfig = syncConfig,
           appStateStorage = storagesInstance.storages.appStateStorage,

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/regular/RegularSyncFixtures.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/regular/RegularSyncFixtures.scala
@@ -158,7 +158,14 @@ trait RegularSyncFixtures { self: Matchers with AsyncMockFactory =>
       .timeout(remainingOrDefault)
 
     class TestLedgerImpl
-        extends LedgerImpl(blockchain, blockchainConfig, syncConfig, consensus, Scheduler(system.dispatcher)) {
+        extends LedgerImpl(
+          blockchain,
+          blockchainReader,
+          blockchainConfig,
+          syncConfig,
+          consensus,
+          Scheduler(system.dispatcher)
+        ) {
       protected val results = mutable.Map[ByteString, Task[BlockImportResult]]()
       protected val importedBlocksSet = mutable.Set[Block]()
       private val importedBlocksSubject = ReplaySubject[Block]()

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/regular/RegularSyncSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/regular/RegularSyncSpec.scala
@@ -444,6 +444,7 @@ class RegularSyncSpec
 
       "save fetched node" in sync(new Fixture(testSystem) {
         override lazy val blockchain: BlockchainImpl = stub[BlockchainImpl]
+        override lazy val blockchainReader: BlockchainReader = stub[BlockchainReader]
         override lazy val ledger: TestLedgerImpl = stub[TestLedgerImpl]
         val failingBlock: Block = testBlocksChunked.head.head
         peersClient.setAutoPilot(new PeersClientAutoPilot)
@@ -456,7 +457,7 @@ class RegularSyncSpec
         var saveNodeWasCalled: Boolean = false
         val nodeData = List(ByteString(failingBlock.header.toBytes: Array[Byte]))
         (blockchain.getBestBlockNumber _).when().returns(0)
-        (blockchain.getBlockHeaderByNumber _).when(*).returns(Some(BlockHelpers.genesis.header))
+        (blockchainReader.getBlockHeaderByNumber _).when(*).returns(Some(BlockHelpers.genesis.header))
         (blockchain.saveNode _)
           .when(*, *, *)
           .onCall((hash, encoded, totalDifficulty) => {

--- a/src/test/scala/io/iohk/ethereum/consensus/blocks/BlockGeneratorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/blocks/BlockGeneratorSpec.scala
@@ -710,7 +710,7 @@ class BlockGeneratorSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
     lazy val blockGenerator = consensus.blockGenerator.withBlockTimestampProvider(blockTimestampProvider)
 
     lazy val blockValidation =
-      new BlockValidation(consensus, blockchain, blockchainReader, BlockQueue(blockchain, syncConfig))
+      new BlockValidation(consensus, blockchainReader, BlockQueue(blockchain, syncConfig))
     lazy val blockExecution =
       new BlockExecution(blockchain, blockchainReader, blockchainConfig, consensus.blockPreparator, blockValidation)
 

--- a/src/test/scala/io/iohk/ethereum/consensus/blocks/BlockGeneratorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/blocks/BlockGeneratorSpec.scala
@@ -691,7 +691,8 @@ class BlockGeneratorSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
     )
     override lazy val blockchainConfig = baseBlockchainConfig
 
-    val genesisDataLoader = new GenesisDataLoader(blockchain, storagesInstance.storages.stateStorage, blockchainConfig)
+    val genesisDataLoader =
+      new GenesisDataLoader(blockchain, blockchainReader, storagesInstance.storages.stateStorage, blockchainConfig)
     genesisDataLoader.loadGenesisData()
 
     val bestBlock = blockchain.getBestBlock()

--- a/src/test/scala/io/iohk/ethereum/consensus/blocks/BlockGeneratorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/blocks/BlockGeneratorSpec.scala
@@ -47,7 +47,7 @@ class BlockGeneratorSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
     )
     validators.blockHeaderValidator.validate(
       fullBlock.header,
-      blockchain.getBlockHeaderByHash
+      blockchainReader.getBlockHeaderByHash
     ) shouldBe Right(BlockHeaderValid)
     blockExecution.executeAndValidateBlock(fullBlock) shouldBe a[Right[_, Seq[Receipt]]]
     fullBlock.header.extraData shouldBe headerExtraData
@@ -74,7 +74,7 @@ class BlockGeneratorSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
     )
     validators.blockHeaderValidator.validate(
       fullBlock.header,
-      blockchain.getBlockHeaderByHash
+      blockchainReader.getBlockHeaderByHash
     ) shouldBe Right(BlockHeaderValid)
     blockExecution.executeAndValidateBlock(fullBlock) shouldBe a[Right[_, Seq[Receipt]]]
     fullBlock.header.extraData shouldBe headerExtraData
@@ -155,7 +155,7 @@ class BlockGeneratorSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
     )
     validators.blockHeaderValidator.validate(
       fullBlock.header,
-      blockchain.getBlockHeaderByHash
+      blockchainReader.getBlockHeaderByHash
     ) shouldBe Right(BlockHeaderValid)
 
     blockExecution.executeAndValidateBlock(fullBlock) shouldBe a[Right[_, Seq[Receipt]]]
@@ -194,7 +194,7 @@ class BlockGeneratorSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
 
     validators.blockHeaderValidator.validate(
       fullBlock.header,
-      blockchain.getBlockHeaderByHash
+      blockchainReader.getBlockHeaderByHash
     ) shouldBe Right(BlockHeaderValid)
     blockExecution.executeAndValidateBlock(fullBlock) shouldBe a[Right[_, Seq[Receipt]]]
     fullBlock.body.transactionList shouldBe Seq(signedTransaction.tx)
@@ -243,7 +243,7 @@ class BlockGeneratorSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
     )
 
     override lazy val blockExecution =
-      new BlockExecution(blockchain, blockchainConfig, consensus.blockPreparator, blockValidation)
+      new BlockExecution(blockchain, blockchainReader, blockchainConfig, consensus.blockPreparator, blockValidation)
 
     val generalTx = SignedTransaction.sign(transaction, keyPair, None).tx
     val specificTx =
@@ -270,7 +270,7 @@ class BlockGeneratorSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
       )
     validators.blockHeaderValidator.validate(
       fullBlock.header,
-      blockchain.getBlockHeaderByHash
+      blockchainReader.getBlockHeaderByHash
     ) shouldBe Right(BlockHeaderValid)
     blockExecution.executeAndValidateBlock(fullBlock) shouldBe a[Right[_, Seq[Receipt]]]
     fullBlock.body.transactionList shouldBe Seq(generalTx)
@@ -319,7 +319,7 @@ class BlockGeneratorSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
     )
 
     override lazy val blockExecution =
-      new BlockExecution(blockchain, blockchainConfig, consensus.blockPreparator, blockValidation)
+      new BlockExecution(blockchain, blockchainReader, blockchainConfig, consensus.blockPreparator, blockValidation)
 
     val transaction1 = Transaction(
       nonce = 0,
@@ -367,7 +367,7 @@ class BlockGeneratorSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
           gasLimit = generatedBlockGasLimit
         )
       )
-    validators.blockHeaderValidator.validate(fullBlock.header, blockchain.getBlockHeaderByHash) shouldBe Right(
+    validators.blockHeaderValidator.validate(fullBlock.header, blockchainReader.getBlockHeaderByHash) shouldBe Right(
       BlockHeaderValid
     )
     blockExecution.executeAndValidateBlock(fullBlock) shouldBe a[Right[_, Seq[Receipt]]]
@@ -404,7 +404,7 @@ class BlockGeneratorSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
           gasLimit = generatedBlockGasLimit
         )
       )
-    validators.blockHeaderValidator.validate(fullBlock.header, blockchain.getBlockHeaderByHash) shouldBe Right(
+    validators.blockHeaderValidator.validate(fullBlock.header, blockchainReader.getBlockHeaderByHash) shouldBe Right(
       BlockHeaderValid
     )
     blockExecution.executeAndValidateBlock(fullBlock) shouldBe a[Right[_, Seq[Receipt]]]
@@ -454,7 +454,7 @@ class BlockGeneratorSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
         gasLimit = generatedBlockGasLimit
       )
     )
-    validators.blockHeaderValidator.validate(fullBlock.header, blockchain.getBlockHeaderByHash) shouldBe Right(
+    validators.blockHeaderValidator.validate(fullBlock.header, blockchainReader.getBlockHeaderByHash) shouldBe Right(
       BlockHeaderValid
     )
     blockExecution.executeAndValidateBlock(fullBlock) shouldBe a[Right[_, Seq[Receipt]]]
@@ -491,7 +491,7 @@ class BlockGeneratorSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
         gasLimit = generatedBlockGasLimit
       )
     )
-    validators.blockHeaderValidator.validate(fullBlock.header, blockchain.getBlockHeaderByHash) shouldBe Right(
+    validators.blockHeaderValidator.validate(fullBlock.header, blockchainReader.getBlockHeaderByHash) shouldBe Right(
       BlockHeaderValid
     )
     blockExecution.executeAndValidateBlock(fullBlock) shouldBe a[Right[_, Seq[Receipt]]]
@@ -708,9 +708,10 @@ class BlockGeneratorSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
 
     lazy val blockGenerator = consensus.blockGenerator.withBlockTimestampProvider(blockTimestampProvider)
 
-    lazy val blockValidation = new BlockValidation(consensus, blockchain, BlockQueue(blockchain, syncConfig))
+    lazy val blockValidation =
+      new BlockValidation(consensus, blockchain, blockchainReader, BlockQueue(blockchain, syncConfig))
     lazy val blockExecution =
-      new BlockExecution(blockchain, blockchainConfig, consensus.blockPreparator, blockValidation)
+      new BlockExecution(blockchain, blockchainReader, blockchainConfig, consensus.blockPreparator, blockValidation)
 
     // FIXME: the change in gas limit voting strategy caused the hardcoded nonce and mixHash in this file to be invalid
     //        The gas limit of all the generated blocks has to be set to the old strategy of increasing as much as possible

--- a/src/test/scala/io/iohk/ethereum/consensus/pow/MinerSpecSetup.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/pow/MinerSpecSetup.scala
@@ -36,6 +36,7 @@ trait MinerSpecSetup extends ConsensusConfigBuilder with MockFactory {
 
   val origin = Block(Fixtures.Blocks.Genesis.header, Fixtures.Blocks.Genesis.body)
 
+  val blockchainReader: BlockchainReader = mock[BlockchainReader]
   val blockchain: BlockchainImpl = mock[BlockchainImpl]
   val blockCreator = mock[PoWBlockCreator]
   val fakeWorld = mock[InMemoryWorldStateProxy]
@@ -76,7 +77,7 @@ trait MinerSpecSetup extends ConsensusConfigBuilder with MockFactory {
     val validators = ValidatorsExecutor(blockchainConfig, consensusConfig.protocol)
 
     val additionalPoWData = NoAdditionalPoWData
-    PoWConsensus(vm, blockchain, blockchainConfig, fullConfig, validators, additionalPoWData)
+    PoWConsensus(vm, blockchain, blockchainReader, blockchainConfig, fullConfig, validators, additionalPoWData)
   }
 
   protected def setBlockForMining(parentBlock: Block, transactions: Seq[SignedTransaction] = Seq(txToMine)): Block = {

--- a/src/test/scala/io/iohk/ethereum/consensus/pow/PoWConsensusSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/pow/PoWConsensusSpec.scala
@@ -9,7 +9,7 @@ import io.iohk.ethereum.consensus.Protocol.{NoAdditionalPoWData, RestrictedPoWMi
 import io.iohk.ethereum.consensus.pow.blocks.{PoWBlockGeneratorImpl, RestrictedPoWBlockGeneratorImpl}
 import io.iohk.ethereum.consensus.pow.validators.ValidatorsExecutor
 import io.iohk.ethereum.consensus.{ConsensusConfigs, FullConsensusConfig, Protocol}
-import io.iohk.ethereum.domain.BlockchainImpl
+import io.iohk.ethereum.domain.{BlockchainImpl, BlockchainReader}
 import io.iohk.ethereum.nodebuilder.StdNode
 import org.bouncycastle.crypto.AsymmetricCipherKeyPair
 import org.scalamock.scalatest.MockFactory
@@ -26,6 +26,7 @@ class PoWConsensusSpec
     val powConsensus = PoWConsensus(
       vm,
       blockchain,
+      blockchainReader,
       blockchainConfig,
       ConsensusConfigs.fullConsensusConfig,
       validator,
@@ -41,6 +42,7 @@ class PoWConsensusSpec
     val powConsensus = PoWConsensus(
       vm,
       blockchain,
+      blockchainReader,
       blockchainConfig,
       ConsensusConfigs.fullConsensusConfig,
       validator,
@@ -57,6 +59,7 @@ class PoWConsensusSpec
     val powConsensus = PoWConsensus(
       vm,
       blockchain,
+      blockchainReader,
       blockchainConfig,
       fullConsensusConfig,
       validator,
@@ -75,6 +78,7 @@ class PoWConsensusSpec
     val powConsensus = PoWConsensus(
       vm,
       blockchain,
+      blockchainReader,
       blockchainConfig,
       fullConsensusConfig,
       validator,
@@ -93,6 +97,7 @@ class PoWConsensusSpec
     val powConsensus = PoWConsensus(
       vm,
       blockchain,
+      blockchainReader,
       blockchainConfig,
       fullConsensusConfig,
       validator,
@@ -111,6 +116,7 @@ class PoWConsensusSpec
     val powConsensus = PoWConsensus(
       vm,
       blockchain,
+      blockchainReader,
       blockchainConfig,
       fullConsensusConfig,
       validator,
@@ -123,6 +129,7 @@ class PoWConsensusSpec
   }
 
   trait TestSetup extends ScenarioSetup with MockFactory {
+    override lazy val blockchainReader: BlockchainReader = mock[BlockchainReader]
     override lazy val blockchain: BlockchainImpl = mock[BlockchainImpl]
     val validator: ValidatorsExecutor = successValidators.asInstanceOf[ValidatorsExecutor]
   }

--- a/src/test/scala/io/iohk/ethereum/consensus/pow/miners/MockedMinerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/pow/miners/MockedMinerSpec.scala
@@ -75,7 +75,7 @@ class MockedMinerSpec
 
         val errorMsg = s"Unable to get parent block with hash ${ByteStringUtils.hash2string(parentHash)} for mining"
 
-        (blockchain.getBlockByHash _).expects(parentHash).returns(None)
+        (blockchainReader.getBlockByHash _).expects(parentHash).returns(None)
 
         withStartedMiner {
           sendToMiner(MineBlocks(2, withTransactions = false, Some(parentHash)))
@@ -115,7 +115,7 @@ class MockedMinerSpec
         val parentHash = origin.hash
         val bfm = setBlockForMining(parent, Seq.empty)
 
-        (blockchain.getBlockByHash _).expects(parentHash).returns(Some(parent))
+        (blockchainReader.getBlockByHash _).expects(parentHash).returns(Some(parent))
 
         blockCreatorBehaviour(parent, withTransactions = false, bfm)
 
@@ -217,6 +217,7 @@ class MockedMinerSpec
     val miner = TestActorRef(
       MockedMiner.props(
         blockchain,
+        blockchainReader,
         blockCreator,
         sync.ref
       )

--- a/src/test/scala/io/iohk/ethereum/consensus/pow/validators/EthashBlockHeaderValidatorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/pow/validators/EthashBlockHeaderValidatorSpec.scala
@@ -168,14 +168,14 @@ class EthashBlockHeaderValidatorSpec
       .storeBlockHeader(validParentBlockHeader)
       .and(blockchain.storeBlockBody(validParentBlockHeader.hash, validParentBlockBody))
       .commit()
-    powBlockHeaderValidator.validate(validBlockHeader, blockchain.getBlockHeaderByHash _) match {
+    powBlockHeaderValidator.validate(validBlockHeader, blockchainReader.getBlockHeaderByHash _) match {
       case Right(_) => succeed
       case _ => fail()
     }
   }
 
   it should "return a failure if the parent's header is not in storage" in new EphemBlockchainTestSetup {
-    powBlockHeaderValidator.validate(validBlockHeader, blockchain.getBlockHeaderByHash _) match {
+    powBlockHeaderValidator.validate(validBlockHeader, blockchainReader.getBlockHeaderByHash _) match {
       case Left(HeaderParentNotFoundError) => succeed
       case _ => fail()
     }

--- a/src/test/scala/io/iohk/ethereum/consensus/pow/validators/StdOmmersValidatorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/pow/validators/StdOmmersValidatorSpec.scala
@@ -79,7 +79,7 @@ class StdOmmersValidatorSpec extends AnyFlatSpec with Matchers with ScalaCheckPr
 
   it should "report failure if there is an ommer which that is not parent of an ancestor" in new BlockUtils {
     val getNBlocksBack: (ByteString, Int) => List[Block] =
-      (_, n) => ((ommersBlockNumber - n) until ommersBlockNumber).toList.flatMap(blockchain.getBlockByNumber)
+      (_, n) => ((ommersBlockNumber - n) until ommersBlockNumber).toList.flatMap(blockchainReader.getBlockByNumber)
 
     ommersValidator.validateOmmersAncestors(
       ommersBlockParentHash,

--- a/src/test/scala/io/iohk/ethereum/consensus/pow/validators/StdOmmersValidatorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/pow/validators/StdOmmersValidatorSpec.scala
@@ -13,14 +13,20 @@ import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 class StdOmmersValidatorSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyChecks with ObjectGenerators {
 
   it should "validate correctly a valid list of ommers" in new BlockUtils {
-    ommersValidator.validate(ommersBlockParentHash, ommersBlockNumber, ommers, blockchain) match {
+    ommersValidator.validate(ommersBlockParentHash, ommersBlockNumber, ommers, blockchain, blockchainReader) match {
       case Right(_) => succeed
       case Left(err) => fail(s"Unexpected validation error: $err")
     }
   }
 
   it should "report failure if the list of ommers is too big" in new BlockUtils {
-    ommersValidator.validate(ommersBlockParentHash, ommersBlockNumber, Seq(ommer1, ommer2, ommer2), blockchain) match {
+    ommersValidator.validate(
+      ommersBlockParentHash,
+      ommersBlockNumber,
+      Seq(ommer1, ommer2, ommer2),
+      blockchain,
+      blockchainReader
+    ) match {
       case Left(OmmersLengthError) => succeed
       case Left(err) => fail(s"Unexpected validation error: $err")
       case Right(_) => fail("Unexpected validation success")
@@ -30,7 +36,13 @@ class StdOmmersValidatorSpec extends AnyFlatSpec with Matchers with ScalaCheckPr
   it should "report failure if there is an invalid header in the list of ommers" in new BlockUtils {
     val invalidOmmer1: BlockHeader = ommer1.copy(number = ommer1.number + 1)
 
-    ommersValidator.validate(ommersBlockParentHash, ommersBlockNumber, Seq(invalidOmmer1, ommer2), blockchain) match {
+    ommersValidator.validate(
+      ommersBlockParentHash,
+      ommersBlockNumber,
+      Seq(invalidOmmer1, ommer2),
+      blockchain,
+      blockchainReader
+    ) match {
       case Left(OmmersHeaderError(List(_))) => succeed
       case Left(err) => fail(s"Unexpected validation error: $err")
       case Right(_) => fail("Unexpected validation success")
@@ -42,7 +54,8 @@ class StdOmmersValidatorSpec extends AnyFlatSpec with Matchers with ScalaCheckPr
       ommersBlockParentHash,
       ommersBlockNumber,
       Seq(block93.body.uncleNodesList.head, ommer2),
-      blockchain
+      blockchain,
+      blockchainReader
     ) match {
       case Left(OmmersUsedBeforeError) => succeed
       case Left(err) => fail(s"Unexpected validation error: $err")
@@ -51,7 +64,13 @@ class StdOmmersValidatorSpec extends AnyFlatSpec with Matchers with ScalaCheckPr
   }
 
   it should "report failure if there is an ommer which is also an ancestor" in new BlockUtils {
-    ommersValidator.validate(ommersBlockParentHash, ommersBlockNumber, Seq(ommer1, block92.header), blockchain) match {
+    ommersValidator.validate(
+      ommersBlockParentHash,
+      ommersBlockNumber,
+      Seq(ommer1, block92.header),
+      blockchain,
+      blockchainReader
+    ) match {
       case Left(OmmerIsAncestorError) => succeed
       case Left(err) => fail(s"Unexpected validation error: $err")
       case Right(_) => fail("Unexpected validation success")
@@ -88,14 +107,26 @@ class StdOmmersValidatorSpec extends AnyFlatSpec with Matchers with ScalaCheckPr
   }
 
   it should "report failure if there is an ommer that is too old" in new BlockUtils {
-    ommersValidator.validate(ommersBlockParentHash, ommersBlockNumber, Seq(ommer1, block90.header), blockchain) match {
+    ommersValidator.validate(
+      ommersBlockParentHash,
+      ommersBlockNumber,
+      Seq(ommer1, block90.header),
+      blockchain,
+      blockchainReader
+    ) match {
       case Left(OmmerParentIsNotAncestorError) => succeed
       case err => fail(err.toString)
     }
   }
 
   it should "report failure if there is a duplicated ommer in the ommers list" in new BlockUtils {
-    ommersValidator.validate(ommersBlockParentHash, ommersBlockNumber, Seq(ommer1, ommer1), blockchain) match {
+    ommersValidator.validate(
+      ommersBlockParentHash,
+      ommersBlockNumber,
+      Seq(ommer1, ommer1),
+      blockchain,
+      blockchainReader
+    ) match {
       case Left(OmmersDuplicatedError) => succeed
       case Left(err) => fail(s"Unexpected validation error: $err")
       case Right(_) => fail("Unexpected validation success")

--- a/src/test/scala/io/iohk/ethereum/consensus/pow/validators/StdOmmersValidatorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/pow/validators/StdOmmersValidatorSpec.scala
@@ -13,7 +13,7 @@ import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 class StdOmmersValidatorSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyChecks with ObjectGenerators {
 
   it should "validate correctly a valid list of ommers" in new BlockUtils {
-    ommersValidator.validate(ommersBlockParentHash, ommersBlockNumber, ommers, blockchain, blockchainReader) match {
+    ommersValidator.validate(ommersBlockParentHash, ommersBlockNumber, ommers, blockchainReader) match {
       case Right(_) => succeed
       case Left(err) => fail(s"Unexpected validation error: $err")
     }
@@ -24,7 +24,6 @@ class StdOmmersValidatorSpec extends AnyFlatSpec with Matchers with ScalaCheckPr
       ommersBlockParentHash,
       ommersBlockNumber,
       Seq(ommer1, ommer2, ommer2),
-      blockchain,
       blockchainReader
     ) match {
       case Left(OmmersLengthError) => succeed
@@ -40,7 +39,6 @@ class StdOmmersValidatorSpec extends AnyFlatSpec with Matchers with ScalaCheckPr
       ommersBlockParentHash,
       ommersBlockNumber,
       Seq(invalidOmmer1, ommer2),
-      blockchain,
       blockchainReader
     ) match {
       case Left(OmmersHeaderError(List(_))) => succeed
@@ -54,7 +52,6 @@ class StdOmmersValidatorSpec extends AnyFlatSpec with Matchers with ScalaCheckPr
       ommersBlockParentHash,
       ommersBlockNumber,
       Seq(block93.body.uncleNodesList.head, ommer2),
-      blockchain,
       blockchainReader
     ) match {
       case Left(OmmersUsedBeforeError) => succeed
@@ -68,7 +65,6 @@ class StdOmmersValidatorSpec extends AnyFlatSpec with Matchers with ScalaCheckPr
       ommersBlockParentHash,
       ommersBlockNumber,
       Seq(ommer1, block92.header),
-      blockchain,
       blockchainReader
     ) match {
       case Left(OmmerIsAncestorError) => succeed
@@ -111,7 +107,6 @@ class StdOmmersValidatorSpec extends AnyFlatSpec with Matchers with ScalaCheckPr
       ommersBlockParentHash,
       ommersBlockNumber,
       Seq(ommer1, block90.header),
-      blockchain,
       blockchainReader
     ) match {
       case Left(OmmerParentIsNotAncestorError) => succeed
@@ -124,7 +119,6 @@ class StdOmmersValidatorSpec extends AnyFlatSpec with Matchers with ScalaCheckPr
       ommersBlockParentHash,
       ommersBlockNumber,
       Seq(ommer1, ommer1),
-      blockchain,
       blockchainReader
     ) match {
       case Left(OmmersDuplicatedError) => succeed

--- a/src/test/scala/io/iohk/ethereum/domain/BlockchainSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/domain/BlockchainSpec.scala
@@ -297,11 +297,7 @@ class BlockchainSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyCh
           val cachedNodeStorage = storagesInstance.storages.cachedNodeStorage
           val stateStorage = stubStateStorage
         }
-        override val blockchainReaderWithStubPersisting = new BlockchainReader(
-          blockchainStoragesWithStubPersisting.blockHeadersStorage,
-          blockchainStoragesWithStubPersisting.blockBodiesStorage,
-          blockchainStoragesWithStubPersisting.blockNumberMappingStorage
-        )
+        override val blockchainReaderWithStubPersisting = BlockchainReader(blockchainStoragesWithStubPersisting)
         override val blockchainWithStubPersisting =
           BlockchainImpl(blockchainStoragesWithStubPersisting, blockchainReaderWithStubPersisting)
 

--- a/src/test/scala/io/iohk/ethereum/domain/BlockchainSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/domain/BlockchainSpec.scala
@@ -28,7 +28,7 @@ class BlockchainSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyCh
     val block = blockchain.getBlockByHash(validBlock.header.hash)
     block.isDefined should ===(true)
     validBlock should ===(block.get)
-    val blockHeader = blockchain.getBlockHeaderByHash(validBlock.header.hash)
+    val blockHeader = blockchainReader.getBlockHeaderByHash(validBlock.header.hash)
     blockHeader.isDefined should ===(true)
     validBlock.header should ===(blockHeader.get)
     val blockBody = blockchain.getBlockBodyByHash(validBlock.header.hash)
@@ -276,6 +276,7 @@ class BlockchainSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyCh
     trait StubPersistingBlockchainSetup {
       def stubStateStorage: StateStorage
       def blockchainStoragesWithStubPersisting: BlockchainStorages
+      def blockchainReaderWithStubPersisting: BlockchainReader
       def blockchainWithStubPersisting: BlockchainImpl
     }
 
@@ -296,7 +297,11 @@ class BlockchainSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyCh
           val cachedNodeStorage = storagesInstance.storages.cachedNodeStorage
           val stateStorage = stubStateStorage
         }
-        override val blockchainWithStubPersisting = BlockchainImpl(blockchainStoragesWithStubPersisting)
+        override val blockchainReaderWithStubPersisting = new BlockchainReader(
+          blockchainStoragesWithStubPersisting.blockHeadersStorage
+        )
+        override val blockchainWithStubPersisting =
+          BlockchainImpl(blockchainStoragesWithStubPersisting, blockchainReaderWithStubPersisting)
 
         blockchainWithStubPersisting.storeBlock(Fixtures.Blocks.Genesis.block)
       }

--- a/src/test/scala/io/iohk/ethereum/domain/BlockchainSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/domain/BlockchainSpec.scala
@@ -25,13 +25,13 @@ class BlockchainSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyCh
   "Blockchain" should "be able to store a block and return it if queried by hash" in new EphemBlockchainTestSetup {
     val validBlock = Fixtures.Blocks.ValidBlock.block
     blockchain.storeBlock(validBlock).commit()
-    val block = blockchain.getBlockByHash(validBlock.header.hash)
+    val block = blockchainReader.getBlockByHash(validBlock.header.hash)
     block.isDefined should ===(true)
     validBlock should ===(block.get)
     val blockHeader = blockchainReader.getBlockHeaderByHash(validBlock.header.hash)
     blockHeader.isDefined should ===(true)
     validBlock.header should ===(blockHeader.get)
-    val blockBody = blockchain.getBlockBodyByHash(validBlock.header.hash)
+    val blockBody = blockchainReader.getBlockBodyByHash(validBlock.header.hash)
     blockBody.isDefined should ===(true)
     validBlock.body should ===(blockBody.get)
   }
@@ -63,7 +63,7 @@ class BlockchainSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyCh
 
   it should "not return a value if not stored" in new EphemBlockchainTestSetup {
     blockchain.getBlockByNumber(Fixtures.Blocks.ValidBlock.header.number).isEmpty should ===(true)
-    blockchain.getBlockByHash(Fixtures.Blocks.ValidBlock.header.hash).isEmpty should ===(true)
+    blockchainReader.getBlockByHash(Fixtures.Blocks.ValidBlock.header.hash).isEmpty should ===(true)
   }
 
   it should "be able to store a block with checkpoint and retrieve it and checkpoint" in new EphemBlockchainTestSetup {
@@ -74,7 +74,7 @@ class BlockchainSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyCh
 
     blockchain.save(validBlock, Seq.empty, ChainWeight(0, 0), saveAsBestBlock = true)
 
-    val retrievedBlock = blockchain.getBlockByHash(validBlock.header.hash)
+    val retrievedBlock = blockchainReader.getBlockByHash(validBlock.header.hash)
     retrievedBlock.isDefined should ===(true)
     validBlock should ===(retrievedBlock.get)
 
@@ -298,7 +298,8 @@ class BlockchainSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyCh
           val stateStorage = stubStateStorage
         }
         override val blockchainReaderWithStubPersisting = new BlockchainReader(
-          blockchainStoragesWithStubPersisting.blockHeadersStorage
+          blockchainStoragesWithStubPersisting.blockHeadersStorage,
+          blockchainStoragesWithStubPersisting.blockBodiesStorage
         )
         override val blockchainWithStubPersisting =
           BlockchainImpl(blockchainStoragesWithStubPersisting, blockchainReaderWithStubPersisting)

--- a/src/test/scala/io/iohk/ethereum/domain/BlockchainSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/domain/BlockchainSpec.scala
@@ -39,7 +39,7 @@ class BlockchainSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyCh
   it should "be able to store a block and retrieve it by number" in new EphemBlockchainTestSetup {
     val validBlock = Fixtures.Blocks.ValidBlock.block
     blockchain.storeBlock(validBlock).commit()
-    val block = blockchain.getBlockByNumber(validBlock.header.number)
+    val block = blockchainReader.getBlockByNumber(validBlock.header.number)
     block.isDefined should ===(true)
     validBlock should ===(block.get)
   }
@@ -56,13 +56,13 @@ class BlockchainSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyCh
   it should "be able to query a stored blockHeader by it's number" in new EphemBlockchainTestSetup {
     val validHeader = Fixtures.Blocks.ValidBlock.header
     blockchain.storeBlockHeader(validHeader).commit()
-    val header = blockchain.getBlockHeaderByNumber(validHeader.number)
+    val header = blockchainReader.getBlockHeaderByNumber(validHeader.number)
     header.isDefined should ===(true)
     validHeader should ===(header.get)
   }
 
   it should "not return a value if not stored" in new EphemBlockchainTestSetup {
-    blockchain.getBlockByNumber(Fixtures.Blocks.ValidBlock.header.number).isEmpty should ===(true)
+    blockchainReader.getBlockByNumber(Fixtures.Blocks.ValidBlock.header.number).isEmpty should ===(true)
     blockchainReader.getBlockByHash(Fixtures.Blocks.ValidBlock.header.hash).isEmpty should ===(true)
   }
 
@@ -299,7 +299,8 @@ class BlockchainSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyCh
         }
         override val blockchainReaderWithStubPersisting = new BlockchainReader(
           blockchainStoragesWithStubPersisting.blockHeadersStorage,
-          blockchainStoragesWithStubPersisting.blockBodiesStorage
+          blockchainStoragesWithStubPersisting.blockBodiesStorage,
+          blockchainStoragesWithStubPersisting.blockNumberMappingStorage
         )
         override val blockchainWithStubPersisting =
           BlockchainImpl(blockchainStoragesWithStubPersisting, blockchainReaderWithStubPersisting)

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/CheckpointingServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/CheckpointingServiceSpec.scala
@@ -43,7 +43,7 @@ class CheckpointingServiceSpec
       val expectedResponse = GetLatestBlockResponse(Some(BlockInfo(block.hash, block.number)))
 
       (blockchain.getBestBlockNumber _).expects().returning(bestBlockNum)
-      (blockchain.getBlockByNumber _).expects(checkpointedBlockNum).returning(Some(block))
+      (blockchainReader.getBlockByNumber _).expects(checkpointedBlockNum).returning(Some(block))
       val result = service.getLatestBlock(request)
 
       result.runSyncUnsafe() shouldEqual Right(expectedResponse)
@@ -73,7 +73,7 @@ class CheckpointingServiceSpec
       (blockchainReader.getBlockHeaderByHash _)
         .expects(hash)
         .returning(Some(previousCheckpoint.header.copy(number = 0)))
-      (blockchain.getBlockByNumber _).expects(checkpointedBlockNum).returning(Some(block))
+      (blockchainReader.getBlockByNumber _).expects(checkpointedBlockNum).returning(Some(block))
       val result = service.getLatestBlock(request)
 
       result.runSyncUnsafe() shouldEqual Right(expectedResponse)
@@ -101,7 +101,7 @@ class CheckpointingServiceSpec
       (blockchainReader.getBlockHeaderByHash _)
         .expects(hash)
         .returning(Some(previousCheckpoint.header.copy(number = bestBlockNum)))
-      (blockchain.getBlockByNumber _).expects(*).returning(Some(previousCheckpoint))
+      (blockchainReader.getBlockByNumber _).expects(*).returning(Some(previousCheckpoint))
       val result = service.getLatestBlock(request)
 
       result.runSyncUnsafe() shouldEqual Right(expectedResponse)
@@ -129,7 +129,7 @@ class CheckpointingServiceSpec
 
       (blockchain.getBestBlockNumber _).expects().returning(bestBlockNum)
       (blockchainReader.getBlockHeaderByHash _).expects(hash).returning(None)
-      (blockchain.getBlockByNumber _).expects(checkpointedBlockNum).returning(Some(block))
+      (blockchainReader.getBlockByNumber _).expects(checkpointedBlockNum).returning(Some(block))
       val result = service.getLatestBlock(request)
 
       result.runSyncUnsafe() shouldEqual Right(expectedResponse)
@@ -157,13 +157,13 @@ class CheckpointingServiceSpec
     (blockchain.getBestBlockNumber _)
       .expects()
       .returning(7)
-    (blockchain.getBlockByNumber _)
+    (blockchainReader.getBlockByNumber _)
       .expects(BigInt(4))
       .returning(None)
     (blockchain.getBestBlockNumber _)
       .expects()
       .returning(7)
-    (blockchain.getBlockByNumber _)
+    (blockchainReader.getBlockByNumber _)
       .expects(BigInt(4))
       .returning(Some(block))
 

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/EthBlocksServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/EthBlocksServiceSpec.scala
@@ -417,6 +417,7 @@ class EthBlocksServiceSpec
 
     lazy val ethBlocksService = new EthBlocksService(
       blockchain,
+      blockchainReader,
       ledger
     )
 

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/EthInfoServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/EthInfoServiceSpec.scala
@@ -96,7 +96,13 @@ class EthServiceSpec
     blockchain.saveBestKnownBlocks(blockToRequest.header.number)
 
     val txResult = TxResult(
-      BlockchainImpl(storagesInstance.storages, new BlockchainReader(storagesInstance.storages.blockHeadersStorage))
+      BlockchainImpl(
+        storagesInstance.storages,
+        new BlockchainReader(
+          storagesInstance.storages.blockHeadersStorage,
+          storagesInstance.storages.blockBodiesStorage
+        )
+      )
         .getWorldStateProxy(-1, UInt256.Zero, ByteString.empty, noEmptyAccounts = false, ethCompatibleStorage = true),
       123,
       Nil,

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/EthInfoServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/EthInfoServiceSpec.scala
@@ -96,14 +96,7 @@ class EthServiceSpec
     blockchain.saveBestKnownBlocks(blockToRequest.header.number)
 
     val txResult = TxResult(
-      BlockchainImpl(
-        storagesInstance.storages,
-        new BlockchainReader(
-          storagesInstance.storages.blockHeadersStorage,
-          storagesInstance.storages.blockBodiesStorage,
-          storagesInstance.storages.blockNumberMappingStorage
-        )
-      )
+      BlockchainImpl(storagesInstance.storages, BlockchainReader(storagesInstance.storages))
         .getWorldStateProxy(-1, UInt256.Zero, ByteString.empty, noEmptyAccounts = false, ethCompatibleStorage = true),
       123,
       Nil,

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/EthInfoServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/EthInfoServiceSpec.scala
@@ -100,7 +100,8 @@ class EthServiceSpec
         storagesInstance.storages,
         new BlockchainReader(
           storagesInstance.storages.blockHeadersStorage,
-          storagesInstance.storages.blockBodiesStorage
+          storagesInstance.storages.blockBodiesStorage,
+          storagesInstance.storages.blockNumberMappingStorage
         )
       )
         .getWorldStateProxy(-1, UInt256.Zero, ByteString.empty, noEmptyAccounts = false, ethCompatibleStorage = true),
@@ -162,6 +163,7 @@ class EthServiceSpec
 
     lazy val ethService = new EthInfoService(
       blockchain,
+      blockchainReader,
       blockchainConfig,
       ledger,
       stxLedger,

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/EthInfoServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/EthInfoServiceSpec.scala
@@ -96,7 +96,7 @@ class EthServiceSpec
     blockchain.saveBestKnownBlocks(blockToRequest.header.number)
 
     val txResult = TxResult(
-      BlockchainImpl(storagesInstance.storages)
+      BlockchainImpl(storagesInstance.storages, new BlockchainReader(storagesInstance.storages.blockHeadersStorage))
         .getWorldStateProxy(-1, UInt256.Zero, ByteString.empty, noEmptyAccounts = false, ethCompatibleStorage = true),
       123,
       Nil,

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/EthMiningServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/EthMiningServiceSpec.scala
@@ -237,7 +237,6 @@ class EthMiningServiceSpec
 
     lazy val restrictedGenerator = new RestrictedPoWBlockGeneratorImpl(
       validators = MockValidatorsAlwaysSucceed,
-      blockchain = blockchain,
       blockchainReader = blockchainReader,
       blockchainConfig = blockchainConfig,
       consensusConfig = consensusConfig,

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/EthMiningServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/EthMiningServiceSpec.scala
@@ -238,6 +238,7 @@ class EthMiningServiceSpec
     lazy val restrictedGenerator = new RestrictedPoWBlockGeneratorImpl(
       validators = MockValidatorsAlwaysSucceed,
       blockchain = blockchain,
+      blockchainReader = blockchainReader,
       blockchainConfig = blockchainConfig,
       consensusConfig = consensusConfig,
       blockPreparator = consensus.blockPreparator,

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/EthProofServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/EthProofServiceSpec.scala
@@ -255,7 +255,8 @@ class EthProofServiceSpec
     blockchain.storeBlock(newblock).commit()
     blockchain.saveBestKnownBlocks(newblock.header.number)
 
-    val ethGetProof = new EthProofService(blockchain, blockGenerator, blockchainConfig.ethCompatibleStorage)
+    val ethGetProof =
+      new EthProofService(blockchain, blockchainReader, blockGenerator, blockchainConfig.ethCompatibleStorage)
 
     val storageKeys = Seq(StorageProofKey(key))
     val blockNumber = BlockParam.Latest
@@ -274,6 +275,7 @@ class EthProofServiceSpec
 
     val ethUserService = new EthUserService(
       blockchain,
+      blockchainReader,
       ledger,
       blockchainConfig
     )

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/EthTxServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/EthTxServiceSpec.scala
@@ -378,6 +378,7 @@ class EthTxServiceSpec
 
     lazy val ethTxService = new EthTxService(
       blockchain,
+      blockchainReader,
       ledger,
       pendingTransactionsManager.ref,
       getTransactionFromPoolTimeout,

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/EthUserServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/EthUserServiceSpec.scala
@@ -139,6 +139,7 @@ class EthUserServiceSpec
     override lazy val ledger = mock[Ledger]
     lazy val ethUserService = new EthUserService(
       blockchain,
+      blockchainReader,
       ledger,
       blockchainConfig
     )

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/FilterManagerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/FilterManagerSpec.scala
@@ -87,7 +87,7 @@ class FilterManagerSpec
       uncleNodesList = Nil
     )
 
-    (blockchain.getBlockBodyByHash _).expects(bh2.hash).returning(Some(bb2))
+    (blockchainReader.getBlockBodyByHash _).expects(bh2.hash).returning(Some(bb2))
     (blockchain.getReceiptsByHash _)
       .expects(bh2.hash)
       .returning(
@@ -176,7 +176,7 @@ class FilterManagerSpec
       uncleNodesList = Nil
     )
 
-    (blockchain.getBlockBodyByHash _).expects(bh4.hash).returning(Some(bb4))
+    (blockchainReader.getBlockBodyByHash _).expects(bh4.hash).returning(Some(bb4))
     (blockchain.getReceiptsByHash _)
       .expects(bh4.hash)
       .returning(
@@ -251,7 +251,7 @@ class FilterManagerSpec
       uncleNodesList = Nil
     )
 
-    (blockchain.getBlockBodyByHash _).expects(bh.hash).returning(Some(bb))
+    (blockchainReader.getBlockBodyByHash _).expects(bh.hash).returning(Some(bb))
     (blockchain.getReceiptsByHash _)
       .expects(bh.hash)
       .returning(
@@ -483,6 +483,7 @@ class FilterManagerSpec
 
     val time = new VirtualTime
 
+    val blockchainReader = mock[BlockchainReader]
     val blockchain = mock[BlockchainImpl]
     val appStateStorage = mock[AppStateStorage]
     val keyStore = mock[KeyStore]
@@ -515,6 +516,7 @@ class FilterManagerSpec
       Props(
         new FilterManager(
           blockchain,
+          blockchainReader,
           blockGenerator,
           appStateStorage,
           keyStore,

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/FilterManagerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/FilterManagerSpec.scala
@@ -66,9 +66,9 @@ class FilterManagerSpec
     val bh3 = blockHeader.copy(number = 3, logsBloom = BloomFilter.create(Nil))
 
     (blockchain.getBestBlockNumber _).expects().returning(3).twice()
-    (blockchain.getBlockHeaderByNumber _).expects(bh1.number).returning(Some(bh1))
-    (blockchain.getBlockHeaderByNumber _).expects(bh2.number).returning(Some(bh2))
-    (blockchain.getBlockHeaderByNumber _).expects(bh3.number).returning(Some(bh3))
+    (blockchainReader.getBlockHeaderByNumber _).expects(bh1.number).returning(Some(bh1))
+    (blockchainReader.getBlockHeaderByNumber _).expects(bh2.number).returning(Some(bh2))
+    (blockchainReader.getBlockHeaderByNumber _).expects(bh3.number).returning(Some(bh3))
 
     val bb2 = BlockBody(
       transactionList = Seq(
@@ -146,7 +146,7 @@ class FilterManagerSpec
 
     val bh4 = blockHeader.copy(number = 4, logsBloom = BloomFilter.create(Seq(log4_1, log4_2)))
 
-    (blockchain.getBlockHeaderByNumber _).expects(BigInt(4)).returning(Some(bh4))
+    (blockchainReader.getBlockHeaderByNumber _).expects(BigInt(4)).returning(Some(bh4))
 
     val bb4 = BlockBody(
       transactionList = Seq(
@@ -233,7 +233,7 @@ class FilterManagerSpec
     val bh = blockHeader.copy(number = 1, logsBloom = BloomFilter.create(logs))
 
     (blockchain.getBestBlockNumber _).expects().returning(1).anyNumberOfTimes()
-    (blockchain.getBlockHeaderByNumber _).expects(bh.number).returning(Some(bh))
+    (blockchainReader.getBlockHeaderByNumber _).expects(bh.number).returning(Some(bh))
     val bb = BlockBody(
       transactionList = Seq(
         SignedTransaction(
@@ -360,9 +360,9 @@ class FilterManagerSpec
     val bh5 = blockHeader.copy(number = 5)
     val bh6 = blockHeader.copy(number = 6)
 
-    (blockchain.getBlockHeaderByNumber _).expects(BigInt(4)).returning(Some(bh4))
-    (blockchain.getBlockHeaderByNumber _).expects(BigInt(5)).returning(Some(bh5))
-    (blockchain.getBlockHeaderByNumber _).expects(BigInt(6)).returning(Some(bh6))
+    (blockchainReader.getBlockHeaderByNumber _).expects(BigInt(4)).returning(Some(bh4))
+    (blockchainReader.getBlockHeaderByNumber _).expects(BigInt(5)).returning(Some(bh5))
+    (blockchainReader.getBlockHeaderByNumber _).expects(BigInt(6)).returning(Some(bh6))
 
     val getChangesRes =
       (filterManager ? FilterManager.GetFilterChanges(createResp.id))

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/FilterManagerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/FilterManagerSpec.scala
@@ -88,7 +88,7 @@ class FilterManagerSpec
     )
 
     (blockchainReader.getBlockBodyByHash _).expects(bh2.hash).returning(Some(bb2))
-    (blockchain.getReceiptsByHash _)
+    (blockchainReader.getReceiptsByHash _)
       .expects(bh2.hash)
       .returning(
         Some(
@@ -177,7 +177,7 @@ class FilterManagerSpec
     )
 
     (blockchainReader.getBlockBodyByHash _).expects(bh4.hash).returning(Some(bb4))
-    (blockchain.getReceiptsByHash _)
+    (blockchainReader.getReceiptsByHash _)
       .expects(bh4.hash)
       .returning(
         Some(
@@ -252,7 +252,7 @@ class FilterManagerSpec
     )
 
     (blockchainReader.getBlockBodyByHash _).expects(bh.hash).returning(Some(bb))
-    (blockchain.getReceiptsByHash _)
+    (blockchainReader.getReceiptsByHash _)
       .expects(bh.hash)
       .returning(
         Some(
@@ -485,7 +485,6 @@ class FilterManagerSpec
 
     val blockchainReader = mock[BlockchainReader]
     val blockchain = mock[BlockchainImpl]
-    val appStateStorage = mock[AppStateStorage]
     val keyStore = mock[KeyStore]
     val blockGenerator = mock[BlockGenerator]
     val pendingTransactionsManager = TestProbe()
@@ -518,7 +517,6 @@ class FilterManagerSpec
           blockchain,
           blockchainReader,
           blockGenerator,
-          appStateStorage,
           keyStore,
           pendingTransactionsManager.ref,
           config,

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerFixture.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerFixture.scala
@@ -95,10 +95,11 @@ class JsonRpcControllerFixture(implicit system: ActorSystem)
     getTransactionFromPoolTimeout
   )
 
-  val ethBlocksService = new EthBlocksService(blockchain, ledger)
+  val ethBlocksService = new EthBlocksService(blockchain, blockchainReader, ledger)
 
   val ethTxService = new EthTxService(
     blockchain,
+    blockchainReader,
     ledger,
     pendingTransactionsManager.ref,
     getTransactionFromPoolTimeout,

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerFixture.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerFixture.scala
@@ -75,6 +75,7 @@ class JsonRpcControllerFixture(implicit system: ActorSystem)
 
   val ethInfoService = new EthInfoService(
     blockchain,
+    blockchainReader,
     blockchainConfig,
     ledger,
     stxLedger,
@@ -108,6 +109,7 @@ class JsonRpcControllerFixture(implicit system: ActorSystem)
 
   val ethUserService = new EthUserService(
     blockchain,
+    blockchainReader,
     ledger,
     blockchainConfig
   )

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/MantisServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/MantisServiceSpec.scala
@@ -70,6 +70,7 @@ class MantisServiceSpec
         override lazy val transactionHistoryService: TransactionHistoryService =
           new TransactionHistoryService(
             blockchain,
+            blockchainReader,
             pendingTransactionsManager,
             txPoolConfig.getTransactionFromPoolTimeout
           ) {

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/QAServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/QAServiceSpec.scala
@@ -50,7 +50,7 @@ class QAServiceSpec
   ) { fixture =>
     import fixture._
 
-    (blockchain.getBlockByHash _)
+    (blockchainReader.getBlockByHash _)
       .expects(req.blockHash.get)
       .returning(Some(block))
       .noMoreThanOnce()
@@ -70,7 +70,7 @@ class QAServiceSpec
     import fixture._
     val reqWithoutBlockHash = req.copy(blockHash = None)
 
-    (blockchain.getBlockByHash _)
+    (blockchainReader.getBlockByHash _)
       .expects(req.blockHash.get)
       .returning(Some(block))
       .noMoreThanOnce()
@@ -104,6 +104,7 @@ class QAServiceSpec
     }
 
     lazy val testConsensus: TestConsensus = mock[TestConsensus]
+    lazy val blockchainReader = mock[BlockchainReader]
     lazy val blockchain = mock[BlockchainImpl]
     lazy val syncController = TestProbe()
     lazy val checkpointBlockGenerator = new CheckpointBlockGenerator()
@@ -111,6 +112,7 @@ class QAServiceSpec
     lazy val qaService = new QAService(
       testConsensus,
       blockchain,
+      blockchainReader,
       checkpointBlockGenerator,
       blockchainConfig,
       syncController.ref

--- a/src/test/scala/io/iohk/ethereum/ledger/BlockExecutionSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/BlockExecutionSpec.scala
@@ -46,7 +46,7 @@ class BlockExecutionSpec extends AnyWordSpec with Matchers with ScalaCheckProper
         val mockValidators = new MockValidatorsFailOnSpecificBlockNumber(block1.header.number)
         val newConsensus: TestConsensus = consensus.withVM(vm).withValidators(mockValidators)
         val blockValidation =
-          new BlockValidation(newConsensus, blockchain, blockchainReader, BlockQueue(blockchain, syncConfig))
+          new BlockValidation(newConsensus, blockchainReader, BlockQueue(blockchain, syncConfig))
         val blockExecution =
           new BlockExecution(
             blockchain,
@@ -87,7 +87,7 @@ class BlockExecutionSpec extends AnyWordSpec with Matchers with ScalaCheckProper
         val mockValidators = new MockValidatorsFailOnSpecificBlockNumber(block2.header.number)
         val newConsensus: TestConsensus = consensus.withVM(mockVm).withValidators(mockValidators)
         val blockValidation =
-          new BlockValidation(newConsensus, blockchain, blockchainReader, BlockQueue(blockchain, syncConfig))
+          new BlockValidation(newConsensus, blockchainReader, BlockQueue(blockchain, syncConfig))
         val blockExecution =
           new BlockExecution(
             blockchain,
@@ -121,7 +121,7 @@ class BlockExecutionSpec extends AnyWordSpec with Matchers with ScalaCheckProper
         val mockValidators = new MockValidatorsFailOnSpecificBlockNumber(chain.last.number)
         val newConsensus: TestConsensus = consensus.withVM(mockVm).withValidators(mockValidators)
         val blockValidation =
-          new BlockValidation(newConsensus, blockchain, blockchainReader, BlockQueue(blockchain, syncConfig))
+          new BlockValidation(newConsensus, blockchainReader, BlockQueue(blockchain, syncConfig))
         val blockExecution =
           new BlockExecution(
             blockchain,
@@ -147,7 +147,7 @@ class BlockExecutionSpec extends AnyWordSpec with Matchers with ScalaCheckProper
         val mockValidators = MockValidatorsAlwaysSucceed
         val newConsensus: TestConsensus = consensus.withVM(vm).withValidators(mockValidators)
         val blockValidation =
-          new BlockValidation(newConsensus, blockchain, blockchainReader, BlockQueue(blockchain, syncConfig))
+          new BlockValidation(newConsensus, blockchainReader, BlockQueue(blockchain, syncConfig))
         val blockExecution =
           new BlockExecution(
             blockchain,
@@ -205,7 +205,7 @@ class BlockExecutionSpec extends AnyWordSpec with Matchers with ScalaCheckProper
         val newConsensus: TestConsensus = consensus.withVM(mockVm)
 
         val blockValidation =
-          new BlockValidation(newConsensus, blockchain, blockchainReader, BlockQueue(blockchain, syncConfig))
+          new BlockValidation(newConsensus, blockchainReader, BlockQueue(blockchain, syncConfig))
         val blockExecution =
           new BlockExecution(
             blockchain,
@@ -280,7 +280,7 @@ class BlockExecutionSpec extends AnyWordSpec with Matchers with ScalaCheckProper
           // Beware we are not using `ledger`
           val newConsensus = consensus.withValidators(mockValidators).withVM(mockVm)
           val blockValidation =
-            new BlockValidation(newConsensus, blockchain, blockchainReader, BlockQueue(blockchain, syncConfig))
+            new BlockValidation(newConsensus, blockchainReader, BlockQueue(blockchain, syncConfig))
           val blockExecution =
             new BlockExecution(
               blockchain,
@@ -350,7 +350,7 @@ class BlockExecutionSpec extends AnyWordSpec with Matchers with ScalaCheckProper
   trait BlockExecutionTestSetup extends BlockchainSetup {
 
     val blockValidation =
-      new BlockValidation(consensus, blockchain, blockchainReader, BlockQueue(blockchain, syncConfig))
+      new BlockValidation(consensus, blockchainReader, BlockQueue(blockchain, syncConfig))
     val blockExecution =
       new BlockExecution(blockchain, blockchainReader, blockchainConfig, consensus.blockPreparator, blockValidation)
 

--- a/src/test/scala/io/iohk/ethereum/ledger/BlockExecutionSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/BlockExecutionSpec.scala
@@ -45,9 +45,16 @@ class BlockExecutionSpec extends AnyWordSpec with Matchers with ScalaCheckProper
 
         val mockValidators = new MockValidatorsFailOnSpecificBlockNumber(block1.header.number)
         val newConsensus: TestConsensus = consensus.withVM(vm).withValidators(mockValidators)
-        val blockValidation = new BlockValidation(newConsensus, blockchain, BlockQueue(blockchain, syncConfig))
+        val blockValidation =
+          new BlockValidation(newConsensus, blockchain, blockchainReader, BlockQueue(blockchain, syncConfig))
         val blockExecution =
-          new BlockExecution(blockchain, blockchainConfig, newConsensus.blockPreparator, blockValidation)
+          new BlockExecution(
+            blockchain,
+            blockchainReader,
+            blockchainConfig,
+            newConsensus.blockPreparator,
+            blockValidation
+          )
 
         val (blocks, error) = blockExecution.executeAndValidateBlocks(List(block1, block2), defaultChainWeight)
 
@@ -79,9 +86,16 @@ class BlockExecutionSpec extends AnyWordSpec with Matchers with ScalaCheckProper
         )
         val mockValidators = new MockValidatorsFailOnSpecificBlockNumber(block2.header.number)
         val newConsensus: TestConsensus = consensus.withVM(mockVm).withValidators(mockValidators)
-        val blockValidation = new BlockValidation(newConsensus, blockchain, BlockQueue(blockchain, syncConfig))
+        val blockValidation =
+          new BlockValidation(newConsensus, blockchain, blockchainReader, BlockQueue(blockchain, syncConfig))
         val blockExecution =
-          new BlockExecution(blockchain, blockchainConfig, newConsensus.blockPreparator, blockValidation)
+          new BlockExecution(
+            blockchain,
+            blockchainReader,
+            blockchainConfig,
+            newConsensus.blockPreparator,
+            blockValidation
+          )
 
         val (blocks, error) = blockExecution.executeAndValidateBlocks(List(block1, block2), defaultChainWeight)
 
@@ -106,9 +120,16 @@ class BlockExecutionSpec extends AnyWordSpec with Matchers with ScalaCheckProper
         )
         val mockValidators = new MockValidatorsFailOnSpecificBlockNumber(chain.last.number)
         val newConsensus: TestConsensus = consensus.withVM(mockVm).withValidators(mockValidators)
-        val blockValidation = new BlockValidation(newConsensus, blockchain, BlockQueue(blockchain, syncConfig))
+        val blockValidation =
+          new BlockValidation(newConsensus, blockchain, blockchainReader, BlockQueue(blockchain, syncConfig))
         val blockExecution =
-          new BlockExecution(blockchain, blockchainConfig, newConsensus.blockPreparator, blockValidation)
+          new BlockExecution(
+            blockchain,
+            blockchainReader,
+            blockchainConfig,
+            newConsensus.blockPreparator,
+            blockValidation
+          )
 
         val (blocks, error) = blockExecution.executeAndValidateBlocks(chain, defaultChainWeight)
 
@@ -125,9 +146,16 @@ class BlockExecutionSpec extends AnyWordSpec with Matchers with ScalaCheckProper
 
         val mockValidators = MockValidatorsAlwaysSucceed
         val newConsensus: TestConsensus = consensus.withVM(vm).withValidators(mockValidators)
-        val blockValidation = new BlockValidation(newConsensus, blockchain, BlockQueue(blockchain, syncConfig))
+        val blockValidation =
+          new BlockValidation(newConsensus, blockchain, blockchainReader, BlockQueue(blockchain, syncConfig))
         val blockExecution =
-          new BlockExecution(blockchain, blockchainConfig, newConsensus.blockPreparator, blockValidation)
+          new BlockExecution(
+            blockchain,
+            blockchainReader,
+            blockchainConfig,
+            newConsensus.blockPreparator,
+            blockValidation
+          )
 
         val (blocks, error) =
           blockExecution.executeAndValidateBlocks(List(blockWithCheckpoint), defaultChainWeight)
@@ -176,9 +204,16 @@ class BlockExecutionSpec extends AnyWordSpec with Matchers with ScalaCheckProper
 
         val newConsensus: TestConsensus = consensus.withVM(mockVm)
 
-        val blockValidation = new BlockValidation(newConsensus, blockchain, BlockQueue(blockchain, syncConfig))
+        val blockValidation =
+          new BlockValidation(newConsensus, blockchain, blockchainReader, BlockQueue(blockchain, syncConfig))
         val blockExecution =
-          new BlockExecution(blockchain, blockchainConfig, newConsensus.blockPreparator, blockValidation)
+          new BlockExecution(
+            blockchain,
+            blockchainReader,
+            blockchainConfig,
+            newConsensus.blockPreparator,
+            blockValidation
+          )
 
         val txsExecResult: Either[BlockExecutionError, BlockResult] =
           blockExecution.executeBlockTransactions(block, validBlockParentHeader)
@@ -244,9 +279,16 @@ class BlockExecutionSpec extends AnyWordSpec with Matchers with ScalaCheckProper
 
           // Beware we are not using `ledger`
           val newConsensus = consensus.withValidators(mockValidators).withVM(mockVm)
-          val blockValidation = new BlockValidation(newConsensus, blockchain, BlockQueue(blockchain, syncConfig))
+          val blockValidation =
+            new BlockValidation(newConsensus, blockchain, blockchainReader, BlockQueue(blockchain, syncConfig))
           val blockExecution =
-            new BlockExecution(blockchain, blockchainConfig, newConsensus.blockPreparator, blockValidation)
+            new BlockExecution(
+              blockchain,
+              blockchainReader,
+              blockchainConfig,
+              newConsensus.blockPreparator,
+              blockValidation
+            )
 
           val txsExecResult = blockExecution.executeBlockTransactions(block, validBlockParentHeader)
 
@@ -307,8 +349,10 @@ class BlockExecutionSpec extends AnyWordSpec with Matchers with ScalaCheckProper
 
   trait BlockExecutionTestSetup extends BlockchainSetup {
 
-    val blockValidation = new BlockValidation(consensus, blockchain, BlockQueue(blockchain, syncConfig))
-    val blockExecution = new BlockExecution(blockchain, blockchainConfig, consensus.blockPreparator, blockValidation)
+    val blockValidation =
+      new BlockValidation(consensus, blockchain, blockchainReader, BlockQueue(blockchain, syncConfig))
+    val blockExecution =
+      new BlockExecution(blockchain, blockchainReader, blockchainConfig, consensus.blockPreparator, blockValidation)
 
   }
 }

--- a/src/test/scala/io/iohk/ethereum/ledger/BlockImportSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/BlockImportSpec.scala
@@ -47,7 +47,13 @@ class BlockImportSpec extends AnyFlatSpec with Matchers with ScalaFutures {
     val newWeight = currentWeight.increaseTotalDifficulty(difficulty)
     val blockData = BlockData(block, Seq.empty[Receipt], newWeight)
     val emptyWorld: InMemoryWorldStateProxy =
-      BlockchainImpl(storagesInstance.storages, new BlockchainReader(storagesInstance.storages.blockHeadersStorage))
+      BlockchainImpl(
+        storagesInstance.storages,
+        new BlockchainReader(
+          storagesInstance.storages.blockHeadersStorage,
+          storagesInstance.storages.blockBodiesStorage
+        )
+      )
         .getWorldStateProxy(
           -1,
           UInt256.Zero,
@@ -57,7 +63,7 @@ class BlockImportSpec extends AnyFlatSpec with Matchers with ScalaFutures {
         )
 
     // Just to bypass metrics needs
-    (blockchain.getBlockByHash _).expects(*).returning(None)
+    (blockchainReader.getBlockByHash _).expects(*).returning(None)
 
     (blockQueue.enqueueBlock _).expects(block, bestNum).returning(Some(Leaf(hash, newWeight)))
     (blockQueue.getBranch _).expects(hash, true).returning(List(block))
@@ -86,7 +92,13 @@ class BlockImportSpec extends AnyFlatSpec with Matchers with ScalaFutures {
     (blockQueue.getBranch _).expects(hash, true).returning(List(block))
 
     val emptyWorld: InMemoryWorldStateProxy =
-      BlockchainImpl(storagesInstance.storages, new BlockchainReader(storagesInstance.storages.blockHeadersStorage))
+      BlockchainImpl(
+        storagesInstance.storages,
+        new BlockchainReader(
+          storagesInstance.storages.blockHeadersStorage,
+          storagesInstance.storages.blockBodiesStorage
+        )
+      )
         .getWorldStateProxy(
           -1,
           UInt256.Zero,

--- a/src/test/scala/io/iohk/ethereum/ledger/BlockImportSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/BlockImportSpec.scala
@@ -51,7 +51,8 @@ class BlockImportSpec extends AnyFlatSpec with Matchers with ScalaFutures {
         storagesInstance.storages,
         new BlockchainReader(
           storagesInstance.storages.blockHeadersStorage,
-          storagesInstance.storages.blockBodiesStorage
+          storagesInstance.storages.blockBodiesStorage,
+          storagesInstance.storages.blockNumberMappingStorage
         )
       )
         .getWorldStateProxy(
@@ -96,7 +97,8 @@ class BlockImportSpec extends AnyFlatSpec with Matchers with ScalaFutures {
         storagesInstance.storages,
         new BlockchainReader(
           storagesInstance.storages.blockHeadersStorage,
-          storagesInstance.storages.blockBodiesStorage
+          storagesInstance.storages.blockBodiesStorage,
+          storagesInstance.storages.blockNumberMappingStorage
         )
       )
         .getWorldStateProxy(

--- a/src/test/scala/io/iohk/ethereum/ledger/BlockImportSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/BlockImportSpec.scala
@@ -47,14 +47,7 @@ class BlockImportSpec extends AnyFlatSpec with Matchers with ScalaFutures {
     val newWeight = currentWeight.increaseTotalDifficulty(difficulty)
     val blockData = BlockData(block, Seq.empty[Receipt], newWeight)
     val emptyWorld: InMemoryWorldStateProxy =
-      BlockchainImpl(
-        storagesInstance.storages,
-        new BlockchainReader(
-          storagesInstance.storages.blockHeadersStorage,
-          storagesInstance.storages.blockBodiesStorage,
-          storagesInstance.storages.blockNumberMappingStorage
-        )
-      )
+      BlockchainImpl(storagesInstance.storages, BlockchainReader(storagesInstance.storages))
         .getWorldStateProxy(
           -1,
           UInt256.Zero,
@@ -93,14 +86,7 @@ class BlockImportSpec extends AnyFlatSpec with Matchers with ScalaFutures {
     (blockQueue.getBranch _).expects(hash, true).returning(List(block))
 
     val emptyWorld: InMemoryWorldStateProxy =
-      BlockchainImpl(
-        storagesInstance.storages,
-        new BlockchainReader(
-          storagesInstance.storages.blockHeadersStorage,
-          storagesInstance.storages.blockBodiesStorage,
-          storagesInstance.storages.blockNumberMappingStorage
-        )
-      )
+      BlockchainImpl(storagesInstance.storages, BlockchainReader(storagesInstance.storages))
         .getWorldStateProxy(
           -1,
           UInt256.Zero,

--- a/src/test/scala/io/iohk/ethereum/ledger/BlockRewardSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/BlockRewardSpec.scala
@@ -192,7 +192,13 @@ class BlockRewardSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyC
     val afterByzantiumNewBlockReward: BigInt = BigInt(10).pow(18) * 3
 
     val worldState: InMemoryWorldStateProxy =
-      BlockchainImpl(storagesInstance.storages, new BlockchainReader(storagesInstance.storages.blockHeadersStorage))
+      BlockchainImpl(
+        storagesInstance.storages,
+        new BlockchainReader(
+          storagesInstance.storages.blockHeadersStorage,
+          storagesInstance.storages.blockBodiesStorage
+        )
+      )
         .getWorldStateProxy(
           -1,
           UInt256.Zero,

--- a/src/test/scala/io/iohk/ethereum/ledger/BlockRewardSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/BlockRewardSpec.scala
@@ -191,20 +191,21 @@ class BlockRewardSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyC
     val ommerFiveBlocksDifferenceReward = BigInt("1875000000000000000")
     val afterByzantiumNewBlockReward: BigInt = BigInt(10).pow(18) * 3
 
-    val worldState: InMemoryWorldStateProxy = BlockchainImpl(storagesInstance.storages)
-      .getWorldStateProxy(
-        -1,
-        UInt256.Zero,
-        ByteString(MerklePatriciaTrie.EmptyRootHash),
-        noEmptyAccounts = false,
-        ethCompatibleStorage = true
-      )
-      .saveAccount(validAccountAddress, Account(balance = 10))
-      .saveAccount(validAccountAddress2, Account(balance = 20))
-      .saveAccount(validAccountAddress3, Account(balance = 30))
-      .saveAccount(validAccountAddress4, Account(balance = 10))
-      .saveAccount(validAccountAddress5, Account(balance = 20))
-      .saveAccount(validAccountAddress6, Account(balance = 20))
+    val worldState: InMemoryWorldStateProxy =
+      BlockchainImpl(storagesInstance.storages, new BlockchainReader(storagesInstance.storages.blockHeadersStorage))
+        .getWorldStateProxy(
+          -1,
+          UInt256.Zero,
+          ByteString(MerklePatriciaTrie.EmptyRootHash),
+          noEmptyAccounts = false,
+          ethCompatibleStorage = true
+        )
+        .saveAccount(validAccountAddress, Account(balance = 10))
+        .saveAccount(validAccountAddress2, Account(balance = 20))
+        .saveAccount(validAccountAddress3, Account(balance = 30))
+        .saveAccount(validAccountAddress4, Account(balance = 10))
+        .saveAccount(validAccountAddress5, Account(balance = 20))
+        .saveAccount(validAccountAddress6, Account(balance = 20))
 
     // We don't care for this tests if block is not valid
     val sampleBlockNumber = 10

--- a/src/test/scala/io/iohk/ethereum/ledger/BlockRewardSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/BlockRewardSpec.scala
@@ -196,7 +196,8 @@ class BlockRewardSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyC
         storagesInstance.storages,
         new BlockchainReader(
           storagesInstance.storages.blockHeadersStorage,
-          storagesInstance.storages.blockBodiesStorage
+          storagesInstance.storages.blockBodiesStorage,
+          storagesInstance.storages.blockNumberMappingStorage
         )
       )
         .getWorldStateProxy(

--- a/src/test/scala/io/iohk/ethereum/ledger/BlockRewardSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/BlockRewardSpec.scala
@@ -192,14 +192,7 @@ class BlockRewardSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyC
     val afterByzantiumNewBlockReward: BigInt = BigInt(10).pow(18) * 3
 
     val worldState: InMemoryWorldStateProxy =
-      BlockchainImpl(
-        storagesInstance.storages,
-        new BlockchainReader(
-          storagesInstance.storages.blockHeadersStorage,
-          storagesInstance.storages.blockBodiesStorage,
-          storagesInstance.storages.blockNumberMappingStorage
-        )
-      )
+      BlockchainImpl(storagesInstance.storages, BlockchainReader(storagesInstance.storages))
         .getWorldStateProxy(
           -1,
           UInt256.Zero,

--- a/src/test/scala/io/iohk/ethereum/ledger/BlockValidationSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/BlockValidationSpec.scala
@@ -40,6 +40,7 @@ class BlockValidationSpec extends AnyWordSpec with Matchers with MockFactory {
   // scalastyle:off magic.number
   trait BlockValidationTestSetup {
     private val setup = new io.iohk.ethereum.blockchain.sync.ScenarioSetup {
+      override lazy val blockchainReader: BlockchainReader = mock[BlockchainReader]
       override lazy val blockchain: BlockchainImpl = mock[BlockchainImpl]
 
       override lazy val validators: Mocks.MockValidatorsAlwaysSucceed = new Mocks.MockValidatorsAlwaysSucceed {
@@ -48,7 +49,12 @@ class BlockValidationSpec extends AnyWordSpec with Matchers with MockFactory {
     }
 
     def blockValidation: BlockValidation =
-      new BlockValidation(setup.consensus, setup.blockchain, BlockQueue(setup.blockchain, setup.syncConfig))
+      new BlockValidation(
+        setup.consensus,
+        setup.blockchain,
+        setup.blockchainReader,
+        BlockQueue(setup.blockchain, setup.syncConfig)
+      )
 
     def hash2ByteString(hash: String): ByteString = ByteString(Hex.decode(hash))
 

--- a/src/test/scala/io/iohk/ethereum/ledger/BlockValidationSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/BlockValidationSpec.scala
@@ -51,7 +51,6 @@ class BlockValidationSpec extends AnyWordSpec with Matchers with MockFactory {
     def blockValidation: BlockValidation =
       new BlockValidation(
         setup.consensus,
-        setup.blockchain,
         setup.blockchainReader,
         BlockQueue(setup.blockchain, setup.syncConfig)
       )

--- a/src/test/scala/io/iohk/ethereum/ledger/DeleteAccountsSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/DeleteAccountsSpec.scala
@@ -66,7 +66,13 @@ class DeleteAccountsSpec extends AnyFlatSpec with Matchers with MockFactory {
     val accountAddresses = Set(validAccountAddress, validAccountAddress2, validAccountAddress3)
 
     val worldStateWithoutPersist: InMemoryWorldStateProxy =
-      BlockchainImpl(storagesInstance.storages, new BlockchainReader(storagesInstance.storages.blockHeadersStorage))
+      BlockchainImpl(
+        storagesInstance.storages,
+        new BlockchainReader(
+          storagesInstance.storages.blockHeadersStorage,
+          storagesInstance.storages.blockBodiesStorage
+        )
+      )
         .getWorldStateProxy(
           -1,
           UInt256.Zero,

--- a/src/test/scala/io/iohk/ethereum/ledger/DeleteAccountsSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/DeleteAccountsSpec.scala
@@ -70,7 +70,8 @@ class DeleteAccountsSpec extends AnyFlatSpec with Matchers with MockFactory {
         storagesInstance.storages,
         new BlockchainReader(
           storagesInstance.storages.blockHeadersStorage,
-          storagesInstance.storages.blockBodiesStorage
+          storagesInstance.storages.blockBodiesStorage,
+          storagesInstance.storages.blockNumberMappingStorage
         )
       )
         .getWorldStateProxy(

--- a/src/test/scala/io/iohk/ethereum/ledger/DeleteAccountsSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/DeleteAccountsSpec.scala
@@ -66,14 +66,7 @@ class DeleteAccountsSpec extends AnyFlatSpec with Matchers with MockFactory {
     val accountAddresses = Set(validAccountAddress, validAccountAddress2, validAccountAddress3)
 
     val worldStateWithoutPersist: InMemoryWorldStateProxy =
-      BlockchainImpl(
-        storagesInstance.storages,
-        new BlockchainReader(
-          storagesInstance.storages.blockHeadersStorage,
-          storagesInstance.storages.blockBodiesStorage,
-          storagesInstance.storages.blockNumberMappingStorage
-        )
-      )
+      BlockchainImpl(storagesInstance.storages, BlockchainReader(storagesInstance.storages))
         .getWorldStateProxy(
           -1,
           UInt256.Zero,

--- a/src/test/scala/io/iohk/ethereum/ledger/DeleteAccountsSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/DeleteAccountsSpec.scala
@@ -3,7 +3,7 @@ package io.iohk.ethereum.ledger
 import akka.util.ByteString
 import io.iohk.ethereum.Mocks.MockVM
 import io.iohk.ethereum.blockchain.sync.EphemBlockchainTestSetup
-import io.iohk.ethereum.domain.{Account, Address, BlockchainImpl, UInt256}
+import io.iohk.ethereum.domain.{Account, Address, BlockchainImpl, BlockchainReader, UInt256}
 import io.iohk.ethereum.ledger.Ledger.VMImpl
 import io.iohk.ethereum.mpt.MerklePatriciaTrie
 import io.iohk.ethereum.utils.Config
@@ -66,7 +66,7 @@ class DeleteAccountsSpec extends AnyFlatSpec with Matchers with MockFactory {
     val accountAddresses = Set(validAccountAddress, validAccountAddress2, validAccountAddress3)
 
     val worldStateWithoutPersist: InMemoryWorldStateProxy =
-      BlockchainImpl(storagesInstance.storages)
+      BlockchainImpl(storagesInstance.storages, new BlockchainReader(storagesInstance.storages.blockHeadersStorage))
         .getWorldStateProxy(
           -1,
           UInt256.Zero,

--- a/src/test/scala/io/iohk/ethereum/ledger/DeleteTouchedAccountsSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/DeleteTouchedAccountsSpec.scala
@@ -160,14 +160,7 @@ class DeleteTouchedAccountsSpec extends AnyFlatSpec with Matchers with MockFacto
     )
 
     val worldStateWithoutPersist: InMemoryWorldStateProxy =
-      BlockchainImpl(
-        storagesInstance.storages,
-        new BlockchainReader(
-          storagesInstance.storages.blockHeadersStorage,
-          storagesInstance.storages.blockBodiesStorage,
-          storagesInstance.storages.blockNumberMappingStorage
-        )
-      )
+      BlockchainImpl(storagesInstance.storages, BlockchainReader(storagesInstance.storages))
         .getWorldStateProxy(
           -1,
           UInt256.Zero,
@@ -182,14 +175,7 @@ class DeleteTouchedAccountsSpec extends AnyFlatSpec with Matchers with MockFacto
         .saveAccount(validEmptyAccountAddress1, Account.empty())
 
     val worldStateWithoutPersistPreEIP161: InMemoryWorldStateProxy =
-      BlockchainImpl(
-        storagesInstance.storages,
-        new BlockchainReader(
-          storagesInstance.storages.blockHeadersStorage,
-          storagesInstance.storages.blockBodiesStorage,
-          storagesInstance.storages.blockNumberMappingStorage
-        )
-      )
+      BlockchainImpl(storagesInstance.storages, BlockchainReader(storagesInstance.storages))
         .getWorldStateProxy(
           -1,
           UInt256.Zero,

--- a/src/test/scala/io/iohk/ethereum/ledger/DeleteTouchedAccountsSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/DeleteTouchedAccountsSpec.scala
@@ -3,7 +3,7 @@ package io.iohk.ethereum.ledger
 import akka.util.ByteString
 import io.iohk.ethereum.Mocks.MockVM
 import io.iohk.ethereum.blockchain.sync.EphemBlockchainTestSetup
-import io.iohk.ethereum.domain.{Account, Address, BlockchainImpl, UInt256}
+import io.iohk.ethereum.domain.{Account, Address, BlockchainImpl, BlockchainReader, UInt256}
 import io.iohk.ethereum.ledger.Ledger.VMImpl
 import io.iohk.ethereum.mpt.MerklePatriciaTrie
 import io.iohk.ethereum.utils.Config
@@ -160,7 +160,7 @@ class DeleteTouchedAccountsSpec extends AnyFlatSpec with Matchers with MockFacto
     )
 
     val worldStateWithoutPersist: InMemoryWorldStateProxy =
-      BlockchainImpl(storagesInstance.storages)
+      BlockchainImpl(storagesInstance.storages, new BlockchainReader(storagesInstance.storages.blockHeadersStorage))
         .getWorldStateProxy(
           -1,
           UInt256.Zero,
@@ -175,7 +175,7 @@ class DeleteTouchedAccountsSpec extends AnyFlatSpec with Matchers with MockFacto
         .saveAccount(validEmptyAccountAddress1, Account.empty())
 
     val worldStateWithoutPersistPreEIP161: InMemoryWorldStateProxy =
-      BlockchainImpl(storagesInstance.storages)
+      BlockchainImpl(storagesInstance.storages, new BlockchainReader(storagesInstance.storages.blockHeadersStorage))
         .getWorldStateProxy(
           -1,
           UInt256.Zero,

--- a/src/test/scala/io/iohk/ethereum/ledger/DeleteTouchedAccountsSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/DeleteTouchedAccountsSpec.scala
@@ -160,7 +160,13 @@ class DeleteTouchedAccountsSpec extends AnyFlatSpec with Matchers with MockFacto
     )
 
     val worldStateWithoutPersist: InMemoryWorldStateProxy =
-      BlockchainImpl(storagesInstance.storages, new BlockchainReader(storagesInstance.storages.blockHeadersStorage))
+      BlockchainImpl(
+        storagesInstance.storages,
+        new BlockchainReader(
+          storagesInstance.storages.blockHeadersStorage,
+          storagesInstance.storages.blockBodiesStorage
+        )
+      )
         .getWorldStateProxy(
           -1,
           UInt256.Zero,
@@ -175,7 +181,13 @@ class DeleteTouchedAccountsSpec extends AnyFlatSpec with Matchers with MockFacto
         .saveAccount(validEmptyAccountAddress1, Account.empty())
 
     val worldStateWithoutPersistPreEIP161: InMemoryWorldStateProxy =
-      BlockchainImpl(storagesInstance.storages, new BlockchainReader(storagesInstance.storages.blockHeadersStorage))
+      BlockchainImpl(
+        storagesInstance.storages,
+        new BlockchainReader(
+          storagesInstance.storages.blockHeadersStorage,
+          storagesInstance.storages.blockBodiesStorage
+        )
+      )
         .getWorldStateProxy(
           -1,
           UInt256.Zero,

--- a/src/test/scala/io/iohk/ethereum/ledger/DeleteTouchedAccountsSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/DeleteTouchedAccountsSpec.scala
@@ -164,7 +164,8 @@ class DeleteTouchedAccountsSpec extends AnyFlatSpec with Matchers with MockFacto
         storagesInstance.storages,
         new BlockchainReader(
           storagesInstance.storages.blockHeadersStorage,
-          storagesInstance.storages.blockBodiesStorage
+          storagesInstance.storages.blockBodiesStorage,
+          storagesInstance.storages.blockNumberMappingStorage
         )
       )
         .getWorldStateProxy(
@@ -185,7 +186,8 @@ class DeleteTouchedAccountsSpec extends AnyFlatSpec with Matchers with MockFacto
         storagesInstance.storages,
         new BlockchainReader(
           storagesInstance.storages.blockHeadersStorage,
-          storagesInstance.storages.blockBodiesStorage
+          storagesInstance.storages.blockBodiesStorage,
+          storagesInstance.storages.blockNumberMappingStorage
         )
       )
         .getWorldStateProxy(

--- a/src/test/scala/io/iohk/ethereum/ledger/InMemoryWorldStateProxySpec.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/InMemoryWorldStateProxySpec.scala
@@ -125,7 +125,7 @@ class InMemoryWorldStateProxySpec extends AnyFlatSpec with Matchers {
     // Create a new WS instance based on storages and new root state and check
     val newWorldState = BlockchainImpl(
       storagesInstance.storages,
-      new BlockchainReader(storagesInstance.storages.blockHeadersStorage)
+      new BlockchainReader(storagesInstance.storages.blockHeadersStorage, storagesInstance.storages.blockBodiesStorage)
     ).getWorldStateProxy(
       -1,
       UInt256.Zero,

--- a/src/test/scala/io/iohk/ethereum/ledger/InMemoryWorldStateProxySpec.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/InMemoryWorldStateProxySpec.scala
@@ -2,7 +2,7 @@ package io.iohk.ethereum.ledger
 
 import akka.util.ByteString
 import io.iohk.ethereum.blockchain.sync.EphemBlockchainTestSetup
-import io.iohk.ethereum.domain.{Account, Address, BlockchainImpl, UInt256}
+import io.iohk.ethereum.domain.{Account, Address, BlockchainImpl, BlockchainReader, UInt256}
 import io.iohk.ethereum.mpt.MerklePatriciaTrie
 import io.iohk.ethereum.mpt.MerklePatriciaTrie.MPTException
 import io.iohk.ethereum.vm.{EvmConfig, Generators}
@@ -123,7 +123,10 @@ class InMemoryWorldStateProxySpec extends AnyFlatSpec with Matchers {
     validateInitialWorld(persistedWorldState)
 
     // Create a new WS instance based on storages and new root state and check
-    val newWorldState = BlockchainImpl(storagesInstance.storages).getWorldStateProxy(
+    val newWorldState = BlockchainImpl(
+      storagesInstance.storages,
+      new BlockchainReader(storagesInstance.storages.blockHeadersStorage)
+    ).getWorldStateProxy(
       -1,
       UInt256.Zero,
       persistedWorldState.stateRootHash,

--- a/src/test/scala/io/iohk/ethereum/ledger/InMemoryWorldStateProxySpec.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/InMemoryWorldStateProxySpec.scala
@@ -123,20 +123,15 @@ class InMemoryWorldStateProxySpec extends AnyFlatSpec with Matchers {
     validateInitialWorld(persistedWorldState)
 
     // Create a new WS instance based on storages and new root state and check
-    val newWorldState = BlockchainImpl(
-      storagesInstance.storages,
-      new BlockchainReader(
-        storagesInstance.storages.blockHeadersStorage,
-        storagesInstance.storages.blockBodiesStorage,
-        storagesInstance.storages.blockNumberMappingStorage
-      )
-    ).getWorldStateProxy(
-      -1,
-      UInt256.Zero,
-      persistedWorldState.stateRootHash,
-      noEmptyAccounts = true,
-      ethCompatibleStorage = true
-    )
+    val newWorldState =
+      BlockchainImpl(storagesInstance.storages, BlockchainReader(storagesInstance.storages))
+        .getWorldStateProxy(
+          -1,
+          UInt256.Zero,
+          persistedWorldState.stateRootHash,
+          noEmptyAccounts = true,
+          ethCompatibleStorage = true
+        )
     validateInitialWorld(newWorldState)
 
     // Update this new WS check everything is ok

--- a/src/test/scala/io/iohk/ethereum/ledger/InMemoryWorldStateProxySpec.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/InMemoryWorldStateProxySpec.scala
@@ -125,7 +125,11 @@ class InMemoryWorldStateProxySpec extends AnyFlatSpec with Matchers {
     // Create a new WS instance based on storages and new root state and check
     val newWorldState = BlockchainImpl(
       storagesInstance.storages,
-      new BlockchainReader(storagesInstance.storages.blockHeadersStorage, storagesInstance.storages.blockBodiesStorage)
+      new BlockchainReader(
+        storagesInstance.storages.blockHeadersStorage,
+        storagesInstance.storages.blockBodiesStorage,
+        storagesInstance.storages.blockNumberMappingStorage
+      )
     ).getWorldStateProxy(
       -1,
       UInt256.Zero,

--- a/src/test/scala/io/iohk/ethereum/ledger/LedgerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/LedgerSpec.scala
@@ -293,7 +293,11 @@ class LedgerSpec extends AnyFlatSpec with ScalaCheckPropertyChecks with Matchers
     }
 
     override lazy val ledger: LedgerImpl =
-      newTestLedger(blockchain = testBlockchain, blockchainConfig = proDaoBlockchainConfig)
+      newTestLedger(
+        blockchain = testBlockchain,
+        blockchainReader = testBlockchainReader,
+        blockchainConfig = proDaoBlockchainConfig
+      )
 
     // We don't care about block txs in this test
     ledger.blockExecution.executeBlockTransactions(
@@ -308,7 +312,8 @@ class LedgerSpec extends AnyFlatSpec with ScalaCheckPropertyChecks with Matchers
       (worldState.transfer _).expects(*, *, *).never()
     }
 
-    override lazy val ledger: LedgerImpl = newTestLedger(blockchain = testBlockchain)
+    override lazy val ledger: LedgerImpl =
+      newTestLedger(blockchain = testBlockchain, blockchainReader = testBlockchainReader)
 
     // We don't care about block txs in this test
     ledger.blockExecution.executeBlockTransactions(

--- a/src/test/scala/io/iohk/ethereum/ledger/LedgerTestSetup.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/LedgerTestSetup.scala
@@ -83,7 +83,10 @@ trait TestSetup extends SecureRandomBuilder with EphemBlockchainTestSetup {
   val defaultValue: BigInt = 1000
 
   val emptyWorld: InMemoryWorldStateProxy =
-    BlockchainImpl(storagesInstance.storages, new BlockchainReader(storagesInstance.storages.blockHeadersStorage))
+    BlockchainImpl(
+      storagesInstance.storages,
+      new BlockchainReader(storagesInstance.storages.blockHeadersStorage, storagesInstance.storages.blockBodiesStorage)
+    )
       .getWorldStateProxy(
         -1,
         UInt256.Zero,
@@ -135,7 +138,10 @@ trait TestSetup extends SecureRandomBuilder with EphemBlockchainTestSetup {
       blockchainStorages: BlockchainStorages,
       changes: Seq[(Address, Changes)]
   ): ByteString = {
-    val initialWorld = BlockchainImpl(blockchainStorages, new BlockchainReader(blockchainStorages.blockHeadersStorage))
+    val initialWorld = BlockchainImpl(
+      blockchainStorages,
+      new BlockchainReader(blockchainStorages.blockHeadersStorage, blockchainStorages.blockBodiesStorage)
+    )
       .getWorldStateProxy(
         -1,
         UInt256.Zero,
@@ -378,7 +384,7 @@ trait MockBlockchain extends MockFactory { self: TestSetupWithVmAndValidators =>
   val blockQueue: BlockQueue = mock[MockBlockQueue]
 
   def setBlockExists(block: Block, inChain: Boolean, inQueue: Boolean): CallHandler1[ByteString, Boolean] = {
-    (blockchain.getBlockByHash _)
+    (blockchainReader.getBlockByHash _)
       .expects(block.header.hash)
       .anyNumberOfTimes()
       .returning(Some(block).filter(_ => inChain))

--- a/src/test/scala/io/iohk/ethereum/ledger/LedgerTestSetup.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/LedgerTestSetup.scala
@@ -85,7 +85,11 @@ trait TestSetup extends SecureRandomBuilder with EphemBlockchainTestSetup {
   val emptyWorld: InMemoryWorldStateProxy =
     BlockchainImpl(
       storagesInstance.storages,
-      new BlockchainReader(storagesInstance.storages.blockHeadersStorage, storagesInstance.storages.blockBodiesStorage)
+      new BlockchainReader(
+        storagesInstance.storages.blockHeadersStorage,
+        storagesInstance.storages.blockBodiesStorage,
+        storagesInstance.storages.blockNumberMappingStorage
+      )
     )
       .getWorldStateProxy(
         -1,
@@ -140,7 +144,11 @@ trait TestSetup extends SecureRandomBuilder with EphemBlockchainTestSetup {
   ): ByteString = {
     val initialWorld = BlockchainImpl(
       blockchainStorages,
-      new BlockchainReader(blockchainStorages.blockHeadersStorage, blockchainStorages.blockBodiesStorage)
+      new BlockchainReader(
+        blockchainStorages.blockHeadersStorage,
+        blockchainStorages.blockBodiesStorage,
+        blockchainStorages.blockNumberMappingStorage
+      )
     )
       .getWorldStateProxy(
         -1,
@@ -421,7 +429,7 @@ trait MockBlockchain extends MockFactory { self: TestSetupWithVmAndValidators =>
     (blockchain.isInChain _).expects(hash).returning(result)
 
   def setBlockByNumber(number: BigInt, block: Option[Block]): CallHandler1[BigInt, Option[Block]] =
-    (blockchain.getBlockByNumber _).expects(number).returning(block)
+    (blockchainReader.getBlockByNumber _).expects(number).returning(block)
 
   def setGenesisHeader(header: BlockHeader): Unit =
     (() => blockchain.genesisHeader).expects().returning(header)

--- a/src/test/scala/io/iohk/ethereum/ledger/LedgerTestSetup.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/LedgerTestSetup.scala
@@ -83,14 +83,7 @@ trait TestSetup extends SecureRandomBuilder with EphemBlockchainTestSetup {
   val defaultValue: BigInt = 1000
 
   val emptyWorld: InMemoryWorldStateProxy =
-    BlockchainImpl(
-      storagesInstance.storages,
-      new BlockchainReader(
-        storagesInstance.storages.blockHeadersStorage,
-        storagesInstance.storages.blockBodiesStorage,
-        storagesInstance.storages.blockNumberMappingStorage
-      )
-    )
+    BlockchainImpl(storagesInstance.storages, BlockchainReader(storagesInstance.storages))
       .getWorldStateProxy(
         -1,
         UInt256.Zero,
@@ -142,14 +135,7 @@ trait TestSetup extends SecureRandomBuilder with EphemBlockchainTestSetup {
       blockchainStorages: BlockchainStorages,
       changes: Seq[(Address, Changes)]
   ): ByteString = {
-    val initialWorld = BlockchainImpl(
-      blockchainStorages,
-      new BlockchainReader(
-        blockchainStorages.blockHeadersStorage,
-        blockchainStorages.blockBodiesStorage,
-        blockchainStorages.blockNumberMappingStorage
-      )
-    )
+    val initialWorld = BlockchainImpl(blockchainStorages, BlockchainReader(blockchainStorages))
       .getWorldStateProxy(
         -1,
         UInt256.Zero,

--- a/src/test/scala/io/iohk/ethereum/network/handshaker/EtcHandshakerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/network/handshaker/EtcHandshakerSpec.scala
@@ -277,6 +277,7 @@ class EtcHandshakerSpec extends AnyFlatSpec with Matchers {
       override val blockchain: Blockchain = TestSetup.this.blockchain
       override val appStateStorage: AppStateStorage = TestSetup.this.storagesInstance.storages.appStateStorage
       override val capabilities: List[Capability] = pv
+      override val blockchainReader: BlockchainReader = TestSetup.this.blockchainReader
     }
 
     val etcHandshakerConfigurationWithResolver = new MockEtcHandshakerConfiguration {
@@ -285,7 +286,9 @@ class EtcHandshakerSpec extends AnyFlatSpec with Matchers {
       )
     }
 
-    val initHandshakerWithoutResolver = EtcHandshaker(new MockEtcHandshakerConfiguration(List(ProtocolVersions.ETC64, ProtocolVersions.ETH63)))
+    val initHandshakerWithoutResolver = EtcHandshaker(
+      new MockEtcHandshakerConfiguration(List(ProtocolVersions.ETC64, ProtocolVersions.ETH63))
+    )
 
     val initHandshakerWithResolver = EtcHandshaker(etcHandshakerConfigurationWithResolver)
 

--- a/src/test/scala/io/iohk/ethereum/network/p2p/PeerActorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/network/p2p/PeerActorSpec.scala
@@ -563,6 +563,7 @@ class PeerActorSpec
       override val nodeStatusHolder: AtomicReference[NodeStatus] = self.nodeStatusHolder
       override val peerConfiguration: PeerConfiguration = self.peerConf
       override val blockchain: Blockchain = self.blockchain
+      override val blockchainReader: BlockchainReader = self.blockchainReader
       override val appStateStorage: AppStateStorage = self.storagesInstance.storages.appStateStorage
       override val capabilities: List[Capability] = List(protocol)
     }

--- a/src/test/scala/io/iohk/ethereum/ommers/OmmersPoolSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/ommers/OmmersPoolSpec.scala
@@ -1,10 +1,10 @@
 package io.iohk.ethereum.ommers
 
 import akka.actor.ActorSystem
-import akka.testkit.{TestProbe, TestKit, ImplicitSender}
+import akka.testkit.{ImplicitSender, TestKit, TestProbe}
 import io.iohk.ethereum.Fixtures.Blocks.Block3125369
 import io.iohk.ethereum.Timeouts
-import io.iohk.ethereum.domain.BlockchainImpl
+import io.iohk.ethereum.domain.{BlockchainImpl, BlockchainReader}
 import io.iohk.ethereum.ommers.OmmersPool.{AddOmmers, GetOmmers}
 import io.iohk.ethereum.WithActorSystemShutDown
 import org.scalamock.scalatest.MockFactory
@@ -29,9 +29,9 @@ class OmmersPoolSpec
         *  [] new block, reference!
         *  () ommer given the new block
         */
-      (blockchain.getBlockHeaderByHash _).expects(block2Chain1.hash).returns(Some(block2Chain1))
-      (blockchain.getBlockHeaderByHash _).expects(block1Chain1.hash).returns(Some(block1Chain1))
-      (blockchain.getBlockHeaderByHash _).expects(block0.hash).returns(Some(block0))
+      (blockchainReader.getBlockHeaderByHash _).expects(block2Chain1.hash).returns(Some(block2Chain1))
+      (blockchainReader.getBlockHeaderByHash _).expects(block1Chain1.hash).returns(Some(block1Chain1))
+      (blockchainReader.getBlockHeaderByHash _).expects(block0.hash).returns(Some(block0))
 
       ommersPool ! AddOmmers(
         block0,
@@ -56,8 +56,8 @@ class OmmersPoolSpec
           *  [] new block, reference!
           *  () ommer given the new block
           */
-        (blockchain.getBlockHeaderByHash _).expects(block0.hash).returns(Some(block0))
-        (blockchain.getBlockHeaderByHash _).expects(block0.parentHash).returns(None)
+        (blockchainReader.getBlockHeaderByHash _).expects(block0.hash).returns(Some(block0))
+        (blockchainReader.getBlockHeaderByHash _).expects(block0.parentHash).returns(None)
 
         ommersPool ! AddOmmers(
           block0,
@@ -85,9 +85,9 @@ class OmmersPoolSpec
           *  () ommer given the new block
           *  XX removed block
           */
-        (blockchain.getBlockHeaderByHash _).expects(block1Chain4.hash).returns(Some(block1Chain4)).once()
-        (blockchain.getBlockHeaderByHash _).expects(block0.hash).returns(Some(block0)).once()
-        (blockchain.getBlockHeaderByHash _).expects(block0.parentHash).returns(None).once()
+        (blockchainReader.getBlockHeaderByHash _).expects(block1Chain4.hash).returns(Some(block1Chain4)).once()
+        (blockchainReader.getBlockHeaderByHash _).expects(block0.hash).returns(Some(block0)).once()
+        (blockchainReader.getBlockHeaderByHash _).expects(block0.parentHash).returns(None).once()
 
         ommersPool ! AddOmmers(
           block0,
@@ -118,9 +118,9 @@ class OmmersPoolSpec
           *  [] new block, reference!
           *  () ommer given the new block
           */
-        (blockchain.getBlockHeaderByHash _).expects(block2Chain1.hash).returns(Some(block2Chain1))
-        (blockchain.getBlockHeaderByHash _).expects(block1Chain1.hash).returns(Some(block1Chain1))
-        (blockchain.getBlockHeaderByHash _).expects(block0.hash).returns(Some(block0))
+        (blockchainReader.getBlockHeaderByHash _).expects(block2Chain1.hash).returns(Some(block2Chain1))
+        (blockchainReader.getBlockHeaderByHash _).expects(block1Chain1.hash).returns(Some(block1Chain1))
+        (blockchainReader.getBlockHeaderByHash _).expects(block0.hash).returns(Some(block0))
 
         ommersPool ! AddOmmers(
           block0,
@@ -174,8 +174,10 @@ class OmmersPoolSpec
 
     val testProbe = TestProbe()
 
-    val blockchain = mock[BlockchainImpl]
+    val blockchainReader = mock[BlockchainReader]
     val ommersPool =
-      system.actorOf(OmmersPool.props(blockchain, ommersPoolSize, ommerGenerationLimit, returnedOmmerSizeLimit))
+      system.actorOf(
+        OmmersPool.props(blockchainReader, ommersPoolSize, ommerGenerationLimit, returnedOmmerSizeLimit)
+      )
   }
 }

--- a/src/test/scala/io/iohk/ethereum/transactions/TransactionHistoryServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/transactions/TransactionHistoryServiceSpec.scala
@@ -26,7 +26,7 @@ class TransactionHistoryServiceSpec
     val pendingTransactionManager = TestProbe()
     pendingTransactionManager.setAutoPilot(PendingTransactionsManagerAutoPilot())
     val transactionHistoryService =
-      new TransactionHistoryService(blockchain, pendingTransactionManager.ref, Timeouts.normalTimeout)
+      new TransactionHistoryService(blockchain, blockchainReader, pendingTransactionManager.ref, Timeouts.normalTimeout)
   }
 
   def createFixture() = new Fixture


### PR DESCRIPTION
# Description

The goal of this PR is to put the read only part of `Blockchain` in another class in order to reduce the dependency on this class. As a target I choose to make `BlockchainHostActor` independent of `Blockchain`. 

I moved a few function inside a new class named `BlockchainReader` for consistency, but we could come up with another name. 

It allowed to remove `Blockchain` at some other places but there are still read only methods that can be moved to go further. But as it is already a big change we should at least validate this before continuing.

# review

This is a big change, but mostly moving things around. Each commit can be viewed one by one and is mergeable, so we can split this PR if needed

One important thing to think about is : does the change help us for a future refactoring ? I don't necessarily see `BlockchainReader` as a final target for the structure of the code, but more as step to help us refactor step by step.


