### PR TITLE
Add extra info data from JsonRpcErrors to the log

### DIFF
--- a/src/main/scala/io/iohk/ethereum/jsonrpc/server/controllers/JsonRpcBaseController.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/server/controllers/JsonRpcBaseController.scala
@@ -62,10 +62,11 @@ trait JsonRpcBaseController {
 
     handleFn(request)
       .flatTap {
-        case JsonRpcResponse(_, _, Some(JsonRpcError(code, message, _)), _) =>
+        case JsonRpcResponse(_, _, Some(JsonRpcError(code, message, extraData)), _) =>
           Task {
             log.error(
-              s"JsonRpcError from request: ${request.toStringWithSensitiveInformation} - response code: $code and message: $message"
+              s"JsonRpcError from request: ${request.toStringWithSensitiveInformation} - response code: $code and message: $message. " +
+                s"${extraData.map(data => s"Extra info: ${data.values}")}"
             )
             JsonRpcControllerMetrics.MethodsErrorCounter.increment()
           }


### PR DESCRIPTION
# Description
When the JSON RPC API logs errors, the `data: Option[JValue]` is not being logged. Given that the same error can happen for more than one reason, this is good information

