### PR TITLE
[ETCM-964] Fix preimage cache to make vmArithmeticTest pass

### DIFF
--- a/src/main/scala/io/iohk/ethereum/ledger/BlockExecution.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/BlockExecution.scala
@@ -148,7 +148,8 @@ class BlockExecution(
     * @param blocks   blocks to be executed
     * @param parentChainWeight parent weight
     *
-    * @return a list of blocks in incremental order that were correctly executed and an optional [[BlockExecutionError]]
+    * @return a list of blocks in incremental order that were correctly executed and an optional
+    *         [[io.iohk.ethereum.ledger.BlockExecutionError]]
     */
   def executeAndValidateBlocks(
       blocks: List[Block],

--- a/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
@@ -427,8 +427,7 @@ trait TestServiceBuilder {
       consensusConfig,
       testModeComponentsProvider,
       blockchainConfig,
-      storagesInstance.storages.transactionMappingStorage,
-      preimages
+      storagesInstance.storages.transactionMappingStorage
     )(scheduler)
 }
 

--- a/src/main/scala/io/iohk/ethereum/testmode/TestBlockchainBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/testmode/TestBlockchainBuilder.scala
@@ -1,16 +1,11 @@
 package io.iohk.ethereum.testmode
 
 import akka.util.ByteString
-import io.iohk.ethereum.crypto
 import io.iohk.ethereum.domain.{BlockchainImpl, UInt256}
-import io.iohk.ethereum.ledger.InMemoryWorldStateProxy
 import io.iohk.ethereum.nodebuilder.{BlockchainBuilder, StorageBuilder}
 
 trait TestBlockchainBuilder extends BlockchainBuilder {
   self: StorageBuilder =>
-
-  lazy val preimages: collection.concurrent.Map[ByteString, UInt256] =
-    new collection.concurrent.TrieMap[ByteString, UInt256]()
 
   override lazy val blockchain: BlockchainImpl = {
     val storages = storagesInstance.storages

--- a/src/main/scala/io/iohk/ethereum/testmode/TestModeBlockExecution.scala
+++ b/src/main/scala/io/iohk/ethereum/testmode/TestModeBlockExecution.scala
@@ -1,0 +1,39 @@
+package io.iohk.ethereum.testmode
+
+import akka.util.ByteString
+import io.iohk.ethereum.crypto
+import io.iohk.ethereum.db.storage.EvmCodeStorage
+import io.iohk.ethereum.domain.{Block, BlockHeader, BlockchainImpl, BlockchainReader, UInt256}
+import io.iohk.ethereum.ledger.{BlockExecution, BlockPreparator, BlockValidation, InMemoryWorldStateProxy}
+import io.iohk.ethereum.utils.BlockchainConfig
+import io.iohk.ethereum.vm.EvmConfig
+
+class TestModeBlockExecution(
+    blockchain: BlockchainImpl,
+    blockchainReader: BlockchainReader,
+    evmCodeStorage: EvmCodeStorage,
+    blockchainConfig: BlockchainConfig,
+    blockPreparator: BlockPreparator,
+    blockValidation: BlockValidation,
+    saveStoragePreimage: (UInt256) => Unit
+) extends BlockExecution(
+      blockchain,
+      blockchainReader,
+      evmCodeStorage,
+      blockchainConfig,
+      blockPreparator,
+      blockValidation
+    ) {
+
+  override protected def buildInitialWorld(block: Block, parentHeader: BlockHeader): InMemoryWorldStateProxy =
+    TestModeWorldStateProxy(
+      evmCodeStorage = evmCodeStorage,
+      nodesKeyValueStorage = blockchain.getBackingMptStorage(block.header.number),
+      getBlockHashByNumber = (number: BigInt) => blockchainReader.getBlockHeaderByNumber(number).map(_.hash),
+      accountStartNonce = blockchainConfig.accountStartNonce,
+      stateRootHash = parentHeader.stateRoot,
+      noEmptyAccounts = EvmConfig.forBlock(parentHeader.number, blockchainConfig).noEmptyAccounts,
+      ethCompatibleStorage = blockchainConfig.ethCompatibleStorage,
+      saveStoragePreimage = saveStoragePreimage
+    )
+}


### PR DESCRIPTION
# Description

We accidentally removed the storage key preimage cache in test mode during our refactoring, which broke lots of ETS tests. 

This PR fixes that to make those ETS test work again

