### PR TITLE
[ETCM-963] blockchain write layer - methods save and storeBlock

### DIFF
--- a/src/it/scala/io/iohk/ethereum/sync/util/CommonFakePeer.scala
+++ b/src/it/scala/io/iohk/ethereum/sync/util/CommonFakePeer.scala
@@ -5,16 +5,20 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.time.Clock
 import java.util.concurrent.atomic.AtomicReference
+
 import akka.actor.ActorRef
 import akka.actor.ActorSystem
 import akka.testkit.TestProbe
 import akka.util.ByteString
 import akka.util.Timeout
+
 import monix.eval.Task
 
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.duration._
+
 import org.bouncycastle.crypto.AsymmetricCipherKeyPair
+
 import io.iohk.ethereum.Fixtures
 import io.iohk.ethereum.Timeouts
 import io.iohk.ethereum.blockchain.sync.BlockchainHostActor
@@ -32,15 +36,13 @@ import io.iohk.ethereum.db.storage.AppStateStorage
 import io.iohk.ethereum.db.storage.Namespaces
 import io.iohk.ethereum.db.storage.pruning.ArchivePruning
 import io.iohk.ethereum.db.storage.pruning.PruningMode
-import io.iohk.ethereum.domain.{
-  Block,
-  Blockchain,
-  BlockchainImpl,
-  BlockchainMetadata,
-  BlockchainReader,
-  BlockchainWriter,
-  ChainWeight
-}
+import io.iohk.ethereum.domain.Block
+import io.iohk.ethereum.domain.Blockchain
+import io.iohk.ethereum.domain.BlockchainImpl
+import io.iohk.ethereum.domain.BlockchainMetadata
+import io.iohk.ethereum.domain.BlockchainReader
+import io.iohk.ethereum.domain.BlockchainWriter
+import io.iohk.ethereum.domain.ChainWeight
 import io.iohk.ethereum.ledger.InMemoryWorldStateProxy
 import io.iohk.ethereum.mpt.MerklePatriciaTrie
 import io.iohk.ethereum.network.EtcPeerManagerActor
@@ -139,8 +141,8 @@ abstract class CommonFakePeer(peerName: String, fakePeerCustomConfig: FakePeerCu
     storagesInstance.storages.appStateStorage.getBestBlockNumber(),
     storagesInstance.storages.appStateStorage.getLatestCheckpointBlockNumber()
   )
-  val blockchainReader = BlockchainReader(storagesInstance.storages)
-  val blockchainWriter = BlockchainWriter(storagesInstance.storages, blockchainMetadata)
+  val blockchainReader: BlockchainReader = BlockchainReader(storagesInstance.storages)
+  val blockchainWriter: BlockchainWriter = BlockchainWriter(storagesInstance.storages, blockchainMetadata)
   val bl: BlockchainImpl = BlockchainImpl(storagesInstance.storages, blockchainReader, blockchainMetadata)
   val evmCodeStorage = storagesInstance.storages.evmCodeStorage
 
@@ -150,7 +152,7 @@ abstract class CommonFakePeer(peerName: String, fakePeerCustomConfig: FakePeerCu
   )
   val genesisWeight: ChainWeight = ChainWeight.zero.increase(genesis.header)
 
-  bl.save(genesis, Seq(), genesisWeight, saveAsBestBlock = true)
+  blockchainWriter.save(genesis, Seq(), genesisWeight, saveAsBestBlock = true)
 
   lazy val nh = nodeStatusHolder
 
@@ -351,7 +353,7 @@ abstract class CommonFakePeer(peerName: String, fakePeerCustomConfig: FakePeerCu
       val newWeight = ChainWeight.totalDifficultyOnly(1)
 
       broadcastBlock(childBlock, newWeight)
-      bl.save(childBlock, Seq(), newWeight, saveAsBestBlock = true)
+      blockchainWriter.save(childBlock, Seq(), newWeight, saveAsBestBlock = true)
     }
 
   private def generateValidBlock(
@@ -362,7 +364,7 @@ abstract class CommonFakePeer(peerName: String, fakePeerCustomConfig: FakePeerCu
       val currentWorld = getMptForBlock(currentBestBlock)
       val (newBlock, newWeight, _) =
         createChildBlock(currentBestBlock, currentWeight, currentWorld)(updateWorldForBlock)
-      bl.save(newBlock, Seq(), newWeight, saveAsBestBlock = true)
+      blockchainWriter.save(newBlock, Seq(), newWeight, saveAsBestBlock = true)
       broadcastBlock(newBlock, newWeight)
     }
 

--- a/src/it/scala/io/iohk/ethereum/sync/util/FastSyncItSpecUtils.scala
+++ b/src/it/scala/io/iohk/ethereum/sync/util/FastSyncItSpecUtils.scala
@@ -36,6 +36,7 @@ object FastSyncItSpecUtils {
         storagesInstance.storages.appStateStorage,
         bl,
         blockchainReader,
+        blockchainWriter,
         storagesInstance.storages.evmCodeStorage,
         storagesInstance.storages.nodeStorage,
         validators,

--- a/src/it/scala/io/iohk/ethereum/sync/util/RegularSyncItSpecUtils.scala
+++ b/src/it/scala/io/iohk/ethereum/sync/util/RegularSyncItSpecUtils.scala
@@ -96,13 +96,22 @@ object RegularSyncItSpecUtils {
       new BlockExecution(
         bl,
         blockchainReader,
+        blockchainWriter,
         storagesInstance.storages.evmCodeStorage,
         blockchainConfig,
         consensus.blockPreparator,
         blockValidation
       )
     lazy val blockImport: BlockImport =
-      new BlockImport(bl, blockchainReader, blockQueue, blockValidation, blockExecution, Scheduler.global)
+      new BlockImport(
+        bl,
+        blockchainReader,
+        blockchainWriter,
+        blockQueue,
+        blockValidation,
+        blockExecution,
+        Scheduler.global
+      )
 
     lazy val ommersPool: ActorRef = system.actorOf(OmmersPool.props(blockchainReader, 1), "ommers-pool")
 

--- a/src/it/scala/io/iohk/ethereum/txExecTest/ContractTest.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/ContractTest.scala
@@ -27,6 +27,7 @@ class ContractTest extends AnyFlatSpec with Matchers {
       new BlockExecution(
         blockchain,
         blockchainReader,
+        blockchainWriter,
         testBlockchainStorages.evmCodeStorage,
         blockchainConfig,
         consensus.blockPreparator,

--- a/src/it/scala/io/iohk/ethereum/txExecTest/ECIP1017Test.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/ECIP1017Test.scala
@@ -6,7 +6,9 @@ import org.scalatest.matchers.should.Matchers
 
 import io.iohk.ethereum.domain.Address
 import io.iohk.ethereum.domain.BlockchainImpl
+import io.iohk.ethereum.domain.BlockchainMetadata
 import io.iohk.ethereum.domain.BlockchainReader
+import io.iohk.ethereum.domain.BlockchainWriter
 import io.iohk.ethereum.domain.Receipt
 import io.iohk.ethereum.domain.UInt256
 import io.iohk.ethereum.ledger.BlockExecution
@@ -83,6 +85,7 @@ class ECIP1017Test extends AnyFlatSpec with Matchers {
         storages.appStateStorage.getLatestCheckpointBlockNumber()
       )
       val blockchainReader = BlockchainReader(storages)
+      val blockchainWriter = BlockchainWriter(storages, blockchainMetadata)
       val blockchain = BlockchainImpl(storages, blockchainReader, blockchainMetadata)
       val blockValidation =
         new BlockValidation(consensus, blockchainReader, BlockQueue(blockchain, syncConfig))
@@ -90,6 +93,7 @@ class ECIP1017Test extends AnyFlatSpec with Matchers {
         new BlockExecution(
           blockchain,
           blockchainReader,
+          blockchainWriter,
           testBlockchainStorages.evmCodeStorage,
           blockchainConfig,
           consensus.blockPreparator,

--- a/src/it/scala/io/iohk/ethereum/txExecTest/ECIP1017Test.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/ECIP1017Test.scala
@@ -78,8 +78,12 @@ class ECIP1017Test extends AnyFlatSpec with Matchers {
 
     (startBlock to endBlock).foreach { blockToExecute =>
       val storages = FixtureProvider.prepareStorages(blockToExecute - 1, fixtures)
+      val blockchainMetadata = new BlockchainMetadata(
+        storages.appStateStorage.getBestBlockNumber(),
+        storages.appStateStorage.getLatestCheckpointBlockNumber()
+      )
       val blockchainReader = BlockchainReader(storages)
-      val blockchain = BlockchainImpl(storages, blockchainReader)
+      val blockchain = BlockchainImpl(storages, blockchainReader, blockchainMetadata)
       val blockValidation =
         new BlockValidation(consensus, blockchainReader, BlockQueue(blockchain, syncConfig))
       val blockExecution =

--- a/src/it/scala/io/iohk/ethereum/txExecTest/ForksTest.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/ForksTest.scala
@@ -72,7 +72,11 @@ class ForksTest extends AnyFlatSpec with Matchers {
     (startBlock to endBlock).foreach { blockToExecute =>
       val storages = FixtureProvider.prepareStorages(blockToExecute - 1, fixtures)
       val blockchainReader = BlockchainReader(storages)
-      val blockchain = BlockchainImpl(storages, blockchainReader)
+      val blockchainMetadata = new BlockchainMetadata(
+        storages.appStateStorage.getBestBlockNumber(),
+        storages.appStateStorage.getLatestCheckpointBlockNumber()
+      )
+      val blockchain = BlockchainImpl(storages, blockchainReader, blockchainMetadata)
       val blockValidation =
         new BlockValidation(consensus, blockchainReader, BlockQueue(blockchain, syncConfig))
       val blockExecution =

--- a/src/it/scala/io/iohk/ethereum/txExecTest/ForksTest.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/ForksTest.scala
@@ -6,7 +6,9 @@ import org.scalatest.matchers.should.Matchers
 
 import io.iohk.ethereum.domain.Address
 import io.iohk.ethereum.domain.BlockchainImpl
+import io.iohk.ethereum.domain.BlockchainMetadata
 import io.iohk.ethereum.domain.BlockchainReader
+import io.iohk.ethereum.domain.BlockchainWriter
 import io.iohk.ethereum.domain.Receipt
 import io.iohk.ethereum.domain.UInt256
 import io.iohk.ethereum.ledger.BlockExecution
@@ -71,11 +73,12 @@ class ForksTest extends AnyFlatSpec with Matchers {
 
     (startBlock to endBlock).foreach { blockToExecute =>
       val storages = FixtureProvider.prepareStorages(blockToExecute - 1, fixtures)
-      val blockchainReader = BlockchainReader(storages)
       val blockchainMetadata = new BlockchainMetadata(
         storages.appStateStorage.getBestBlockNumber(),
         storages.appStateStorage.getLatestCheckpointBlockNumber()
       )
+      val blockchainReader = BlockchainReader(storages)
+      val blockchainWriter = BlockchainWriter(storages, blockchainMetadata)
       val blockchain = BlockchainImpl(storages, blockchainReader, blockchainMetadata)
       val blockValidation =
         new BlockValidation(consensus, blockchainReader, BlockQueue(blockchain, syncConfig))
@@ -83,6 +86,7 @@ class ForksTest extends AnyFlatSpec with Matchers {
         new BlockExecution(
           blockchain,
           blockchainReader,
+          blockchainWriter,
           testBlockchainStorages.evmCodeStorage,
           blockchainConfig,
           consensus.blockPreparator,

--- a/src/it/scala/io/iohk/ethereum/txExecTest/ScenarioSetup.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/ScenarioSetup.scala
@@ -1,7 +1,11 @@
 package io.iohk.ethereum.txExecTest
 
 import io.iohk.ethereum.blockchain.sync.EphemBlockchainTestSetup
-import io.iohk.ethereum.domain.{BlockchainImpl, BlockchainMetadata, BlockchainReader, BlockchainStorages}
+import io.iohk.ethereum.domain.BlockchainImpl
+import io.iohk.ethereum.domain.BlockchainMetadata
+import io.iohk.ethereum.domain.BlockchainReader
+import io.iohk.ethereum.domain.BlockchainStorages
+import io.iohk.ethereum.domain.BlockchainWriter
 import io.iohk.ethereum.ledger.VMImpl
 
 trait ScenarioSetup extends EphemBlockchainTestSetup {
@@ -12,6 +16,7 @@ trait ScenarioSetup extends EphemBlockchainTestSetup {
     testBlockchainStorages.appStateStorage.getLatestCheckpointBlockNumber()
   )
   override lazy val blockchainReader: BlockchainReader = BlockchainReader(testBlockchainStorages)
+  override lazy val blockchainWriter: BlockchainWriter = BlockchainWriter(testBlockchainStorages, blockchainMetadata)
   override lazy val blockchain: BlockchainImpl =
     BlockchainImpl(testBlockchainStorages, blockchainReader, blockchainMetadata)
   override lazy val vm: VMImpl = new VMImpl

--- a/src/it/scala/io/iohk/ethereum/txExecTest/ScenarioSetup.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/ScenarioSetup.scala
@@ -1,15 +1,18 @@
 package io.iohk.ethereum.txExecTest
 
 import io.iohk.ethereum.blockchain.sync.EphemBlockchainTestSetup
-import io.iohk.ethereum.domain.BlockchainImpl
-import io.iohk.ethereum.domain.BlockchainReader
-import io.iohk.ethereum.domain.BlockchainStorages
+import io.iohk.ethereum.domain.{BlockchainImpl, BlockchainMetadata, BlockchainReader, BlockchainStorages}
 import io.iohk.ethereum.ledger.VMImpl
 
 trait ScenarioSetup extends EphemBlockchainTestSetup {
   protected val testBlockchainStorages: BlockchainStorages
 
+  override lazy val blockchainMetadata = new BlockchainMetadata(
+    testBlockchainStorages.appStateStorage.getBestBlockNumber(),
+    testBlockchainStorages.appStateStorage.getLatestCheckpointBlockNumber()
+  )
   override lazy val blockchainReader: BlockchainReader = BlockchainReader(testBlockchainStorages)
-  override lazy val blockchain: BlockchainImpl = BlockchainImpl(testBlockchainStorages, blockchainReader)
+  override lazy val blockchain: BlockchainImpl =
+    BlockchainImpl(testBlockchainStorages, blockchainReader, blockchainMetadata)
   override lazy val vm: VMImpl = new VMImpl
 }

--- a/src/it/scala/io/iohk/ethereum/txExecTest/util/DumpChainActor.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/util/DumpChainActor.scala
@@ -48,7 +48,6 @@ import io.iohk.ethereum.txExecTest.util.DumpChainActor._
 class DumpChainActor(
     peerManager: ActorRef,
     peerMessageBus: ActorRef,
-    startBlock: BigInt,
     maxBlocks: BigInt,
     bootstrapNode: String
 ) extends Actor {
@@ -287,12 +286,11 @@ object DumpChainActor {
   def props(
       peerManager: ActorRef,
       peerMessageBus: ActorRef,
-      startBlock: BigInt,
       maxBlocks: BigInt,
       bootstrapNode: String
   ): Props =
     Props(
-      new DumpChainActor(peerManager, peerMessageBus: ActorRef, startBlock: BigInt, maxBlocks: BigInt, bootstrapNode)
+      new DumpChainActor(peerManager, peerMessageBus: ActorRef, maxBlocks: BigInt, bootstrapNode)
     )
   val emptyStorage: ByteString = ByteString(
     Hex.decode("56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421")

--- a/src/it/scala/io/iohk/ethereum/txExecTest/util/DumpChainApp.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/util/DumpChainApp.scala
@@ -18,7 +18,6 @@ import io.iohk.ethereum.blockchain.sync.CacheBasedBlacklist
 import io.iohk.ethereum.db.components.RocksDbDataSourceComponent
 import io.iohk.ethereum.db.components.Storages
 import io.iohk.ethereum.db.components.Storages.PruningModeComponent
-import io.iohk.ethereum.db.dataSource.DataSourceBatchUpdate
 import io.iohk.ethereum.db.storage.AppStateStorage
 import io.iohk.ethereum.db.storage.MptStorage
 import io.iohk.ethereum.db.storage.NodeStorage.NodeEncoded
@@ -150,7 +149,7 @@ object DumpChainApp
   )
   peerManager ! PeerManagerActor.StartConnecting
 
-  actorSystem.actorOf(DumpChainActor.props(peerManager, peerMessageBus, startBlock, maxBlocks, node), "dumper")
+  actorSystem.actorOf(DumpChainActor.props(peerManager, peerMessageBus, maxBlocks, node), "dumper")
 }
 
 class BlockchainMock(genesisHash: ByteString) extends Blockchain {
@@ -185,14 +184,6 @@ class BlockchainMock(genesisHash: ByteString) extends Blockchain {
       ethCompatibleStorage: Boolean
   ): StorageProof = EmptyStorageValueProof(StorageProofKey(position))
 
-  override def storeBlockHeader(blockHeader: BlockHeader): DataSourceBatchUpdate = ???
-
-  override def storeBlockBody(blockHash: ByteString, blockBody: BlockBody): DataSourceBatchUpdate = ???
-
-  override def storeReceipts(blockHash: ByteString, receipts: Seq[Receipt]): DataSourceBatchUpdate = ???
-
-  override def storeChainWeight(blockhash: ByteString, chainWeight: ChainWeight): DataSourceBatchUpdate = ???
-
   override def saveNode(nodeHash: NodeHash, nodeEncoded: NodeEncoded, blockNumber: BigInt): Unit = ???
 
   override def removeBlock(hash: ByteString, withState: Boolean = true): Unit = ???
@@ -214,8 +205,6 @@ class BlockchainMock(genesisHash: ByteString) extends Blockchain {
   def saveBestKnownBlocks(bestBlockNumber: BigInt, latestCheckpointNumber: Option[BigInt] = None): Unit = ???
 
   def getBestBlock(): Option[Block] = ???
-
-  override def save(block: Block, receipts: Seq[Receipt], weight: ChainWeight, saveAsBestBlock: Boolean): Unit = ???
 
   override def getLatestCheckpointBlockNumber(): BigInt = ???
 

--- a/src/main/scala/io/iohk/ethereum/blockchain/data/GenesisDataLoader.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/data/GenesisDataLoader.scala
@@ -36,8 +36,8 @@ import io.iohk.ethereum.utils.BlockchainConfig
 import io.iohk.ethereum.utils.Logger
 
 class GenesisDataLoader(
-    blockchain: Blockchain,
     blockchainReader: BlockchainReader,
+    blockchainWriter: BlockchainWriter,
     stateStorage: StateStorage,
     blockchainConfig: BlockchainConfig
 ) extends Logger {
@@ -122,7 +122,7 @@ class GenesisDataLoader(
       case None =>
         storage.persist()
         stateStorage.forcePersist(GenesisDataLoad)
-        blockchain.save(
+        blockchainWriter.save(
           Block(header, BlockBody(Nil, Nil)),
           Nil,
           ChainWeight.totalDifficultyOnly(header.difficulty),
@@ -162,8 +162,8 @@ class GenesisDataLoader(
     )
 
     val storageTrie = storage.foldLeft(emptyTrie) {
-      case (trie, (key, UInt256.Zero)) => trie
-      case (trie, (key, value))        => trie.put(key, value)
+      case (trie, (_, UInt256.Zero)) => trie
+      case (trie, (key, value))      => trie.put(key, value)
     }
 
     ByteString(storageTrie.getRootHash)
@@ -210,7 +210,7 @@ object GenesisDataLoader {
     }
 
     object ByteStringJsonSerializer
-        extends CustomSerializer[ByteString](formats =>
+        extends CustomSerializer[ByteString](_ =>
           (
             { case jv => deserializeByteString(jv) },
             PartialFunction.empty

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/SyncController.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/SyncController.scala
@@ -6,6 +6,7 @@ import akka.actor.ActorRef
 import akka.actor.PoisonPill
 import akka.actor.Props
 import akka.actor.Scheduler
+
 import io.iohk.ethereum.blockchain.sync.fast.FastSync
 import io.iohk.ethereum.blockchain.sync.regular.RegularSync
 import io.iohk.ethereum.consensus.validators.Validators
@@ -13,7 +14,9 @@ import io.iohk.ethereum.db.storage.AppStateStorage
 import io.iohk.ethereum.db.storage.EvmCodeStorage
 import io.iohk.ethereum.db.storage.FastSyncStateStorage
 import io.iohk.ethereum.db.storage.NodeStorage
-import io.iohk.ethereum.domain.{Blockchain, BlockchainReader, BlockchainWriter}
+import io.iohk.ethereum.domain.Blockchain
+import io.iohk.ethereum.domain.BlockchainReader
+import io.iohk.ethereum.domain.BlockchainWriter
 import io.iohk.ethereum.ledger.BlockImport
 import io.iohk.ethereum.ledger.BranchResolution
 import io.iohk.ethereum.utils.Config.SyncConfig

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/SyncController.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/SyncController.scala
@@ -6,7 +6,6 @@ import akka.actor.ActorRef
 import akka.actor.PoisonPill
 import akka.actor.Props
 import akka.actor.Scheduler
-
 import io.iohk.ethereum.blockchain.sync.fast.FastSync
 import io.iohk.ethereum.blockchain.sync.regular.RegularSync
 import io.iohk.ethereum.consensus.validators.Validators
@@ -14,8 +13,7 @@ import io.iohk.ethereum.db.storage.AppStateStorage
 import io.iohk.ethereum.db.storage.EvmCodeStorage
 import io.iohk.ethereum.db.storage.FastSyncStateStorage
 import io.iohk.ethereum.db.storage.NodeStorage
-import io.iohk.ethereum.domain.Blockchain
-import io.iohk.ethereum.domain.BlockchainReader
+import io.iohk.ethereum.domain.{Blockchain, BlockchainReader, BlockchainWriter}
 import io.iohk.ethereum.ledger.BlockImport
 import io.iohk.ethereum.ledger.BranchResolution
 import io.iohk.ethereum.utils.Config.SyncConfig
@@ -24,6 +22,7 @@ class SyncController(
     appStateStorage: AppStateStorage,
     blockchain: Blockchain,
     blockchainReader: BlockchainReader,
+    blockchainWriter: BlockchainWriter,
     evmCodeStorage: EvmCodeStorage,
     nodeStorage: NodeStorage,
     fastSyncStateStorage: FastSyncStateStorage,
@@ -92,6 +91,7 @@ class SyncController(
         appStateStorage,
         blockchain,
         blockchainReader,
+        blockchainWriter,
         evmCodeStorage,
         nodeStorage,
         validators,
@@ -139,6 +139,7 @@ object SyncController {
       appStateStorage: AppStateStorage,
       blockchain: Blockchain,
       blockchainReader: BlockchainReader,
+      blockchainWriter: BlockchainWriter,
       evmCodeStorage: EvmCodeStorage,
       nodeStorage: NodeStorage,
       syncStateStorage: FastSyncStateStorage,
@@ -156,6 +157,7 @@ object SyncController {
         appStateStorage,
         blockchain,
         blockchainReader,
+        blockchainWriter,
         evmCodeStorage,
         nodeStorage,
         syncStateStorage,

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/fast/FastSync.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/fast/FastSync.scala
@@ -54,6 +54,7 @@ class FastSync(
     val appStateStorage: AppStateStorage,
     val blockchain: Blockchain,
     val blockchainReader: BlockchainReader,
+    blockchainWriter: BlockchainWriter,
     evmCodeStorage: EvmCodeStorage,
     nodeStorage: NodeStorage,
     val validators: Validators,
@@ -588,7 +589,7 @@ class FastSync(
     }
 
     private def updateSyncState(header: BlockHeader, parentWeight: ChainWeight): Unit = {
-      blockchain
+      blockchainWriter
         .storeBlockHeader(header)
         .and(blockchain.storeChainWeight(header.hash, parentWeight.increase(header)))
         .commit()
@@ -798,7 +799,7 @@ class FastSync(
       requestedHashes
         .zip(blockBodies)
         .map { case (hash, body) =>
-          blockchain.storeBlockBody(hash, body)
+          blockchainWriter.storeBlockBody(hash, body)
         }
         .reduce(_.and(_))
         .commit()
@@ -1147,6 +1148,7 @@ object FastSync {
       appStateStorage: AppStateStorage,
       blockchain: Blockchain,
       blockchainReader: BlockchainReader,
+      blockchainWriter: BlockchainWriter,
       evmCodeStorage: EvmCodeStorage,
       nodeStorage: NodeStorage,
       validators: Validators,
@@ -1162,6 +1164,7 @@ object FastSync {
         appStateStorage,
         blockchain,
         blockchainReader,
+        blockchainWriter,
         evmCodeStorage,
         nodeStorage,
         validators,

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/fast/FastSync.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/fast/FastSync.scala
@@ -591,7 +591,7 @@ class FastSync(
     private def updateSyncState(header: BlockHeader, parentWeight: ChainWeight): Unit = {
       blockchainWriter
         .storeBlockHeader(header)
-        .and(blockchain.storeChainWeight(header.hash, parentWeight.increase(header)))
+        .and(blockchainWriter.storeChainWeight(header.hash, parentWeight.increase(header)))
         .commit()
 
       if (header.number > syncState.bestBlockHeaderNumber) {
@@ -710,7 +710,7 @@ class FastSync(
           case ReceiptsValidationResult.Valid(blockHashesWithReceipts) =>
             blockHashesWithReceipts
               .map { case (hash, receiptsForBlock) =>
-                blockchain.storeReceipts(hash, receiptsForBlock)
+                blockchainWriter.storeReceipts(hash, receiptsForBlock)
               }
               .reduce(_.and(_))
               .commit()
@@ -944,7 +944,7 @@ class FastSync(
         requestBlockBodies(peer)
       } else if (blockHeadersQueue.nonEmpty) {
         requestBlockHeaders(peer)
-      } else if (shouldRequestNewSkeleton(peerInfo)) {
+      } else if (shouldRequestNewSkeleton()) {
         requestSkeletonHeaders(peer)
       } else {
         log.debug(
@@ -955,7 +955,7 @@ class FastSync(
       }
     }
 
-    private def shouldRequestNewSkeleton(peerInfo: PeerInfo): Boolean =
+    private def shouldRequestNewSkeleton(): Boolean =
       currentSkeletonState.isEmpty &&
         skeletonHandler.isEmpty &&
         syncState.bestBlockHeaderNumber < syncState.safeDownloadTarget

--- a/src/main/scala/io/iohk/ethereum/domain/BlockchainMetadata.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/BlockchainMetadata.scala
@@ -1,0 +1,10 @@
+package io.iohk.ethereum.domain
+
+import java.util.concurrent.atomic.AtomicReference
+
+class BlockchainMetadata(bestBlockNumber: BigInt, latestCheckpointNumber: BigInt) {
+  lazy val bestKnownBlockAndLatestCheckpoint: AtomicReference[BestBlockLatestCheckpointNumbers] =
+    new AtomicReference(BestBlockLatestCheckpointNumbers(bestBlockNumber, latestCheckpointNumber))
+}
+
+case class BestBlockLatestCheckpointNumbers(bestBlockNumber: BigInt, latestCheckpointNumber: BigInt)

--- a/src/main/scala/io/iohk/ethereum/domain/BlockchainWriter.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/BlockchainWriter.scala
@@ -1,0 +1,59 @@
+package io.iohk.ethereum.domain
+
+import akka.util.ByteString
+import io.iohk.ethereum.db.dataSource.DataSourceBatchUpdate
+import io.iohk.ethereum.db.storage.TransactionMappingStorage.TransactionLocation
+import io.iohk.ethereum.db.storage.{
+  BlockBodiesStorage,
+  BlockHeadersStorage,
+  BlockNumberMappingStorage,
+  TransactionMappingStorage
+}
+import io.iohk.ethereum.utils.Logger
+
+class BlockchainWriter(
+    blockHeadersStorage: BlockHeadersStorage,
+    blockBodiesStorage: BlockBodiesStorage,
+    blockNumberMappingStorage: BlockNumberMappingStorage,
+    transactionMappingStorage: TransactionMappingStorage
+) extends Logger {
+
+  /**
+    * Persists a block in the underlying Blockchain Database
+    * Note: all store* do not update the database immediately, rather they create
+    * a [[io.iohk.ethereum.db.dataSource.DataSourceBatchUpdate]] which then has to be committed (atomic operation)
+    *
+    * @param block Block to be saved
+    */
+  def storeBlock(block: Block): DataSourceBatchUpdate = {
+    storeBlockHeader(block.header).and(storeBlockBody(block.header.hash, block.body))
+  }
+
+  def storeBlockHeader(blockHeader: BlockHeader): DataSourceBatchUpdate = {
+    val hash = blockHeader.hash
+    blockHeadersStorage.put(hash, blockHeader).and(saveBlockNumberMapping(blockHeader.number, hash))
+  }
+
+  def storeBlockBody(blockHash: ByteString, blockBody: BlockBody): DataSourceBatchUpdate = {
+    blockBodiesStorage.put(blockHash, blockBody).and(saveTxsLocations(blockHash, blockBody))
+  }
+
+  private def saveBlockNumberMapping(number: BigInt, hash: ByteString): DataSourceBatchUpdate =
+    blockNumberMappingStorage.put(number, hash)
+
+  private def saveTxsLocations(blockHash: ByteString, blockBody: BlockBody): DataSourceBatchUpdate =
+    blockBody.transactionList.zipWithIndex.foldLeft(transactionMappingStorage.emptyBatchUpdate) {
+      case (updates, (tx, index)) =>
+        updates.and(transactionMappingStorage.put(tx.hash, TransactionLocation(blockHash, index)))
+    }
+}
+
+object BlockchainWriter {
+  def apply(storages: BlockchainStorages): BlockchainWriter =
+    new BlockchainWriter(
+      storages.blockHeadersStorage,
+      storages.blockBodiesStorage,
+      storages.blockNumberMappingStorage,
+      storages.transactionMappingStorage
+    )
+}

--- a/src/main/scala/io/iohk/ethereum/domain/BlockchainWriter.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/BlockchainWriter.scala
@@ -1,42 +1,83 @@
 package io.iohk.ethereum.domain
 
 import akka.util.ByteString
+
 import io.iohk.ethereum.db.dataSource.DataSourceBatchUpdate
+import io.iohk.ethereum.db.storage.AppStateStorage
+import io.iohk.ethereum.db.storage.BlockBodiesStorage
+import io.iohk.ethereum.db.storage.BlockHeadersStorage
+import io.iohk.ethereum.db.storage.BlockNumberMappingStorage
+import io.iohk.ethereum.db.storage.ChainWeightStorage
+import io.iohk.ethereum.db.storage.ReceiptStorage
+import io.iohk.ethereum.db.storage.StateStorage
+import io.iohk.ethereum.db.storage.TransactionMappingStorage
 import io.iohk.ethereum.db.storage.TransactionMappingStorage.TransactionLocation
-import io.iohk.ethereum.db.storage.{
-  BlockBodiesStorage,
-  BlockHeadersStorage,
-  BlockNumberMappingStorage,
-  TransactionMappingStorage
-}
 import io.iohk.ethereum.utils.Logger
 
 class BlockchainWriter(
     blockHeadersStorage: BlockHeadersStorage,
     blockBodiesStorage: BlockBodiesStorage,
     blockNumberMappingStorage: BlockNumberMappingStorage,
-    transactionMappingStorage: TransactionMappingStorage
+    transactionMappingStorage: TransactionMappingStorage,
+    receiptStorage: ReceiptStorage,
+    chainWeightStorage: ChainWeightStorage,
+    stateStorage: StateStorage,
+    appStateStorage: AppStateStorage,
+    blockchainMetadata: BlockchainMetadata
 ) extends Logger {
 
-  /**
-    * Persists a block in the underlying Blockchain Database
+  def save(block: Block, receipts: Seq[Receipt], weight: ChainWeight, saveAsBestBlock: Boolean): Unit = {
+    if (saveAsBestBlock && block.hasCheckpoint) {
+      log.debug(
+        "New best known block number - {}, new best checkpoint number - {}",
+        block.header.number,
+        block.header.number
+      )
+      saveBestKnownBlockAndLatestCheckpointNumber(block.header.number, block.header.number)
+    } else if (saveAsBestBlock) {
+      log.debug(
+        "New best known block number - {}",
+        block.header.number
+      )
+      saveBestKnownBlock(block.header.number)
+    }
+
+    log.debug("Saving new block {} to database", block.idTag)
+    storeBlock(block)
+      .and(storeReceipts(block.header.hash, receipts))
+      .and(storeChainWeight(block.header.hash, weight))
+      .commit()
+
+    // not transactional part
+    // the best blocks data will be persisted only when the cache will be persisted
+    stateStorage.onBlockSave(block.header.number, appStateStorage.getBestBlockNumber())(persistBestBlocksData)
+  }
+
+  def storeReceipts(blockHash: ByteString, receipts: Seq[Receipt]): DataSourceBatchUpdate =
+    receiptStorage.put(blockHash, receipts)
+
+  def storeChainWeight(blockHash: ByteString, weight: ChainWeight): DataSourceBatchUpdate =
+    chainWeightStorage.put(blockHash, weight)
+
+  private def saveBestKnownBlock(bestBlockNumber: BigInt): Unit =
+    blockchainMetadata.bestKnownBlockAndLatestCheckpoint.updateAndGet(_.copy(bestBlockNumber = bestBlockNumber))
+
+  /** Persists a block in the underlying Blockchain Database
     * Note: all store* do not update the database immediately, rather they create
     * a [[io.iohk.ethereum.db.dataSource.DataSourceBatchUpdate]] which then has to be committed (atomic operation)
     *
     * @param block Block to be saved
     */
-  def storeBlock(block: Block): DataSourceBatchUpdate = {
+  def storeBlock(block: Block): DataSourceBatchUpdate =
     storeBlockHeader(block.header).and(storeBlockBody(block.header.hash, block.body))
-  }
 
   def storeBlockHeader(blockHeader: BlockHeader): DataSourceBatchUpdate = {
     val hash = blockHeader.hash
     blockHeadersStorage.put(hash, blockHeader).and(saveBlockNumberMapping(blockHeader.number, hash))
   }
 
-  def storeBlockBody(blockHash: ByteString, blockBody: BlockBody): DataSourceBatchUpdate = {
+  def storeBlockBody(blockHash: ByteString, blockBody: BlockBody): DataSourceBatchUpdate =
     blockBodiesStorage.put(blockHash, blockBody).and(saveTxsLocations(blockHash, blockBody))
-  }
 
   private def saveBlockNumberMapping(number: BigInt, hash: ByteString): DataSourceBatchUpdate =
     blockNumberMappingStorage.put(number, hash)
@@ -46,14 +87,40 @@ class BlockchainWriter(
       case (updates, (tx, index)) =>
         updates.and(transactionMappingStorage.put(tx.hash, TransactionLocation(blockHash, index)))
     }
+
+  private def saveBestKnownBlockAndLatestCheckpointNumber(number: BigInt, latestCheckpointNumber: BigInt): Unit =
+    blockchainMetadata.bestKnownBlockAndLatestCheckpoint.set(
+      BestBlockLatestCheckpointNumbers(number, latestCheckpointNumber)
+    )
+
+  private def persistBestBlocksData(): Unit = {
+    val currentBestBlockNumber = blockchainMetadata.bestKnownBlockAndLatestCheckpoint.get().bestBlockNumber
+    val currentBestCheckpointNumber = blockchainMetadata.bestKnownBlockAndLatestCheckpoint.get().latestCheckpointNumber
+    log.debug(
+      "Persisting app info data into database. Persisted block number is {}. " +
+        "Persisted checkpoint number is {}",
+      currentBestBlockNumber,
+      currentBestCheckpointNumber
+    )
+
+    appStateStorage
+      .putBestBlockNumber(currentBestBlockNumber)
+      .and(appStateStorage.putLatestCheckpointBlockNumber(currentBestCheckpointNumber))
+      .commit()
+  }
 }
 
 object BlockchainWriter {
-  def apply(storages: BlockchainStorages): BlockchainWriter =
+  def apply(storages: BlockchainStorages, metadata: BlockchainMetadata): BlockchainWriter =
     new BlockchainWriter(
       storages.blockHeadersStorage,
       storages.blockBodiesStorage,
       storages.blockNumberMappingStorage,
-      storages.transactionMappingStorage
+      storages.transactionMappingStorage,
+      storages.receiptStorage,
+      storages.chainWeightStorage,
+      storages.stateStorage,
+      storages.appStateStorage,
+      metadata
     )
 }

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/TestService.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/TestService.scala
@@ -31,6 +31,7 @@ import io.iohk.ethereum.domain.Block
 import io.iohk.ethereum.domain.Block._
 import io.iohk.ethereum.domain.BlockchainImpl
 import io.iohk.ethereum.domain.BlockchainReader
+import io.iohk.ethereum.domain.BlockchainWriter
 import io.iohk.ethereum.domain.UInt256
 import io.iohk.ethereum.jsonrpc.JsonMethodsImplicits._
 import io.iohk.ethereum.ledger._
@@ -133,6 +134,7 @@ object TestService {
 class TestService(
     blockchain: BlockchainImpl,
     blockchainReader: BlockchainReader,
+    blockchainWriter: BlockchainWriter,
     stateStorage: StateStorage,
     evmCodeStorage: EvmCodeStorage,
     pendingTransactionsManager: ActorRef,
@@ -189,7 +191,8 @@ class TestService(
     // for example: bcMultiChainTest/ChainAtoChainB_BlockHash_Istanbul
 
     // load the new genesis
-    val genesisDataLoader = new GenesisDataLoader(blockchain, blockchainReader, stateStorage, currentConfig)
+    val genesisDataLoader =
+      new GenesisDataLoader(blockchainReader, blockchainWriter, stateStorage, currentConfig)
     genesisDataLoader.loadGenesisData(genesisData)
 
     //save account codes to world state

--- a/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
@@ -31,7 +31,7 @@ import io.iohk.ethereum.db.components.Storages.PruningModeComponent
 import io.iohk.ethereum.db.components._
 import io.iohk.ethereum.db.storage.AppStateStorage
 import io.iohk.ethereum.db.storage.pruning.PruningMode
-import io.iohk.ethereum.domain._
+import io.iohk.ethereum.domain.{BlockchainMetadata, _}
 import io.iohk.ethereum.jsonrpc.NetService.NetServiceConfig
 import io.iohk.ethereum.jsonrpc._
 import io.iohk.ethereum.jsonrpc.server.controllers.ApisBase
@@ -175,8 +175,14 @@ trait NodeStatusBuilder {
 trait BlockchainBuilder {
   self: StorageBuilder =>
 
+  lazy val blockchainMetadata: BlockchainMetadata =
+    new BlockchainMetadata(
+      storagesInstance.storages.appStateStorage.getBestBlockNumber(),
+      storagesInstance.storages.appStateStorage.getLatestCheckpointBlockNumber()
+    )
   lazy val blockchainReader: BlockchainReader = BlockchainReader(storagesInstance.storages)
-  lazy val blockchain: BlockchainImpl = BlockchainImpl(storagesInstance.storages, blockchainReader)
+  lazy val blockchainWriter: BlockchainWriter = BlockchainWriter(storagesInstance.storages)
+  lazy val blockchain: BlockchainImpl = BlockchainImpl(storagesInstance.storages, blockchainReader, blockchainMetadata)
 }
 
 trait BlockQueueBuilder {
@@ -786,6 +792,7 @@ trait SyncControllerBuilder {
       storagesInstance.storages.appStateStorage,
       blockchain,
       blockchainReader,
+      blockchainWriter,
       storagesInstance.storages.evmCodeStorage,
       storagesInstance.storages.nodeStorage,
       storagesInstance.storages.fastSyncStateStorage,

--- a/src/main/scala/io/iohk/ethereum/testmode/TestBlockchainBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/testmode/TestBlockchainBuilder.scala
@@ -18,7 +18,8 @@ trait TestBlockchainBuilder extends BlockchainBuilder {
       transactionMappingStorage = storages.transactionMappingStorage,
       appStateStorage = storages.appStateStorage,
       stateStorage = storages.stateStorage,
-      blockchainReader = blockchainReader
+      blockchainReader = blockchainReader,
+      blockchainMetadata = blockchainMetadata
     )
   }
 

--- a/src/main/scala/io/iohk/ethereum/testmode/TestModeBlockExecution.scala
+++ b/src/main/scala/io/iohk/ethereum/testmode/TestModeBlockExecution.scala
@@ -5,6 +5,7 @@ import io.iohk.ethereum.domain.Block
 import io.iohk.ethereum.domain.BlockHeader
 import io.iohk.ethereum.domain.BlockchainImpl
 import io.iohk.ethereum.domain.BlockchainReader
+import io.iohk.ethereum.domain.BlockchainWriter
 import io.iohk.ethereum.domain.UInt256
 import io.iohk.ethereum.ledger.BlockExecution
 import io.iohk.ethereum.ledger.BlockPreparator
@@ -16,6 +17,7 @@ import io.iohk.ethereum.vm.EvmConfig
 class TestModeBlockExecution(
     blockchain: BlockchainImpl,
     blockchainReader: BlockchainReader,
+    blockchainWriter: BlockchainWriter,
     evmCodeStorage: EvmCodeStorage,
     blockchainConfig: BlockchainConfig,
     blockPreparator: BlockPreparator,
@@ -24,6 +26,7 @@ class TestModeBlockExecution(
 ) extends BlockExecution(
       blockchain,
       blockchainReader,
+      blockchainWriter,
       evmCodeStorage,
       blockchainConfig,
       blockPreparator,

--- a/src/main/scala/io/iohk/ethereum/testmode/TestModeComponentsProvider.scala
+++ b/src/main/scala/io/iohk/ethereum/testmode/TestModeComponentsProvider.scala
@@ -10,6 +10,7 @@ import io.iohk.ethereum.crypto
 import io.iohk.ethereum.db.storage.EvmCodeStorage
 import io.iohk.ethereum.domain.BlockchainImpl
 import io.iohk.ethereum.domain.BlockchainReader
+import io.iohk.ethereum.domain.BlockchainWriter
 import io.iohk.ethereum.domain.UInt256
 import io.iohk.ethereum.ledger.BlockImport
 import io.iohk.ethereum.ledger.BlockQueue
@@ -23,6 +24,7 @@ import io.iohk.ethereum.utils.Config.SyncConfig
 class TestModeComponentsProvider(
     blockchain: BlockchainImpl,
     blockchainReader: BlockchainReader,
+    blockchainWriter: BlockchainWriter,
     evmCodeStorage: EvmCodeStorage,
     syncConfig: SyncConfig,
     validationExecutionContext: Scheduler,
@@ -41,13 +43,13 @@ class TestModeComponentsProvider(
       preimageCache: collection.concurrent.Map[ByteString, UInt256],
       sealEngine: SealEngineType
   ): BlockImport = {
-//    val blockQueue = BlockQueue(blockchain, syncConfig)
     val consensuz = consensus(blockchainConfig, sealEngine)
     val blockValidation = new BlockValidation(consensuz, blockchainReader, internalBlockQueue)
     val blockExecution =
       new TestModeBlockExecution(
         blockchain,
         blockchainReader,
+        blockchainWriter,
         evmCodeStorage,
         blockchainConfig,
         consensuz.blockPreparator,
@@ -58,6 +60,7 @@ class TestModeComponentsProvider(
     new BlockImport(
       blockchain,
       blockchainReader,
+      blockchainWriter,
       internalBlockQueue,
       blockValidation,
       blockExecution,
@@ -68,8 +71,6 @@ class TestModeComponentsProvider(
   /** Clear the internal builder state
     */
   def clearState(): Unit =
-//    blockQueue = BlockQueue(blockchain, syncConfig)
-//    cache = cache.empty
     internalBlockQueue.clear()
 
   def stxLedger(blockchainConfig: BlockchainConfig, sealEngine: SealEngineType): StxLedger =
@@ -80,6 +81,7 @@ class TestModeComponentsProvider(
       blockchainConfig,
       consensus(blockchainConfig, sealEngine).blockPreparator
     )
+
   def consensus(
       blockchainConfig: BlockchainConfig,
       sealEngine: SealEngineType,

--- a/src/main/scala/io/iohk/ethereum/testmode/TestModeServiceBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/testmode/TestModeServiceBuilder.scala
@@ -26,6 +26,7 @@ trait TestModeServiceBuilder extends StxLedgerBuilder {
     new TestModeComponentsProvider(
       blockchain,
       blockchainReader,
+      blockchainWriter,
       storagesInstance.storages.evmCodeStorage,
       syncConfig,
       scheduler,

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/BlockchainHostActorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/BlockchainHostActorSpec.scala
@@ -59,7 +59,7 @@ class BlockchainHostActorSpec extends AnyFlatSpec with Matchers {
     val receipts: Seq[Seq[Receipt]] = Seq(Seq(), Seq())
 
     blockchain
-      .storeReceipts(receiptsHashes(0), receipts(0))
+      .storeReceipts(receiptsHashes.head, receipts.head)
       .and(blockchain.storeReceipts(receiptsHashes(1), receipts(1)))
       .commit()
 
@@ -79,9 +79,9 @@ class BlockchainHostActorSpec extends AnyFlatSpec with Matchers {
 
     val blockBodies = Seq(baseBlockBody, baseBlockBody)
 
-    blockchain
+    blockchainWriter
       .storeBlockBody(blockBodiesHashes(0), blockBodies(0))
-      .and(blockchain.storeBlockBody(blockBodiesHashes(1), blockBodies(1)))
+      .and(blockchainWriter.storeBlockBody(blockBodiesHashes(1), blockBodies(1)))
       .commit()
 
     //when
@@ -96,11 +96,11 @@ class BlockchainHostActorSpec extends AnyFlatSpec with Matchers {
     val firstHeader: BlockHeader = baseBlockHeader.copy(number = 3)
     val secondHeader: BlockHeader = baseBlockHeader.copy(number = 4)
 
-    blockchain
+    blockchainWriter
       .storeBlockHeader(firstHeader)
-      .and(blockchain.storeBlockHeader(secondHeader))
-      .and(blockchain.storeBlockHeader(baseBlockHeader.copy(number = 5)))
-      .and(blockchain.storeBlockHeader(baseBlockHeader.copy(number = 6)))
+      .and(blockchainWriter.storeBlockHeader(secondHeader))
+      .and(blockchainWriter.storeBlockHeader(baseBlockHeader.copy(number = 5)))
+      .and(blockchainWriter.storeBlockHeader(baseBlockHeader.copy(number = 6)))
       .commit()
 
     //when
@@ -115,9 +115,9 @@ class BlockchainHostActorSpec extends AnyFlatSpec with Matchers {
     val firstHeader: BlockHeader = baseBlockHeader.copy(number = 3)
     val secondHeader: BlockHeader = baseBlockHeader.copy(number = 4)
 
-    blockchain
+    blockchainWriter
       .storeBlockHeader(firstHeader)
-      .and(blockchain.storeBlockHeader(secondHeader))
+      .and(blockchainWriter.storeBlockHeader(secondHeader))
       .commit()
 
     //when
@@ -132,10 +132,10 @@ class BlockchainHostActorSpec extends AnyFlatSpec with Matchers {
     val firstHeader: BlockHeader = baseBlockHeader.copy(number = 3)
     val secondHeader: BlockHeader = baseBlockHeader.copy(number = 2)
 
-    blockchain
+    blockchainWriter
       .storeBlockHeader(firstHeader)
-      .and(blockchain.storeBlockHeader(secondHeader))
-      .and(blockchain.storeBlockHeader(baseBlockHeader.copy(number = 1)))
+      .and(blockchainWriter.storeBlockHeader(secondHeader))
+      .and(blockchainWriter.storeBlockHeader(baseBlockHeader.copy(number = 1)))
       .commit()
 
     //when
@@ -150,11 +150,11 @@ class BlockchainHostActorSpec extends AnyFlatSpec with Matchers {
     val firstHeader: BlockHeader = baseBlockHeader.copy(number = 3)
     val secondHeader: BlockHeader = baseBlockHeader.copy(number = 4)
 
-    blockchain
+    blockchainWriter
       .storeBlockHeader(firstHeader)
-      .and(blockchain.storeBlockHeader(secondHeader))
-      .and(blockchain.storeBlockHeader(baseBlockHeader.copy(number = 5)))
-      .and(blockchain.storeBlockHeader(baseBlockHeader.copy(number = 6)))
+      .and(blockchainWriter.storeBlockHeader(secondHeader))
+      .and(blockchainWriter.storeBlockHeader(baseBlockHeader.copy(number = 5)))
+      .and(blockchainWriter.storeBlockHeader(baseBlockHeader.copy(number = 6)))
       .commit()
 
     //when
@@ -169,12 +169,12 @@ class BlockchainHostActorSpec extends AnyFlatSpec with Matchers {
     val firstHeader: BlockHeader = baseBlockHeader.copy(number = 3)
     val secondHeader: BlockHeader = baseBlockHeader.copy(number = 5)
 
-    blockchain
+    blockchainWriter
       .storeBlockHeader(firstHeader)
-      .and(blockchain.storeBlockHeader(baseBlockHeader.copy(number = 4)))
-      .and(blockchain.storeBlockHeader(secondHeader))
-      .and(blockchain.storeBlockHeader(baseBlockHeader.copy(number = 6)))
-      .and(blockchain.storeBlockHeader(baseBlockHeader.copy(number = 7)))
+      .and(blockchainWriter.storeBlockHeader(baseBlockHeader.copy(number = 4)))
+      .and(blockchainWriter.storeBlockHeader(secondHeader))
+      .and(blockchainWriter.storeBlockHeader(baseBlockHeader.copy(number = 6)))
+      .and(blockchainWriter.storeBlockHeader(baseBlockHeader.copy(number = 7)))
       .commit()
 
     //when
@@ -192,9 +192,9 @@ class BlockchainHostActorSpec extends AnyFlatSpec with Matchers {
     val firstHeader: BlockHeader = baseBlockHeader.copy(number = 3)
     val secondHeader: BlockHeader = baseBlockHeader.copy(number = 1)
 
-    blockchain
+    blockchainWriter
       .storeBlockHeader(firstHeader)
-      .and(blockchain.storeBlockHeader(secondHeader))
+      .and(blockchainWriter.storeBlockHeader(secondHeader))
       .commit()
 
     //when
@@ -209,9 +209,9 @@ class BlockchainHostActorSpec extends AnyFlatSpec with Matchers {
     val firstHeader: BlockHeader = baseBlockHeader.copy(number = 3)
     val secondHeader: BlockHeader = baseBlockHeader.copy(number = 1)
 
-    blockchain
+    blockchainWriter
       .storeBlockHeader(firstHeader)
-      .and(blockchain.storeBlockHeader(secondHeader))
+      .and(blockchainWriter.storeBlockHeader(secondHeader))
       .commit()
 
     //when
@@ -226,9 +226,9 @@ class BlockchainHostActorSpec extends AnyFlatSpec with Matchers {
     val firstHeader: BlockHeader = baseBlockHeader.copy(number = 4)
     val secondHeader: BlockHeader = baseBlockHeader.copy(number = 2)
 
-    blockchain
+    blockchainWriter
       .storeBlockHeader(firstHeader)
-      .and(blockchain.storeBlockHeader(secondHeader))
+      .and(blockchainWriter.storeBlockHeader(secondHeader))
       .commit()
 
     //when
@@ -276,7 +276,7 @@ class BlockchainHostActorSpec extends AnyFlatSpec with Matchers {
   trait TestSetup extends EphemBlockchainTestSetup {
     implicit override lazy val system: ActorSystem = ActorSystem("BlockchainHostActor_System")
 
-    blockchain.storeBlockHeader(Fixtures.Blocks.Genesis.header).commit()
+    blockchainWriter.storeBlockHeader(Fixtures.Blocks.Genesis.header).commit()
 
     val peerConf: PeerConfiguration = new PeerConfiguration {
       override val fastSyncHostConfiguration: FastSyncHostConfiguration = new FastSyncHostConfiguration {

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/BlockchainHostActorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/BlockchainHostActorSpec.scala
@@ -58,9 +58,9 @@ class BlockchainHostActorSpec extends AnyFlatSpec with Matchers {
 
     val receipts: Seq[Seq[Receipt]] = Seq(Seq(), Seq())
 
-    blockchain
+    blockchainWriter
       .storeReceipts(receiptsHashes.head, receipts.head)
-      .and(blockchain.storeReceipts(receiptsHashes(1), receipts(1)))
+      .and(blockchainWriter.storeReceipts(receiptsHashes(1), receipts(1)))
       .commit()
 
     //when

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/FastSyncSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/FastSyncSpec.scala
@@ -93,7 +93,12 @@ class FastSyncSpec
     )
 
     val saveGenesis: Task[Unit] = Task {
-      blockchain.save(BlockHelpers.genesis, receipts = Nil, ChainWeight.totalDifficultyOnly(1), saveAsBestBlock = true)
+      blockchainWriter.save(
+        BlockHelpers.genesis,
+        receipts = Nil,
+        ChainWeight.totalDifficultyOnly(1),
+        saveAsBestBlock = true
+      )
     }
 
     val startSync: Task[Unit] = Task(fastSync ! SyncProtocol.Start)

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/FastSyncSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/FastSyncSpec.scala
@@ -80,6 +80,7 @@ class FastSyncSpec
         appStateStorage = storagesInstance.storages.appStateStorage,
         blockchain = blockchain,
         blockchainReader = blockchainReader,
+        blockchainWriter = blockchainWriter,
         evmCodeStorage = storagesInstance.storages.evmCodeStorage,
         nodeStorage = storagesInstance.storages.nodeStorage,
         validators = validators,

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/ScenarioSetup.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/ScenarioSetup.scala
@@ -82,12 +82,14 @@ trait ScenarioSetup extends StdTestConsensusBuilder with StxLedgerBuilder {
     new BlockImport(
       blockchain,
       blockchainReader,
+      blockchainWriter,
       blockQueue,
       blockValidation,
       blockExecutionOpt.getOrElse(
         new BlockExecution(
           blockchain,
           blockchainReader,
+          blockchainWriter,
           storagesInstance.storages.evmCodeStorage,
           blockchainConfig,
           consensuz.blockPreparator,

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/SchedulerStateSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/SchedulerStateSpec.scala
@@ -21,7 +21,7 @@ class SchedulerStateSpec extends AnyFlatSpec with Matchers {
     assert(stateWithRequests != schedulerState)
     val (allMissingElements, newState) = stateWithRequests.getAllMissingHashes
     assert(allMissingElements == reqestsInDepthOrder.map(_.nodeHash))
-    val (allMissingElements1, newState1) = newState.getAllMissingHashes
+    val (allMissingElements1, _) = newState.getAllMissingHashes
     assert(allMissingElements1.isEmpty)
   }
 
@@ -30,7 +30,7 @@ class SchedulerStateSpec extends AnyFlatSpec with Matchers {
     assert(stateWithRequests != schedulerState)
     val (twoMissingElements, newState) = stateWithRequests.getMissingHashes(2)
     assert(twoMissingElements == reqestsInDepthOrder.take(2).map(_.nodeHash))
-    val (allMissingElements1, newState1) = newState.getAllMissingHashes
+    val (allMissingElements1, _) = newState.getAllMissingHashes
     assert(allMissingElements1.size == 2)
   }
 

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/StateSyncSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/StateSyncSpec.scala
@@ -2,6 +2,7 @@ package io.iohk.ethereum.blockchain.sync
 
 import java.net.InetSocketAddress
 import java.util.concurrent.ThreadLocalRandom
+
 import akka.actor.ActorRef
 import akka.actor.ActorSystem
 import akka.testkit.TestActor.AutoPilot
@@ -11,11 +12,13 @@ import akka.util.ByteString
 
 import scala.concurrent.duration._
 import scala.util.Random
+
 import org.scalactic.anyvals.PosInt
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+
 import io.iohk.ethereum.Fixtures
 import io.iohk.ethereum.ObjectGenerators
 import io.iohk.ethereum.WithActorSystemShutDown
@@ -28,7 +31,11 @@ import io.iohk.ethereum.blockchain.sync.fast.SyncStateSchedulerActor.StartSyncin
 import io.iohk.ethereum.blockchain.sync.fast.SyncStateSchedulerActor.StateSyncFinished
 import io.iohk.ethereum.blockchain.sync.fast.SyncStateSchedulerActor.StateSyncStats
 import io.iohk.ethereum.blockchain.sync.fast.SyncStateSchedulerActor.WaitingForNewTargetBlock
-import io.iohk.ethereum.domain.{Address, BlockchainImpl, BlockchainMetadata, BlockchainReader, ChainWeight}
+import io.iohk.ethereum.domain.Address
+import io.iohk.ethereum.domain.BlockchainImpl
+import io.iohk.ethereum.domain.BlockchainMetadata
+import io.iohk.ethereum.domain.BlockchainReader
+import io.iohk.ethereum.domain.ChainWeight
 import io.iohk.ethereum.network.EtcPeerManagerActor._
 import io.iohk.ethereum.network.Peer
 import io.iohk.ethereum.network.PeerEventBusActor.PeerEvent.MessageFromPeer

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/StateSyncUtils.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/StateSyncUtils.scala
@@ -1,9 +1,15 @@
 package io.iohk.ethereum.blockchain.sync
 
 import akka.util.ByteString
+
 import io.iohk.ethereum.blockchain.sync.fast.SyncStateScheduler.SyncResponse
 import io.iohk.ethereum.db.storage.EvmCodeStorage
-import io.iohk.ethereum.domain.{Account, Address, Blockchain, BlockchainImpl, BlockchainMetadata, BlockchainReader}
+import io.iohk.ethereum.domain.Account
+import io.iohk.ethereum.domain.Address
+import io.iohk.ethereum.domain.Blockchain
+import io.iohk.ethereum.domain.BlockchainImpl
+import io.iohk.ethereum.domain.BlockchainMetadata
+import io.iohk.ethereum.domain.BlockchainReader
 import io.iohk.ethereum.ledger.InMemoryWorldStateProxy
 import io.iohk.ethereum.mpt.MerklePatriciaTrie
 import io.iohk.ethereum.utils.BlockchainConfig

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/StateSyncUtils.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/StateSyncUtils.scala
@@ -1,14 +1,9 @@
 package io.iohk.ethereum.blockchain.sync
 
 import akka.util.ByteString
-
 import io.iohk.ethereum.blockchain.sync.fast.SyncStateScheduler.SyncResponse
 import io.iohk.ethereum.db.storage.EvmCodeStorage
-import io.iohk.ethereum.domain.Account
-import io.iohk.ethereum.domain.Address
-import io.iohk.ethereum.domain.Blockchain
-import io.iohk.ethereum.domain.BlockchainImpl
-import io.iohk.ethereum.domain.BlockchainReader
+import io.iohk.ethereum.domain.{Account, Address, Blockchain, BlockchainImpl, BlockchainMetadata, BlockchainReader}
 import io.iohk.ethereum.ledger.InMemoryWorldStateProxy
 import io.iohk.ethereum.mpt.MerklePatriciaTrie
 import io.iohk.ethereum.utils.BlockchainConfig
@@ -77,9 +72,13 @@ object StateSyncUtils extends EphemBlockchainTestSetup {
   object TrieProvider {
     def apply(): TrieProvider = {
       val freshStorage = getNewStorages
+      val blockchainMetadata = new BlockchainMetadata(
+        freshStorage.storages.appStateStorage.getBestBlockNumber(),
+        freshStorage.storages.appStateStorage.getLatestCheckpointBlockNumber()
+      )
       val blockchainReader = BlockchainReader(freshStorage.storages)
       new TrieProvider(
-        BlockchainImpl(freshStorage.storages, blockchainReader),
+        BlockchainImpl(freshStorage.storages, blockchainReader, blockchainMetadata),
         blockchainReader,
         freshStorage.storages.evmCodeStorage,
         blockchainConfig

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/SyncControllerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/SyncControllerSpec.scala
@@ -544,6 +544,7 @@ class SyncControllerSpec
           storagesInstance.storages.appStateStorage,
           blockchain,
           blockchainReader,
+          blockchainWriter,
           storagesInstance.storages.evmCodeStorage,
           storagesInstance.storages.nodeStorage,
           storagesInstance.storages.fastSyncStateStorage,

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/SyncControllerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/SyncControllerSpec.scala
@@ -564,7 +564,7 @@ class SyncControllerSpec
     val EmptyTrieRootHash: ByteString = Account.EmptyStorageRootHash
     val baseBlockHeader = Fixtures.Blocks.Genesis.header
 
-    blockchain.storeChainWeight(baseBlockHeader.parentHash, ChainWeight.zero).commit()
+    blockchainWriter.storeChainWeight(baseBlockHeader.parentHash, ChainWeight.zero).commit()
 
     case class BlockchainData(
         headers: Map[BigInt, BlockHeader],

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/SyncStateSchedulerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/SyncStateSchedulerSpec.scala
@@ -1,6 +1,7 @@
 package io.iohk.ethereum.blockchain.sync
 
 import akka.util.ByteString
+
 import org.scalactic.anyvals.PosInt
 import org.scalatest.EitherValues
 import org.scalatest.flatspec.AnyFlatSpec
@@ -22,7 +23,9 @@ import io.iohk.ethereum.db.components.EphemDataSourceComponent
 import io.iohk.ethereum.db.components.Storages
 import io.iohk.ethereum.domain.Address
 import io.iohk.ethereum.domain.BlockchainImpl
+import io.iohk.ethereum.domain.BlockchainMetadata
 import io.iohk.ethereum.domain.BlockchainReader
+import io.iohk.ethereum.domain.BlockchainWriter
 import io.iohk.ethereum.vm.Generators.genMultipleNodeData
 
 class SyncStateSchedulerSpec
@@ -188,7 +191,7 @@ class SyncStateSchedulerSpec
     )
     val (syncStateScheduler, _, _, _) = buildScheduler()
     val initState = syncStateScheduler.initState(worldHash).get
-    val (firstMissing, state1) = syncStateScheduler.getMissingNodes(initState, 1)
+    val (_, state1) = syncStateScheduler.getMissingNodes(initState, 1)
     val result1 = syncStateScheduler.processResponse(state1, SyncResponse(ByteString(1), ByteString(2)))
     assert(result1.isLeft)
     assert(result1.left.value == NotRequestedItem)
@@ -305,8 +308,8 @@ class SyncStateSchedulerSpec
         freshStorage.storages.appStateStorage.getLatestCheckpointBlockNumber()
       )
       val freshBlockchainReader = BlockchainReader(freshStorage.storages)
-      val freshBlockchain = BlockchainImpl(freshStorage.storages, freshBlockchainReader, blockchainMetadata)
-      val freshBlockchainWriter = BlockchainWriter(freshStorage.storages, blockchainMetadata)
+      val freshBlockchain = BlockchainImpl(freshStorage.storages, freshBlockchainReader, freshBlockchainMetadata)
+      val freshBlockchainWriter = BlockchainWriter(freshStorage.storages, freshBlockchainMetadata)
       (
         SyncStateScheduler(
           freshBlockchain,

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/SyncStateSchedulerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/SyncStateSchedulerSpec.scala
@@ -1,7 +1,6 @@
 package io.iohk.ethereum.blockchain.sync
 
 import akka.util.ByteString
-
 import org.scalactic.anyvals.PosInt
 import org.scalatest.EitherValues
 import org.scalatest.flatspec.AnyFlatSpec
@@ -35,7 +34,7 @@ class SyncStateSchedulerSpec
   "SyncStateScheduler" should "sync with mptTrie with one account (1 leaf node)" in new TestSetup {
     val prov = getTrieProvider
     val worldHash = prov.buildWorld(Seq(MptNodeData(Address(1), None, Seq(), 20)))
-    val (syncStateScheduler, _, schedulerDb) = buildScheduler()
+    val (syncStateScheduler, _, _, schedulerDb) = buildScheduler()
     val initialState = syncStateScheduler.initState(worldHash).get
     val (missingNodes, newState) = syncStateScheduler.getMissingNodes(initialState, 1)
     val responses = prov.getNodes(missingNodes)
@@ -56,7 +55,7 @@ class SyncStateSchedulerSpec
     val worldHash = prov.buildWorld(
       Seq(MptNodeData(Address(1), Some(ByteString(1, 2, 3)), Seq((1, 1)), 20))
     )
-    val (syncStateScheduler, schedulerBlockchain, schedulerDb) = buildScheduler()
+    val (syncStateScheduler, _, _, schedulerDb) = buildScheduler()
     val initState = syncStateScheduler.initState(worldHash).get
     val state1 = exchangeSingleNode(initState, syncStateScheduler, prov).value
     val state2 = exchangeSingleNode(state1, syncStateScheduler, prov).value
@@ -79,7 +78,7 @@ class SyncStateSchedulerSpec
         MptNodeData(Address(2), Some(ByteString(1, 2, 3)), Seq((1, 1)), 20)
       )
     )
-    val (syncStateScheduler, schedulerBlockchain, schedulerDb) = buildScheduler()
+    val (syncStateScheduler, _, _, _) = buildScheduler()
     val initState = syncStateScheduler.initState(worldHash).get
     val stateAfterExchange = exchangeAllNodes(initState, syncStateScheduler, prov)
     assert(stateAfterExchange.numberOfPendingRequests == 0)
@@ -111,7 +110,7 @@ class SyncStateSchedulerSpec
         MptNodeData(Address(2), Some(ByteString(1, 2, 3, 4)), Seq((2, 2)), 20)
       )
     )
-    val (syncStateScheduler, schedulerBlockchain, schedulerDb) = buildScheduler()
+    val (syncStateScheduler, _, _, schedulerDb) = buildScheduler()
     val initState = syncStateScheduler.initState(worldHash).get
     assert(schedulerDb.dataSource.storage.isEmpty)
     val state1 = exchangeSingleNode(initState, syncStateScheduler, prov).value
@@ -155,7 +154,7 @@ class SyncStateSchedulerSpec
         MptNodeData(Address(2), Some(ByteString(1, 2, 3)), Seq((1, 1)), 20)
       )
     )
-    val (syncStateScheduler, schedulerBlockchain, schedulerDb) = buildScheduler()
+    val (syncStateScheduler, _, _, schedulerDb) = buildScheduler()
     val initState = syncStateScheduler.initState(worldHash).get
     val state1 = exchangeSingleNode(initState, syncStateScheduler, prov).value
     val (allMissingNodes1, state2) = syncStateScheduler.getAllMissingNodes(state1)
@@ -187,7 +186,7 @@ class SyncStateSchedulerSpec
         MptNodeData(Address(2), Some(ByteString(1, 2, 3)), Seq((1, 1)), 20)
       )
     )
-    val (syncStateScheduler, schedulerBlockchain, schedulerDb) = buildScheduler()
+    val (syncStateScheduler, _, _, _) = buildScheduler()
     val initState = syncStateScheduler.initState(worldHash).get
     val (firstMissing, state1) = syncStateScheduler.getMissingNodes(initState, 1)
     val result1 = syncStateScheduler.processResponse(state1, SyncResponse(ByteString(1), ByteString(2)))
@@ -204,7 +203,7 @@ class SyncStateSchedulerSpec
         MptNodeData(Address(2), Some(ByteString(1, 2, 3)), Seq((1, 1)), 20)
       )
     )
-    val (syncStateScheduler, schedulerBlockchain, schedulerDb) = buildScheduler()
+    val (syncStateScheduler, _, _, _) = buildScheduler()
     val initState = syncStateScheduler.initState(worldHash).get
     val (firstMissing, state1) = syncStateScheduler.getMissingNodes(initState, 1)
     val firstMissingResponse = prov.getNodes(firstMissing)
@@ -226,7 +225,7 @@ class SyncStateSchedulerSpec
         MptNodeData(Address(2), Some(ByteString(1, 2, 3)), Seq((1, 1)), 20)
       )
     )
-    val (syncStateScheduler, schedulerBlockchain, schedulerDb) = buildScheduler()
+    val (syncStateScheduler, _, _, _) = buildScheduler()
     val initState = syncStateScheduler.initState(worldHash).get
     val (firstMissing, state1) = syncStateScheduler.getMissingNodes(initState, 1)
     val firstMissingResponse = prov.getNodes(firstMissing)
@@ -247,9 +246,9 @@ class SyncStateSchedulerSpec
     forAll(nodeDataGen) { nodeData =>
       val prov = getTrieProvider
       val worldHash = prov.buildWorld(nodeData)
-      val (scheduler, schedulerBlockchain, allStorages) = buildScheduler()
+      val (scheduler, schedulerBlockchain, schedulerBlockchainWriter, allStorages) = buildScheduler()
       val header = Fixtures.Blocks.ValidBlock.header.copy(stateRoot = worldHash, number = 1)
-      schedulerBlockchain.storeBlockHeader(header).commit()
+      schedulerBlockchainWriter.storeBlockHeader(header).commit()
       var state = scheduler.initState(worldHash).get
       while (state.activeRequest.nonEmpty) {
         val (allMissingNodes1, state2) = scheduler.getAllMissingNodes(state)
@@ -269,8 +268,12 @@ class SyncStateSchedulerSpec
   trait TestSetup extends EphemBlockchainTestSetup {
     def getTrieProvider: TrieProvider = {
       val freshStorage = getNewStorages
+      val freshBlockchainMetadata = new BlockchainMetadata(
+        freshStorage.storages.appStateStorage.getBestBlockNumber(),
+        freshStorage.storages.appStateStorage.getLatestCheckpointBlockNumber()
+      )
       val freshBlockchainReader = BlockchainReader(freshStorage.storages)
-      val freshBlockchain = BlockchainImpl(freshStorage.storages, freshBlockchainReader)
+      val freshBlockchain = BlockchainImpl(freshStorage.storages, freshBlockchainReader, freshBlockchainMetadata)
       new TrieProvider(freshBlockchain, freshBlockchainReader, freshStorage.storages.evmCodeStorage, blockchainConfig)
     }
     val bloomFilterSize = 1000
@@ -293,11 +296,17 @@ class SyncStateSchedulerSpec
     def buildScheduler(): (
         SyncStateScheduler,
         BlockchainImpl,
+        BlockchainWriter,
         EphemDataSourceComponent with LocalPruningConfigBuilder with Storages.DefaultStorages
     ) = {
       val freshStorage = getNewStorages
+      val freshBlockchainMetadata = new BlockchainMetadata(
+        freshStorage.storages.appStateStorage.getBestBlockNumber(),
+        freshStorage.storages.appStateStorage.getLatestCheckpointBlockNumber()
+      )
       val freshBlockchainReader = BlockchainReader(freshStorage.storages)
-      val freshBlockchain = BlockchainImpl(freshStorage.storages, freshBlockchainReader)
+      val freshBlockchain = BlockchainImpl(freshStorage.storages, freshBlockchainReader, blockchainMetadata)
+      val freshBlockchainWriter = BlockchainWriter(freshStorage.storages, blockchainMetadata)
       (
         SyncStateScheduler(
           freshBlockchain,
@@ -307,6 +316,7 @@ class SyncStateSchedulerSpec
           bloomFilterSize
         ),
         freshBlockchain,
+        freshBlockchainWriter,
         freshStorage
       )
     }

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/fast/FastSyncBranchResolverActorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/fast/FastSyncBranchResolverActorSpec.scala
@@ -283,7 +283,9 @@ class FastSyncBranchResolverActorSpec
       (0 to 5).toList.map((peerId _).andThen(getPeer)).fproduct(getPeerInfo(_)).toMap
 
     def saveBlocks(blocks: List[Block]): Unit =
-      blocks.foreach(block => blockchain.save(block, Nil, ChainWeight.totalDifficultyOnly(1), saveAsBestBlock = true))
+      blocks.foreach(block =>
+        blockchainWriter.save(block, Nil, ChainWeight.totalDifficultyOnly(1), saveAsBestBlock = true)
+      )
 
     def createEtcPeerManager(peers: Map[Peer, PeerInfo], blocks: Map[Int, List[Block]])(implicit
         scheduler: Scheduler

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/regular/RegularSyncFixtures.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/regular/RegularSyncFixtures.scala
@@ -101,7 +101,7 @@ trait RegularSyncFixtures { self: Matchers with AsyncMockFactory =>
 
     override lazy val blockImport: BlockImport = new TestBlockImport()
 
-    blockchain.save(
+    blockchainWriter.save(
       block = BlockHelpers.genesis,
       receipts = Nil,
       weight = ChainWeight.totalDifficultyOnly(10000),
@@ -193,6 +193,7 @@ trait RegularSyncFixtures { self: Matchers with AsyncMockFactory =>
         extends BlockImport(
           stub[BlockchainImpl],
           stub[BlockchainReader],
+          stub[BlockchainWriter],
           stub[BlockQueue],
           stub[BlockValidation],
           stub[BlockExecution],

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/regular/RegularSyncSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/regular/RegularSyncSpec.scala
@@ -779,7 +779,7 @@ class RegularSyncSpec
           _ <- testBlocks
             .take(5)
             .traverse(block =>
-              Task(blockchain.save(block, Nil, ChainWeight.totalDifficultyOnly(10000), saveAsBestBlock = true))
+              Task(blockchainWriter.save(block, Nil, ChainWeight.totalDifficultyOnly(10000), saveAsBestBlock = true))
             )
           _ <- Task {
             regularSync ! SyncProtocol.Start

--- a/src/test/scala/io/iohk/ethereum/consensus/blocks/BlockGeneratorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/blocks/BlockGeneratorSpec.scala
@@ -254,6 +254,7 @@ class BlockGeneratorSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
       new BlockExecution(
         blockchain,
         blockchainReader,
+        blockchainWriter,
         storagesInstance.storages.evmCodeStorage,
         blockchainConfig,
         consensus.blockPreparator,
@@ -337,6 +338,7 @@ class BlockGeneratorSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
       new BlockExecution(
         blockchain,
         blockchainReader,
+        blockchainWriter,
         storagesInstance.storages.evmCodeStorage,
         blockchainConfig,
         consensus.blockPreparator,
@@ -715,7 +717,12 @@ class BlockGeneratorSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
     override lazy val blockchainConfig = baseBlockchainConfig
 
     val genesisDataLoader =
-      new GenesisDataLoader(blockchain, blockchainReader, storagesInstance.storages.stateStorage, blockchainConfig)
+      new GenesisDataLoader(
+        blockchainReader,
+        blockchainWriter,
+        storagesInstance.storages.stateStorage,
+        blockchainConfig
+      )
     genesisDataLoader.loadGenesisData()
 
     val bestBlock: Option[Block] = blockchain.getBestBlock()
@@ -739,6 +746,7 @@ class BlockGeneratorSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
       new BlockExecution(
         blockchain,
         blockchainReader,
+        blockchainWriter,
         storagesInstance.storages.evmCodeStorage,
         blockchainConfig,
         consensus.blockPreparator,

--- a/src/test/scala/io/iohk/ethereum/consensus/pow/PoWMiningCoordinatorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/pow/PoWMiningCoordinatorSpec.scala
@@ -87,7 +87,7 @@ class PoWMiningCoordinatorSpec extends ScalaTestWithActorTestKit with AnyFreeSpe
 
         LoggingTestKit
           .debug("Mining with Keccak")
-          .withCustom { case msg: LoggingEvent =>
+          .withCustom { _: LoggingEvent =>
             coordinator ! StopMining
             true
           }

--- a/src/test/scala/io/iohk/ethereum/consensus/pow/validators/EthashBlockHeaderValidatorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/pow/validators/EthashBlockHeaderValidatorSpec.scala
@@ -173,9 +173,9 @@ class EthashBlockHeaderValidatorSpec
   }
 
   it should "validate correctly a block whose parent is in storage" in new EphemBlockchainTestSetup {
-    blockchain
+    blockchainWriter
       .storeBlockHeader(validParentBlockHeader)
-      .and(blockchain.storeBlockBody(validParentBlockHeader.hash, validParentBlockBody))
+      .and(blockchainWriter.storeBlockBody(validParentBlockHeader.hash, validParentBlockBody))
       .commit()
     powBlockHeaderValidator.validate(validBlockHeader, blockchainReader.getBlockHeaderByHash _) match {
       case Right(_) => succeed

--- a/src/test/scala/io/iohk/ethereum/consensus/pow/validators/StdOmmersValidatorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/pow/validators/StdOmmersValidatorSpec.scala
@@ -452,15 +452,15 @@ class StdOmmersValidatorSpec extends AnyFlatSpec with Matchers with ScalaCheckPr
 
     val ommersBlockParentHash: ByteString = block96.header.hash
 
-    blockchain
+    blockchainWriter
       .storeBlock(block89)
-      .and(blockchain.storeBlock(block90))
-      .and(blockchain.storeBlock(block91))
-      .and(blockchain.storeBlock(block92))
-      .and(blockchain.storeBlock(block93))
-      .and(blockchain.storeBlock(block94))
-      .and(blockchain.storeBlock(block95))
-      .and(blockchain.storeBlock(block96))
+      .and(blockchainWriter.storeBlock(block90))
+      .and(blockchainWriter.storeBlock(block91))
+      .and(blockchainWriter.storeBlock(block92))
+      .and(blockchainWriter.storeBlock(block93))
+      .and(blockchainWriter.storeBlock(block94))
+      .and(blockchainWriter.storeBlock(block95))
+      .and(blockchainWriter.storeBlock(block96))
       .commit()
 
   }

--- a/src/test/scala/io/iohk/ethereum/domain/BlockchainSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/domain/BlockchainSpec.scala
@@ -29,7 +29,7 @@ class BlockchainSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyCh
 
   "Blockchain" should "be able to store a block and return it if queried by hash" in new EphemBlockchainTestSetup {
     val validBlock = Fixtures.Blocks.ValidBlock.block
-    blockchain.storeBlock(validBlock).commit()
+    blockchainWriter.storeBlock(validBlock).commit()
     val block = blockchainReader.getBlockByHash(validBlock.header.hash)
     block.isDefined should ===(true)
     validBlock should ===(block.get)
@@ -43,7 +43,7 @@ class BlockchainSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyCh
 
   it should "be able to store a block and retrieve it by number" in new EphemBlockchainTestSetup {
     val validBlock = Fixtures.Blocks.ValidBlock.block
-    blockchain.storeBlock(validBlock).commit()
+    blockchainWriter.storeBlock(validBlock).commit()
     val block = blockchainReader.getBlockByNumber(validBlock.header.number)
     block.isDefined should ===(true)
     validBlock should ===(block.get)
@@ -60,7 +60,7 @@ class BlockchainSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyCh
 
   it should "be able to query a stored blockHeader by it's number" in new EphemBlockchainTestSetup {
     val validHeader = Fixtures.Blocks.ValidBlock.header
-    blockchain.storeBlockHeader(validHeader).commit()
+    blockchainWriter.storeBlockHeader(validHeader).commit()
     val header = blockchainReader.getBlockHeaderByNumber(validHeader.number)
     header.isDefined should ===(true)
     validHeader should ===(header.get)
@@ -73,7 +73,7 @@ class BlockchainSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyCh
 
   it should "be able to store a block with checkpoint and retrieve it and checkpoint" in new EphemBlockchainTestSetup {
     val parent = Fixtures.Blocks.Genesis.block
-    blockchain.storeBlock(parent)
+    blockchainWriter.storeBlock(parent)
 
     val validBlock = new CheckpointBlockGenerator().generate(parent, checkpoint)
 
@@ -89,7 +89,7 @@ class BlockchainSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyCh
 
   it should "be able to rollback block with checkpoint and store the previous existed checkpoint" in new EphemBlockchainTestSetup {
     val genesis = Fixtures.Blocks.Genesis.block
-    blockchain.storeBlock(genesis)
+    blockchainWriter.storeBlock(genesis)
 
     def nextBlock(parent: Block, body: BlockBody = BlockBody.empty): Block =
       Block(
@@ -117,7 +117,7 @@ class BlockchainSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyCh
 
   it should "be able to rollback block with last checkpoint in the chain" in new EphemBlockchainTestSetup {
     val genesis = Fixtures.Blocks.Genesis.block
-    blockchain.storeBlock(genesis)
+    blockchainWriter.storeBlock(genesis)
 
     val validBlock = checkpointBlockGenerator.generate(genesis, checkpoint)
 
@@ -142,7 +142,7 @@ class BlockchainSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyCh
     val mptWithAcc = emptyMpt.put(address, account)
     val headerWithAcc = validHeader.copy(stateRoot = ByteString(mptWithAcc.getRootHash))
 
-    blockchain.storeBlockHeader(headerWithAcc).commit()
+    blockchainWriter.storeBlockHeader(headerWithAcc).commit()
 
     val retrievedAccount = blockchain.getAccount(address, headerWithAcc.number)
     retrievedAccount shouldEqual Some(account)
@@ -161,7 +161,7 @@ class BlockchainSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyCh
 
     val headerWithAcc = validHeader.copy(stateRoot = ByteString(mptWithAcc.getRootHash))
 
-    blockchain.storeBlockHeader(headerWithAcc).commit()
+    blockchainWriter.storeBlockHeader(headerWithAcc).commit()
 
     //unhappy path
     val wrongAddress = Address(666)
@@ -187,7 +187,7 @@ class BlockchainSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyCh
 
     val headerWithAcc = Fixtures.Blocks.ValidBlock.header.copy(stateRoot = ByteString(mptWithAcc.getRootHash))
 
-    blockchain.storeBlockHeader(headerWithAcc).commit()
+    blockchainWriter.storeBlockHeader(headerWithAcc).commit()
 
     val wrongAddress = Address(666)
     val retrievedAccountProofWrong = blockchain.getAccountProof(wrongAddress, headerWithAcc.number)
@@ -281,6 +281,7 @@ class BlockchainSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyCh
       def stubStateStorage: StateStorage
       def blockchainStoragesWithStubPersisting: BlockchainStorages
       def blockchainReaderWithStubPersisting: BlockchainReader
+      def blockchainWriterWithStubPersisting: BlockchainWriter
       def blockchainWithStubPersisting: BlockchainImpl
     }
 
@@ -295,16 +296,20 @@ class BlockchainSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyCh
           val evmCodeStorage = storagesInstance.storages.evmCodeStorage
           val chainWeightStorage = storagesInstance.storages.chainWeightStorage
           val transactionMappingStorage = storagesInstance.storages.transactionMappingStorage
-          storagesInstance.storages.nodeStorage
-          storagesInstance.storages.pruningMode
           val appStateStorage = storagesInstance.storages.appStateStorage
           val stateStorage = stubStateStorage
         }
+        override lazy val blockchainMetadata = new BlockchainMetadata(
+          blockchainStoragesWithStubPersisting.appStateStorage.getBestBlockNumber(),
+          blockchainStoragesWithStubPersisting.appStateStorage.getLatestCheckpointBlockNumber()
+        )
         override val blockchainReaderWithStubPersisting = BlockchainReader(blockchainStoragesWithStubPersisting)
+        override val blockchainWriterWithStubPersisting =
+          BlockchainWriter(blockchainStoragesWithStubPersisting, blockchainMetadata)
         override val blockchainWithStubPersisting =
-          BlockchainImpl(blockchainStoragesWithStubPersisting, blockchainReaderWithStubPersisting)
+          BlockchainImpl(blockchainStoragesWithStubPersisting, blockchainReaderWithStubPersisting, blockchainMetadata)
 
-        blockchainWithStubPersisting.storeBlock(Fixtures.Blocks.Genesis.block)
+        blockchainWriterWithStubPersisting.storeBlock(Fixtures.Blocks.Genesis.block)
       }
 
   }

--- a/src/test/scala/io/iohk/ethereum/domain/BlockchainSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/domain/BlockchainSpec.scala
@@ -51,7 +51,7 @@ class BlockchainSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyCh
 
   it should "be able to do strict check of block existence in the chain" in new EphemBlockchainTestSetup {
     val validBlock = Fixtures.Blocks.ValidBlock.block
-    blockchain.save(validBlock, Seq.empty, ChainWeight(100, 100), saveAsBestBlock = true)
+    blockchainWriter.save(validBlock, Seq.empty, ChainWeight(100, 100), saveAsBestBlock = true)
     blockchain.isInChain(validBlock.hash) === false
     // simulation of node restart
     blockchain.saveBestKnownBlocks(validBlock.header.number - 1)
@@ -77,7 +77,7 @@ class BlockchainSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyCh
 
     val validBlock = new CheckpointBlockGenerator().generate(parent, checkpoint)
 
-    blockchain.save(validBlock, Seq.empty, ChainWeight(0, 0), saveAsBestBlock = true)
+    blockchainWriter.save(validBlock, Seq.empty, ChainWeight(0, 0), saveAsBestBlock = true)
 
     val retrievedBlock = blockchainReader.getBlockByHash(validBlock.header.hash)
     retrievedBlock.isDefined should ===(true)
@@ -105,9 +105,9 @@ class BlockchainSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyCh
     val secondBlock = nextBlock(firstBlock)
     val thirdBlock = checkpointBlockGenerator.generate(secondBlock, checkpoint)
 
-    blockchain.save(firstBlock, Seq.empty, ChainWeight(0, 0), saveAsBestBlock = true)
-    blockchain.save(secondBlock, Seq.empty, ChainWeight(0, 0), saveAsBestBlock = true)
-    blockchain.save(thirdBlock, Seq.empty, ChainWeight(0, 0), saveAsBestBlock = true)
+    blockchainWriter.save(firstBlock, Seq.empty, ChainWeight(0, 0), saveAsBestBlock = true)
+    blockchainWriter.save(secondBlock, Seq.empty, ChainWeight(0, 0), saveAsBestBlock = true)
+    blockchainWriter.save(thirdBlock, Seq.empty, ChainWeight(0, 0), saveAsBestBlock = true)
 
     blockchain.removeBlock(thirdBlock.hash, withState = true)
 
@@ -121,7 +121,7 @@ class BlockchainSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyCh
 
     val validBlock = checkpointBlockGenerator.generate(genesis, checkpoint)
 
-    blockchain.save(validBlock, Seq.empty, ChainWeight(0, 0), saveAsBestBlock = true)
+    blockchainWriter.save(validBlock, Seq.empty, ChainWeight(0, 0), saveAsBestBlock = true)
 
     blockchain.removeBlock(validBlock.hash, withState = true)
 
@@ -217,7 +217,7 @@ class BlockchainSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyCh
         }
 
       blocksToImport.foreach { block =>
-        blockchainWithStubPersisting.save(block, Nil, ChainWeight.zero, true)
+        blockchainWriterWithStubPersisting.save(block, Nil, ChainWeight.zero, true)
       }
 
       blockchainWithStubPersisting.getBestBlockNumber() shouldBe blocksToImport.last.number

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/EthBlocksServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/EthBlocksServiceSpec.scala
@@ -58,14 +58,14 @@ class EthBlocksServiceSpec
   }
 
   it should "answer eth_getBlockTransactionCountByHash with the block has no tx when the requested block is in the blockchain and has no tx" in new TestSetup {
-    blockchain.storeBlock(blockToRequest.copy(body = BlockBody(Nil, Nil))).commit()
+    blockchainWriter.storeBlock(blockToRequest.copy(body = BlockBody(Nil, Nil))).commit()
     val request = TxCountByBlockHashRequest(blockToRequestHash)
     val response = ethBlocksService.getBlockTransactionCountByHash(request).runSyncUnsafe(Duration.Inf).toOption.get
     response.txsQuantity shouldBe Some(0)
   }
 
   it should "answer eth_getBlockTransactionCountByHash correctly when the requested block is in the blockchain and has some tx" in new TestSetup {
-    blockchain.storeBlock(blockToRequest).commit()
+    blockchainWriter.storeBlock(blockToRequest).commit()
     val request = TxCountByBlockHashRequest(blockToRequestHash)
     val response = ethBlocksService.getBlockTransactionCountByHash(request).runSyncUnsafe(Duration.Inf).toOption.get
     response.txsQuantity shouldBe Some(blockToRequest.body.transactionList.size)
@@ -78,7 +78,7 @@ class EthBlocksServiceSpec
   }
 
   it should "answer eth_getBlockByHash with the block response correctly when it's chain weight is in blockchain" in new TestSetup {
-    blockchain
+    blockchainWriter
       .storeBlock(blockToRequest)
       .and(blockchain.storeChainWeight(blockToRequestHash, blockWeight))
       .commit()
@@ -98,7 +98,7 @@ class EthBlocksServiceSpec
   }
 
   it should "answer eth_getBlockByHash with the block response correctly when it's chain weight is not in blockchain" in new TestSetup {
-    blockchain.storeBlock(blockToRequest).commit()
+    blockchainWriter.storeBlock(blockToRequest).commit()
 
     val request = BlockByBlockHashRequest(blockToRequestHash, fullTxs = true)
     val response = ethBlocksService.getByBlockHash(request).runSyncUnsafe(Duration.Inf).toOption.get
@@ -113,7 +113,7 @@ class EthBlocksServiceSpec
   }
 
   it should "answer eth_getBlockByHash with the block response correctly when the txs should be hashed" in new TestSetup {
-    blockchain
+    blockchainWriter
       .storeBlock(blockToRequest)
       .and(blockchain.storeChainWeight(blockToRequestHash, blockWeight))
       .commit()
@@ -149,7 +149,7 @@ class EthBlocksServiceSpec
   }
 
   it should "answer eth_getBlockByNumber with the latest block pending block is requested and there are no pending ones" in new TestSetup {
-    blockchain
+    blockchainWriter
       .storeBlock(blockToRequest)
       .and(blockchain.storeChainWeight(blockToRequestHash, blockWeight))
       .commit()
@@ -169,7 +169,7 @@ class EthBlocksServiceSpec
   }
 
   it should "answer eth_getBlockByNumber with the block response correctly when it's chain weight is in blockchain" in new TestSetup {
-    blockchain
+    blockchainWriter
       .storeBlock(blockToRequest)
       .and(blockchain.storeChainWeight(blockToRequestHash, blockWeight))
       .commit()
@@ -189,7 +189,7 @@ class EthBlocksServiceSpec
   }
 
   it should "answer eth_getBlockByNumber with the block response correctly when it's chain weight is not in blockchain" in new TestSetup {
-    blockchain.storeBlock(blockToRequest).commit()
+    blockchainWriter.storeBlock(blockToRequest).commit()
 
     val request = BlockByNumberRequest(BlockParam.WithNumber(blockToRequestNumber), fullTxs = true)
     val response = ethBlocksService.getBlockByNumber(request).runSyncUnsafe(Duration.Inf).toOption.get
@@ -204,7 +204,7 @@ class EthBlocksServiceSpec
   }
 
   it should "answer eth_getBlockByNumber with the block response correctly when the txs should be hashed" in new TestSetup {
-    blockchain
+    blockchainWriter
       .storeBlock(blockToRequest)
       .and(blockchain.storeChainWeight(blockToRequestHash, blockWeight))
       .commit()
@@ -221,7 +221,7 @@ class EthBlocksServiceSpec
   }
 
   it should "get transaction count by block number" in new TestSetup {
-    blockchain.storeBlock(blockToRequest).commit()
+    blockchainWriter.storeBlock(blockToRequest).commit()
 
     val response = ethBlocksService.getBlockTransactionCountByNumber(
       GetBlockTransactionCountByNumberRequest(BlockParam.WithNumber(blockToRequest.header.number))
@@ -233,7 +233,7 @@ class EthBlocksServiceSpec
   }
 
   it should "get transaction count by latest block number" in new TestSetup {
-    blockchain.storeBlock(blockToRequest).commit()
+    blockchainWriter.storeBlock(blockToRequest).commit()
     blockchain.saveBestKnownBlocks(blockToRequest.header.number)
 
     val response =
@@ -252,7 +252,7 @@ class EthBlocksServiceSpec
   }
 
   it should "answer eth_getUncleByBlockHashAndIndex with None when there's no uncle" in new TestSetup {
-    blockchain.storeBlock(blockToRequest).commit()
+    blockchainWriter.storeBlock(blockToRequest).commit()
 
     val uncleIndexToRequest = 0
     val request = UncleByBlockHashAndIndexRequest(blockToRequestHash, uncleIndexToRequest)
@@ -262,7 +262,7 @@ class EthBlocksServiceSpec
   }
 
   it should "answer eth_getUncleByBlockHashAndIndex with None when there's no uncle in the requested index" in new TestSetup {
-    blockchain.storeBlock(blockToRequestWithUncles).commit()
+    blockchainWriter.storeBlock(blockToRequestWithUncles).commit()
 
     val uncleIndexToRequest = 0
     val request = UncleByBlockHashAndIndexRequest(blockToRequestHash, uncleIndexToRequest)
@@ -284,7 +284,7 @@ class EthBlocksServiceSpec
   }
 
   it should "answer eth_getUncleByBlockHashAndIndex correctly when the requested index has one but there's no chain weight for it" in new TestSetup {
-    blockchain.storeBlock(blockToRequestWithUncles).commit()
+    blockchainWriter.storeBlock(blockToRequestWithUncles).commit()
 
     val uncleIndexToRequest = 0
     val request = UncleByBlockHashAndIndexRequest(blockToRequestHash, uncleIndexToRequest)
@@ -297,7 +297,7 @@ class EthBlocksServiceSpec
   }
 
   it should "anwer eth_getUncleByBlockHashAndIndex correctly when the requested index has one and there's chain weight for it" in new TestSetup {
-    blockchain
+    blockchainWriter
       .storeBlock(blockToRequestWithUncles)
       .and(blockchain.storeChainWeight(uncle.hash, uncleWeight))
       .commit()
@@ -321,7 +321,7 @@ class EthBlocksServiceSpec
 
   it should "answer eth_getUncleByBlockNumberAndIndex with None when there's no uncle" in new TestSetup {
 
-    blockchain.storeBlock(blockToRequest).commit()
+    blockchainWriter.storeBlock(blockToRequest).commit()
 
     val uncleIndexToRequest = 0
     val request = UncleByBlockNumberAndIndexRequest(BlockParam.WithNumber(blockToRequestNumber), uncleIndexToRequest)
@@ -332,7 +332,7 @@ class EthBlocksServiceSpec
 
   it should "answer eth_getUncleByBlockNumberAndIndex with None when there's no uncle in the requested index" in new TestSetup {
 
-    blockchain.storeBlock(blockToRequestWithUncles).commit()
+    blockchainWriter.storeBlock(blockToRequestWithUncles).commit()
 
     val uncleIndexToRequest = 0
     val request = UncleByBlockNumberAndIndexRequest(BlockParam.WithNumber(blockToRequestNumber), uncleIndexToRequest)
@@ -354,7 +354,7 @@ class EthBlocksServiceSpec
   }
 
   it should "answer eth_getUncleByBlockNumberAndIndex correctly when the requested index has one but there's no chain weight for it" in new TestSetup {
-    blockchain.storeBlock(blockToRequestWithUncles).commit()
+    blockchainWriter.storeBlock(blockToRequestWithUncles).commit()
 
     val uncleIndexToRequest = 0
     val request = UncleByBlockNumberAndIndexRequest(BlockParam.WithNumber(blockToRequestNumber), uncleIndexToRequest)
@@ -367,7 +367,7 @@ class EthBlocksServiceSpec
   }
 
   it should "anwer eth_getUncleByBlockNumberAndIndex correctly when the requested index has one and there's chain weight for it" in new TestSetup {
-    blockchain
+    blockchainWriter
       .storeBlock(blockToRequestWithUncles)
       .and(blockchain.storeChainWeight(uncle.hash, uncleWeight))
       .commit()
@@ -383,7 +383,7 @@ class EthBlocksServiceSpec
   }
 
   it should "get uncle count by block number" in new TestSetup {
-    blockchain.storeBlock(blockToRequest).commit()
+    blockchainWriter.storeBlock(blockToRequest).commit()
     blockchain.saveBestKnownBlocks(blockToRequest.header.number)
 
     val response = ethBlocksService.getUncleCountByBlockNumber(GetUncleCountByBlockNumberRequest(BlockParam.Latest))
@@ -394,7 +394,7 @@ class EthBlocksServiceSpec
   }
 
   it should "get uncle count by block hash" in new TestSetup {
-    blockchain.storeBlock(blockToRequest).commit()
+    blockchainWriter.storeBlock(blockToRequest).commit()
 
     val response =
       ethBlocksService.getUncleCountByBlockHash(GetUncleCountByBlockHashRequest(blockToRequest.header.hash))

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/EthBlocksServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/EthBlocksServiceSpec.scala
@@ -80,7 +80,7 @@ class EthBlocksServiceSpec
   it should "answer eth_getBlockByHash with the block response correctly when it's chain weight is in blockchain" in new TestSetup {
     blockchainWriter
       .storeBlock(blockToRequest)
-      .and(blockchain.storeChainWeight(blockToRequestHash, blockWeight))
+      .and(blockchainWriter.storeChainWeight(blockToRequestHash, blockWeight))
       .commit()
 
     val request = BlockByBlockHashRequest(blockToRequestHash, fullTxs = true)
@@ -115,7 +115,7 @@ class EthBlocksServiceSpec
   it should "answer eth_getBlockByHash with the block response correctly when the txs should be hashed" in new TestSetup {
     blockchainWriter
       .storeBlock(blockToRequest)
-      .and(blockchain.storeChainWeight(blockToRequestHash, blockWeight))
+      .and(blockchainWriter.storeChainWeight(blockToRequestHash, blockWeight))
       .commit()
 
     val request = BlockByBlockHashRequest(blockToRequestHash, fullTxs = true)
@@ -151,7 +151,7 @@ class EthBlocksServiceSpec
   it should "answer eth_getBlockByNumber with the latest block pending block is requested and there are no pending ones" in new TestSetup {
     blockchainWriter
       .storeBlock(blockToRequest)
-      .and(blockchain.storeChainWeight(blockToRequestHash, blockWeight))
+      .and(blockchainWriter.storeChainWeight(blockToRequestHash, blockWeight))
       .commit()
     blockchain.saveBestKnownBlocks(blockToRequest.header.number)
 
@@ -171,7 +171,7 @@ class EthBlocksServiceSpec
   it should "answer eth_getBlockByNumber with the block response correctly when it's chain weight is in blockchain" in new TestSetup {
     blockchainWriter
       .storeBlock(blockToRequest)
-      .and(blockchain.storeChainWeight(blockToRequestHash, blockWeight))
+      .and(blockchainWriter.storeChainWeight(blockToRequestHash, blockWeight))
       .commit()
 
     val request = BlockByNumberRequest(BlockParam.WithNumber(blockToRequestNumber), fullTxs = true)
@@ -206,7 +206,7 @@ class EthBlocksServiceSpec
   it should "answer eth_getBlockByNumber with the block response correctly when the txs should be hashed" in new TestSetup {
     blockchainWriter
       .storeBlock(blockToRequest)
-      .and(blockchain.storeChainWeight(blockToRequestHash, blockWeight))
+      .and(blockchainWriter.storeChainWeight(blockToRequestHash, blockWeight))
       .commit()
 
     val request = BlockByNumberRequest(BlockParam.WithNumber(blockToRequestNumber), fullTxs = true)
@@ -299,7 +299,7 @@ class EthBlocksServiceSpec
   it should "anwer eth_getUncleByBlockHashAndIndex correctly when the requested index has one and there's chain weight for it" in new TestSetup {
     blockchainWriter
       .storeBlock(blockToRequestWithUncles)
-      .and(blockchain.storeChainWeight(uncle.hash, uncleWeight))
+      .and(blockchainWriter.storeChainWeight(uncle.hash, uncleWeight))
       .commit()
 
     val uncleIndexToRequest = 0
@@ -369,7 +369,7 @@ class EthBlocksServiceSpec
   it should "anwer eth_getUncleByBlockNumberAndIndex correctly when the requested index has one and there's chain weight for it" in new TestSetup {
     blockchainWriter
       .storeBlock(blockToRequestWithUncles)
-      .and(blockchain.storeChainWeight(uncle.hash, uncleWeight))
+      .and(blockchainWriter.storeChainWeight(uncle.hash, uncleWeight))
       .commit()
 
     val uncleIndexToRequest = 0

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/EthInfoServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/EthInfoServiceSpec.scala
@@ -100,7 +100,7 @@ class EthServiceSpec
   }
 
   it should "execute call and return a value" in new TestSetup {
-    blockchain.storeBlock(blockToRequest).commit()
+    blockchainWriter.storeBlock(blockToRequest).commit()
     blockchain.saveBestKnownBlocks(blockToRequest.header.number)
 
     val worldStateProxy = InMemoryWorldStateProxy(
@@ -130,7 +130,7 @@ class EthServiceSpec
   }
 
   it should "execute estimateGas and return a value" in new TestSetup {
-    blockchain.storeBlock(blockToRequest).commit()
+    blockchainWriter.storeBlock(blockToRequest).commit()
     blockchain.saveBestKnownBlocks(blockToRequest.header.number)
 
     val estimatedGas = BigInt(123)

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/EthMiningServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/EthMiningServiceSpec.scala
@@ -115,7 +115,7 @@ class EthMiningServiceSpec
     (blockGenerator.generateBlock _)
       .expects(parentBlock, Nil, *, *, *)
       .returning(PendingBlockAndState(PendingBlock(block, Nil), fakeWorld))
-    blockchain.save(parentBlock, Nil, ChainWeight.totalDifficultyOnly(parentBlock.header.difficulty), true)
+    blockchainWriter.save(parentBlock, Nil, ChainWeight.totalDifficultyOnly(parentBlock.header.difficulty), true)
 
     val response = ethMiningService.getWork(GetWorkRequest()).runSyncUnsafe()
     pendingTransactionsManager.expectMsg(PendingTransactionsManager.GetPendingTransactions)
@@ -141,7 +141,7 @@ class EthMiningServiceSpec
     )
     override lazy val consensus: TestConsensus = testConsensus.withBlockGenerator(restrictedGenerator)
 
-    blockchain.save(parentBlock, Nil, ChainWeight.totalDifficultyOnly(parentBlock.header.difficulty), true)
+    blockchainWriter.save(parentBlock, Nil, ChainWeight.totalDifficultyOnly(parentBlock.header.difficulty), true)
 
     val response = ethMiningService.getWork(GetWorkRequest()).runSyncUnsafe()
     pendingTransactionsManager.expectMsg(PendingTransactionsManager.GetPendingTransactions)

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/EthMiningServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/EthMiningServiceSpec.scala
@@ -62,7 +62,7 @@ class EthMiningServiceSpec
     (blockGenerator.generateBlock _)
       .expects(parentBlock, *, *, *, *)
       .returning(PendingBlockAndState(PendingBlock(block, Nil), fakeWorld))
-    blockchain.storeBlock(parentBlock).commit()
+    blockchainWriter.storeBlock(parentBlock).commit()
     ethMiningService.getWork(GetWorkRequest())
 
     val response = ethMiningService.getMining(GetMiningRequest())
@@ -100,7 +100,7 @@ class EthMiningServiceSpec
     (blockGenerator.generateBlock _)
       .expects(parentBlock, *, *, *, *)
       .returning(PendingBlockAndState(PendingBlock(block, Nil), fakeWorld))
-    blockchain.storeBlock(parentBlock).commit()
+    blockchainWriter.storeBlock(parentBlock).commit()
     ethMiningService.getWork(GetWorkRequest())
 
     Thread.sleep(minerActiveTimeout.toMillis)

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/EthProofServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/EthProofServiceSpec.scala
@@ -253,7 +253,7 @@ class EthProofServiceSpec
     val blockToRequest: Block = Block(Fixtures.Blocks.Block3125369.header, Fixtures.Blocks.Block3125369.body)
     val newBlockHeader: BlockHeader = blockToRequest.header.copy(stateRoot = ByteString(mpt.getRootHash))
     val newblock: Block = blockToRequest.copy(header = newBlockHeader)
-    blockchain.storeBlock(newblock).commit()
+    blockchainWriter.storeBlock(newblock).commit()
     blockchain.saveBestKnownBlocks(newblock.header.number)
 
     val ethGetProof =

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/EthTxServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/EthTxServiceSpec.scala
@@ -50,7 +50,7 @@ class EthTxServiceSpec
   }
 
   it should "answer eth_getTransactionByBlockHashAndIndex with None when there is no tx in requested index" in new TestSetup {
-    blockchain.storeBlock(blockToRequest).commit()
+    blockchainWriter.storeBlock(blockToRequest).commit()
 
     val invalidTxIndex = blockToRequest.body.transactionList.size
     val requestWithInvalidIndex = GetTransactionByBlockHashAndIndexRequest(blockToRequest.header.hash, invalidTxIndex)
@@ -64,7 +64,7 @@ class EthTxServiceSpec
   }
 
   it should "answer eth_getTransactionByBlockHashAndIndex with the transaction response correctly when the requested index has one" in new TestSetup {
-    blockchain.storeBlock(blockToRequest).commit()
+    blockchainWriter.storeBlock(blockToRequest).commit()
 
     val txIndexToRequest = blockToRequest.body.transactionList.size / 2
     val request = GetTransactionByBlockHashAndIndexRequest(blockToRequest.header.hash, txIndexToRequest)
@@ -89,7 +89,7 @@ class EthTxServiceSpec
 
   it should "answer eth_getRawTransactionByBlockHashAndIndex with None when there is no tx in requested index" in new TestSetup {
     // given
-    blockchain.storeBlock(blockToRequest).commit()
+    blockchainWriter.storeBlock(blockToRequest).commit()
 
     val invalidTxIndex = blockToRequest.body.transactionList.size
     val requestWithInvalidIndex = GetTransactionByBlockHashAndIndexRequest(blockToRequest.header.hash, invalidTxIndex)
@@ -107,7 +107,7 @@ class EthTxServiceSpec
 
   it should "answer eth_getRawTransactionByBlockHashAndIndex with the transaction response correctly when the requested index has one" in new TestSetup {
     // given
-    blockchain.storeBlock(blockToRequest).commit()
+    blockchainWriter.storeBlock(blockToRequest).commit()
     val txIndexToRequest = blockToRequest.body.transactionList.size / 2
     val request = GetTransactionByBlockHashAndIndexRequest(blockToRequest.header.hash, txIndexToRequest)
 
@@ -153,7 +153,7 @@ class EthTxServiceSpec
     // given
 
     val blockWithTx = Block(Fixtures.Blocks.Block3125369.header, Fixtures.Blocks.Block3125369.body)
-    blockchain.storeBlock(blockWithTx).commit()
+    blockchainWriter.storeBlock(blockWithTx).commit()
     val request = GetTransactionByHashRequest(txToRequestHash)
 
     // when
@@ -175,7 +175,7 @@ class EthTxServiceSpec
 
   it should "return average gas price" in new TestSetup {
     blockchain.saveBestKnownBlocks(42)
-    blockchain
+    blockchainWriter
       .storeBlock(Block(Fixtures.Blocks.Block3125369.header.copy(number = 42), Fixtures.Blocks.Block3125369.body))
       .commit()
 
@@ -184,7 +184,7 @@ class EthTxServiceSpec
   }
 
   it should "getTransactionByBlockNumberAndIndexRequest return transaction by index" in new TestSetup {
-    blockchain.storeBlock(blockToRequest).commit()
+    blockchainWriter.storeBlock(blockToRequest).commit()
     blockchain.saveBestKnownBlocks(blockToRequest.header.number)
 
     val txIndex: Int = 1
@@ -197,7 +197,7 @@ class EthTxServiceSpec
   }
 
   it should "getTransactionByBlockNumberAndIndexRequest return empty response if transaction does not exists when getting by index" in new TestSetup {
-    blockchain.storeBlock(blockToRequest).commit()
+    blockchainWriter.storeBlock(blockToRequest).commit()
 
     val txIndex: Int = blockToRequest.body.transactionList.length + 42
     val request =
@@ -208,7 +208,7 @@ class EthTxServiceSpec
   }
 
   it should "getTransactionByBlockNumberAndIndex return empty response if block does not exists when getting by index" in new TestSetup {
-    blockchain.storeBlock(blockToRequest).commit()
+    blockchainWriter.storeBlock(blockToRequest).commit()
 
     val txIndex: Int = 1
     val request =
@@ -219,7 +219,7 @@ class EthTxServiceSpec
   }
 
   it should "getRawTransactionByBlockNumberAndIndex return transaction by index" in new TestSetup {
-    blockchain.storeBlock(blockToRequest).commit()
+    blockchainWriter.storeBlock(blockToRequest).commit()
     blockchain.saveBestKnownBlocks(blockToRequest.header.number)
 
     val txIndex: Int = 1
@@ -231,7 +231,7 @@ class EthTxServiceSpec
   }
 
   it should "getRawTransactionByBlockNumberAndIndex return empty response if transaction does not exists when getting by index" in new TestSetup {
-    blockchain.storeBlock(blockToRequest).commit()
+    blockchainWriter.storeBlock(blockToRequest).commit()
 
     val txIndex: Int = blockToRequest.body.transactionList.length + 42
     val request =
@@ -242,7 +242,7 @@ class EthTxServiceSpec
   }
 
   it should "getRawTransactionByBlockNumberAndIndex return empty response if block does not exists when getting by index" in new TestSetup {
-    blockchain.storeBlock(blockToRequest).commit()
+    blockchainWriter.storeBlock(blockToRequest).commit()
 
     val txIndex: Int = 1
     val request =
@@ -279,7 +279,7 @@ class EthTxServiceSpec
   it should "handle get transaction by hash if the tx was already executed" in new TestSetup {
 
     val blockWithTx = Block(Fixtures.Blocks.Block3125369.header, Fixtures.Blocks.Block3125369.body)
-    blockchain.storeBlock(blockWithTx).commit()
+    blockchainWriter.storeBlock(blockWithTx).commit()
 
     val request = GetTransactionByHashRequest(txToRequestHash)
     val response = ethTxService.getTransactionByHash(request).runSyncUnsafe()
@@ -296,7 +296,7 @@ class EthTxServiceSpec
     val body = BlockBody(Seq(Fixtures.Blocks.Block3125369.body.transactionList.head, contractCreatingTransaction), Nil)
     val blockWithTx = Block(Fixtures.Blocks.Block3125369.header, body)
     val gasUsedByTx = 4242
-    blockchain
+    blockchainWriter
       .storeBlock(blockWithTx)
       .and(
         blockchain.storeReceipts(

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/EthTxServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/EthTxServiceSpec.scala
@@ -299,7 +299,7 @@ class EthTxServiceSpec
     blockchainWriter
       .storeBlock(blockWithTx)
       .and(
-        blockchain.storeReceipts(
+        blockchainWriter.storeReceipts(
           Fixtures.Blocks.Block3125369.header.hash,
           Seq(fakeReceipt, fakeReceipt.copy(cumulativeGasUsed = fakeReceipt.cumulativeGasUsed + gasUsedByTx))
         )

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/EthUserServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/EthUserServiceSpec.scala
@@ -48,7 +48,7 @@ class EthUserServiceSpec
 
     val newBlockHeader = blockToRequest.header.copy(stateRoot = ByteString(mpt.getRootHash))
     val newblock = blockToRequest.copy(header = newBlockHeader)
-    blockchain.storeBlock(newblock).commit()
+    blockchainWriter.storeBlock(newblock).commit()
     blockchain.saveBestKnownBlocks(newblock.header.number)
 
     val response = ethUserService.getCode(GetCodeRequest(address, BlockParam.Latest))
@@ -70,7 +70,7 @@ class EthUserServiceSpec
 
     val newBlockHeader = blockToRequest.header.copy(stateRoot = ByteString(mpt.getRootHash))
     val newblock = blockToRequest.copy(header = newBlockHeader)
-    blockchain.storeBlock(newblock).commit()
+    blockchainWriter.storeBlock(newblock).commit()
     blockchain.saveBestKnownBlocks(newblock.header.number)
 
     val response = ethUserService.getBalance(GetBalanceRequest(address, BlockParam.Latest))
@@ -83,7 +83,7 @@ class EthUserServiceSpec
 
     val newBlockHeader = blockToRequest.header
     val newblock = blockToRequest.copy(header = newBlockHeader)
-    blockchain.storeBlock(newblock).commit()
+    blockchainWriter.storeBlock(newblock).commit()
     blockchain.saveBestKnownBlocks(newblock.header.number)
 
     val response = ethUserService.getBalance(GetBalanceRequest(address, BlockParam.Latest))
@@ -113,7 +113,7 @@ class EthUserServiceSpec
 
     val newBlockHeader = blockToRequest.header.copy(stateRoot = ByteString(mpt.getRootHash))
     val newblock = blockToRequest.copy(header = newBlockHeader)
-    blockchain.storeBlock(newblock).commit()
+    blockchainWriter.storeBlock(newblock).commit()
     blockchain.saveBestKnownBlocks(newblock.header.number)
 
     val response = ethUserService.getStorageAt(GetStorageAtRequest(address, 333, BlockParam.Latest))
@@ -131,7 +131,7 @@ class EthUserServiceSpec
 
     val newBlockHeader = blockToRequest.header.copy(stateRoot = ByteString(mpt.getRootHash))
     val newblock = blockToRequest.copy(header = newBlockHeader)
-    blockchain.storeBlock(newblock).commit()
+    blockchainWriter.storeBlock(newblock).commit()
     blockchain.saveBestKnownBlocks(newblock.header.number)
 
     val response = ethUserService.getTransactionCount(GetTransactionCountRequest(address, BlockParam.Latest))

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerEthSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerEthSpec.scala
@@ -108,7 +108,7 @@ class JsonRpcControllerEthSpec
     val blockToRequest = Block(Fixtures.Blocks.Block3125369.header, Fixtures.Blocks.Block3125369.body)
     val blockWeight = ChainWeight.zero.increase(blockToRequest.header)
 
-    blockchain
+    blockchainWriter
       .storeBlock(blockToRequest)
       .and(blockchain.storeChainWeight(blockToRequest.header.hash, blockWeight))
       .commit()
@@ -129,7 +129,7 @@ class JsonRpcControllerEthSpec
     val blockToRequest = blockWithCheckpoint
     val blockWeight = ChainWeight.zero.increase(blockToRequest.header)
 
-    blockchain
+    blockchainWriter
       .storeBlock(blockToRequest)
       .and(blockchain.storeChainWeight(blockToRequest.header.hash, blockWeight))
       .commit()
@@ -150,7 +150,7 @@ class JsonRpcControllerEthSpec
     val blockToRequest = blockWithTreasuryOptOut
     val blockWeight = ChainWeight.zero.increase(blockToRequest.header)
 
-    blockchain
+    blockchainWriter
       .storeBlock(blockToRequest)
       .and(blockchain.storeChainWeight(blockToRequest.header.hash, blockWeight))
       .commit()
@@ -171,7 +171,7 @@ class JsonRpcControllerEthSpec
     val blockToRequest = Block(Fixtures.Blocks.Block3125369.header, Fixtures.Blocks.Block3125369.body)
     val blockWeight = ChainWeight.zero.increase(blockToRequest.header)
 
-    blockchain
+    blockchainWriter
       .storeBlock(blockToRequest)
       .and(blockchain.storeChainWeight(blockToRequest.header.hash, blockWeight))
       .commit()
@@ -192,7 +192,7 @@ class JsonRpcControllerEthSpec
     val blockToRequest = blockWithTreasuryOptOut
     val blockWeight = ChainWeight.zero.increase(blockToRequest.header)
 
-    blockchain
+    blockchainWriter
       .storeBlock(blockToRequest)
       .and(blockchain.storeChainWeight(blockToRequest.header.hash, blockWeight))
       .commit()
@@ -213,7 +213,7 @@ class JsonRpcControllerEthSpec
     val blockToRequest = blockWithCheckpoint
     val blockWeight = ChainWeight.zero.increase(blockToRequest.header)
 
-    blockchain
+    blockchainWriter
       .storeBlock(blockToRequest)
       .and(blockchain.storeChainWeight(blockToRequest.header.hash, blockWeight))
       .commit()
@@ -234,7 +234,7 @@ class JsonRpcControllerEthSpec
     val uncle = Fixtures.Blocks.DaoForkBlock.header
     val blockToRequest = Block(Fixtures.Blocks.Block3125369.header, BlockBody(Nil, Seq(uncle)))
 
-    blockchain.storeBlock(blockToRequest).commit()
+    blockchainWriter.storeBlock(blockToRequest).commit()
 
     val request: JsonRpcRequest = newJsonRpcRequest(
       "eth_getUncleByBlockHashAndIndex",
@@ -259,7 +259,7 @@ class JsonRpcControllerEthSpec
     val uncle = Fixtures.Blocks.DaoForkBlock.header
     val blockToRequest = Block(Fixtures.Blocks.Block3125369.header, BlockBody(Nil, Seq(uncle)))
 
-    blockchain.storeBlock(blockToRequest).commit()
+    blockchainWriter.storeBlock(blockToRequest).commit()
 
     val request: JsonRpcRequest = newJsonRpcRequest(
       "eth_getUncleByBlockNumberAndIndex",
@@ -393,7 +393,7 @@ class JsonRpcControllerEthSpec
   }
 
   it should "eth_gasPrice" in new JsonRpcControllerFixture {
-    blockchain
+    blockchainWriter
       .storeBlock(Block(Fixtures.Blocks.Block3125369.header.copy(number = 42), Fixtures.Blocks.Block3125369.body))
       .commit()
     blockchain.saveBestKnownBlocks(42)

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerEthSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerEthSpec.scala
@@ -110,7 +110,7 @@ class JsonRpcControllerEthSpec
 
     blockchainWriter
       .storeBlock(blockToRequest)
-      .and(blockchain.storeChainWeight(blockToRequest.header.hash, blockWeight))
+      .and(blockchainWriter.storeChainWeight(blockToRequest.header.hash, blockWeight))
       .commit()
 
     val request = newJsonRpcRequest(
@@ -131,7 +131,7 @@ class JsonRpcControllerEthSpec
 
     blockchainWriter
       .storeBlock(blockToRequest)
-      .and(blockchain.storeChainWeight(blockToRequest.header.hash, blockWeight))
+      .and(blockchainWriter.storeChainWeight(blockToRequest.header.hash, blockWeight))
       .commit()
 
     val request = newJsonRpcRequest(
@@ -152,7 +152,7 @@ class JsonRpcControllerEthSpec
 
     blockchainWriter
       .storeBlock(blockToRequest)
-      .and(blockchain.storeChainWeight(blockToRequest.header.hash, blockWeight))
+      .and(blockchainWriter.storeChainWeight(blockToRequest.header.hash, blockWeight))
       .commit()
 
     val request = newJsonRpcRequest(
@@ -173,7 +173,7 @@ class JsonRpcControllerEthSpec
 
     blockchainWriter
       .storeBlock(blockToRequest)
-      .and(blockchain.storeChainWeight(blockToRequest.header.hash, blockWeight))
+      .and(blockchainWriter.storeChainWeight(blockToRequest.header.hash, blockWeight))
       .commit()
 
     val request = newJsonRpcRequest(
@@ -194,7 +194,7 @@ class JsonRpcControllerEthSpec
 
     blockchainWriter
       .storeBlock(blockToRequest)
-      .and(blockchain.storeChainWeight(blockToRequest.header.hash, blockWeight))
+      .and(blockchainWriter.storeChainWeight(blockToRequest.header.hash, blockWeight))
       .commit()
 
     val request = newJsonRpcRequest(
@@ -215,7 +215,7 @@ class JsonRpcControllerEthSpec
 
     blockchainWriter
       .storeBlock(blockToRequest)
-      .and(blockchain.storeChainWeight(blockToRequest.header.hash, blockWeight))
+      .and(blockchainWriter.storeChainWeight(blockToRequest.header.hash, blockWeight))
       .commit()
 
     val request = newJsonRpcRequest(
@@ -286,7 +286,7 @@ class JsonRpcControllerEthSpec
     val target = "0x1999999999999999999999999999999999999999999999999999999999999999"
     val headerPowHash = s"0x${Hex.toHexString(kec256(BlockHeader.getEncodedWithoutNonce(blockHeader)))}"
 
-    blockchain.save(parentBlock, Nil, ChainWeight.zero.increase(parentBlock.header), true)
+    blockchainWriter.save(parentBlock, Nil, ChainWeight.zero.increase(parentBlock.header), true)
     (blockGenerator.generateBlock _)
       .expects(parentBlock, *, *, *, *)
       .returns(PendingBlockAndState(PendingBlock(Block(blockHeader, BlockBody(Nil, Nil)), Nil), fakeWorld))
@@ -318,7 +318,7 @@ class JsonRpcControllerEthSpec
     val target = "0x1999999999999999999999999999999999999999999999999999999999999999"
     val headerPowHash = s"0x${Hex.toHexString(kec256(BlockHeader.getEncodedWithoutNonce(blockHeader)))}"
 
-    blockchain.save(parentBlock, Nil, ChainWeight.zero.increase(parentBlock.header), true)
+    blockchainWriter.save(parentBlock, Nil, ChainWeight.zero.increase(parentBlock.header), true)
     (blockGenerator.generateBlock _)
       .expects(parentBlock, *, *, *, *)
       .returns(PendingBlockAndState(PendingBlock(Block(blockHeader, BlockBody(Nil, Nil)), Nil), fakeWorld))

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerEthTransactionSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerEthTransactionSpec.scala
@@ -53,7 +53,7 @@ class JsonRpcControllerEthTransactionSpec
     val blockToRequest = Block(Fixtures.Blocks.Block3125369.header, Fixtures.Blocks.Block3125369.body)
     val txIndexToRequest = blockToRequest.body.transactionList.size / 2
 
-    blockchain.storeBlock(blockToRequest).commit()
+    blockchainWriter.storeBlock(blockToRequest).commit()
     blockchain.saveBestKnownBlocks(blockToRequest.header.number)
 
     val request: JsonRpcRequest = newJsonRpcRequest(
@@ -76,7 +76,7 @@ class JsonRpcControllerEthTransactionSpec
     val blockToRequest = Block(Fixtures.Blocks.Block3125369.header, Fixtures.Blocks.Block3125369.body)
     val txIndexToRequest = blockToRequest.body.transactionList.size / 2
 
-    blockchain.storeBlock(blockToRequest).commit()
+    blockchainWriter.storeBlock(blockToRequest).commit()
     blockchain.saveBestKnownBlocks(blockToRequest.header.number)
 
     val request: JsonRpcRequest = newJsonRpcRequest(
@@ -136,7 +136,7 @@ class JsonRpcControllerEthTransactionSpec
     val blockToRequest = Block(Fixtures.Blocks.Block3125369.header, Fixtures.Blocks.Block3125369.body)
     val txIndex = 1
 
-    blockchain.storeBlock(blockToRequest).commit()
+    blockchainWriter.storeBlock(blockToRequest).commit()
     blockchain.saveBestKnownBlocks(blockToRequest.header.number)
 
     val request: JsonRpcRequest = newJsonRpcRequest(
@@ -160,7 +160,7 @@ class JsonRpcControllerEthTransactionSpec
       Block(Fixtures.Blocks.Block3125369.header.copy(number = BigInt(0xc005)), Fixtures.Blocks.Block3125369.body)
     val txIndex = 1
 
-    blockchain.storeBlock(blockToRequest).commit()
+    blockchainWriter.storeBlock(blockToRequest).commit()
 
     val request: JsonRpcRequest = newJsonRpcRequest(
       "eth_getTransactionByBlockNumberAndIndex",
@@ -182,7 +182,7 @@ class JsonRpcControllerEthTransactionSpec
     val blockToRequest = Block(Fixtures.Blocks.Block3125369.header, Fixtures.Blocks.Block3125369.body)
     val txIndex = 1
 
-    blockchain.storeBlock(blockToRequest).commit()
+    blockchainWriter.storeBlock(blockToRequest).commit()
 
     val request: JsonRpcRequest = newJsonRpcRequest(
       "eth_getTransactionByBlockNumberAndIndex",
@@ -205,7 +205,7 @@ class JsonRpcControllerEthTransactionSpec
     val blockToRequest: Block = Block(Fixtures.Blocks.Block3125369.header, Fixtures.Blocks.Block3125369.body)
     val txIndex = 1
 
-    blockchain.storeBlock(blockToRequest).commit()
+    blockchainWriter.storeBlock(blockToRequest).commit()
     blockchain.saveBestKnownBlocks(blockToRequest.header.number)
 
     val request: JsonRpcRequest = newJsonRpcRequest(
@@ -231,7 +231,7 @@ class JsonRpcControllerEthTransactionSpec
       Block(Fixtures.Blocks.Block3125369.header.copy(number = BigInt(0xc005)), Fixtures.Blocks.Block3125369.body)
     val txIndex = 1
 
-    blockchain.storeBlock(blockToRequest).commit()
+    blockchainWriter.storeBlock(blockToRequest).commit()
 
     val request: JsonRpcRequest = newJsonRpcRequest(
       "eth_getRawTransactionByBlockNumberAndIndex",
@@ -254,7 +254,7 @@ class JsonRpcControllerEthTransactionSpec
     val blockToRequest = Block(Fixtures.Blocks.Block3125369.header, Fixtures.Blocks.Block3125369.body)
     val txIndex = 1
 
-    blockchain.storeBlock(blockToRequest).commit()
+    blockchainWriter.storeBlock(blockToRequest).commit()
 
     val request: JsonRpcRequest = newJsonRpcRequest(
       "eth_getRawTransactionByBlockNumberAndIndex",
@@ -331,7 +331,7 @@ class JsonRpcControllerEthTransactionSpec
   it should "handle eth_getBlockTransactionCountByHash request" in new JsonRpcControllerFixture {
     val blockToRequest = Block(Fixtures.Blocks.Block3125369.header, Fixtures.Blocks.Block3125369.body)
 
-    blockchain.storeBlock(blockToRequest).commit()
+    blockchainWriter.storeBlock(blockToRequest).commit()
 
     val rpcRequest = newJsonRpcRequest(
       "eth_getBlockTransactionCountByHash",

--- a/src/test/scala/io/iohk/ethereum/ledger/BlockExecutionSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/BlockExecutionSpec.scala
@@ -25,7 +25,6 @@ import io.iohk.ethereum.consensus.validators.Validators
 import io.iohk.ethereum.consensus.validators.std.StdBlockValidator
 import io.iohk.ethereum.crypto.ECDSASignature
 import io.iohk.ethereum.domain._
-import io.iohk.ethereum.ledger.BlockResult
 import io.iohk.ethereum.ledger.BlockRewardCalculatorOps._
 import io.iohk.ethereum.utils.ByteStringUtils._
 import io.iohk.ethereum.utils.Hex
@@ -68,6 +67,7 @@ class BlockExecutionSpec extends AnyWordSpec with Matchers with ScalaCheckProper
           new BlockExecution(
             blockchain,
             blockchainReader,
+            blockchainWriter,
             blockchainStorages.evmCodeStorage,
             blockchainConfig,
             newConsensus.blockPreparator,
@@ -110,6 +110,7 @@ class BlockExecutionSpec extends AnyWordSpec with Matchers with ScalaCheckProper
           new BlockExecution(
             blockchain,
             blockchainReader,
+            blockchainWriter,
             blockchainStorages.evmCodeStorage,
             blockchainConfig,
             newConsensus.blockPreparator,
@@ -145,6 +146,7 @@ class BlockExecutionSpec extends AnyWordSpec with Matchers with ScalaCheckProper
           new BlockExecution(
             blockchain,
             blockchainReader,
+            blockchainWriter,
             blockchainStorages.evmCodeStorage,
             blockchainConfig,
             newConsensus.blockPreparator,
@@ -172,6 +174,7 @@ class BlockExecutionSpec extends AnyWordSpec with Matchers with ScalaCheckProper
           new BlockExecution(
             blockchain,
             blockchainReader,
+            blockchainWriter,
             blockchainStorages.evmCodeStorage,
             blockchainConfig,
             newConsensus.blockPreparator,
@@ -231,6 +234,7 @@ class BlockExecutionSpec extends AnyWordSpec with Matchers with ScalaCheckProper
           new BlockExecution(
             blockchain,
             blockchainReader,
+            blockchainWriter,
             blockchainStorages.evmCodeStorage,
             blockchainConfig,
             newConsensus.blockPreparator,
@@ -306,6 +310,7 @@ class BlockExecutionSpec extends AnyWordSpec with Matchers with ScalaCheckProper
             new BlockExecution(
               blockchain,
               blockchainReader,
+              blockchainWriter,
               blockchainStorages.evmCodeStorage,
               blockchainConfig,
               newConsensus.blockPreparator,
@@ -670,6 +675,7 @@ class BlockExecutionSpec extends AnyWordSpec with Matchers with ScalaCheckProper
       new BlockExecution(
         blockchain,
         blockchainReader,
+        blockchainWriter,
         blockchainStorages.evmCodeStorage,
         blockchainConfig,
         consensus.blockPreparator,

--- a/src/test/scala/io/iohk/ethereum/ledger/BlockImportSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/BlockImportSpec.scala
@@ -115,12 +115,12 @@ class BlockImportSpec extends AnyFlatSpec with Matchers with ScalaFutures {
     val oldWeight2 = weight1.increase(oldBlock2.header)
     val oldWeight3 = oldWeight2.increase(oldBlock3.header)
 
-    blockchain.save(block1, Nil, weight1, saveAsBestBlock = true)
-    blockchain.save(oldBlock2, receipts, oldWeight2, saveAsBestBlock = true)
-    blockchain.save(oldBlock3, Nil, oldWeight3, saveAsBestBlock = true)
+    blockchainWriter.save(block1, Nil, weight1, saveAsBestBlock = true)
+    blockchainWriter.save(oldBlock2, receipts, oldWeight2, saveAsBestBlock = true)
+    blockchainWriter.save(oldBlock3, Nil, oldWeight3, saveAsBestBlock = true)
 
     val ancestorForValidation: Block = getBlock(0, difficulty = 1)
-    blockchain.save(ancestorForValidation, Nil, ChainWeight.totalDifficultyOnly(1), saveAsBestBlock = false)
+    blockchainWriter.save(ancestorForValidation, Nil, ChainWeight.totalDifficultyOnly(1), saveAsBestBlock = false)
 
     val oldBranch = List(oldBlock2, oldBlock3)
     val newBranch = List(newBlock2, newBlock3)
@@ -137,8 +137,8 @@ class BlockImportSpec extends AnyFlatSpec with Matchers with ScalaFutures {
     }
 
     // Saving new blocks, because it's part of executeBlocks method mechanism
-    blockchain.save(blockData2.block, blockData2.receipts, blockData2.weight, saveAsBestBlock = true)
-    blockchain.save(blockData3.block, blockData3.receipts, blockData3.weight, saveAsBestBlock = true)
+    blockchainWriter.save(blockData2.block, blockData2.receipts, blockData2.weight, saveAsBestBlock = true)
+    blockchainWriter.save(blockData3.block, blockData3.receipts, blockData3.weight, saveAsBestBlock = true)
 
     blockchain.getBestBlock().get shouldEqual newBlock3
     blockchain.getChainWeightByHash(newBlock3.header.hash) shouldEqual Some(newWeight3)
@@ -163,13 +163,13 @@ class BlockImportSpec extends AnyFlatSpec with Matchers with ScalaFutures {
     val oldWeight3 = oldWeight2.increase(oldBlock3.header)
     val oldWeight4 = oldWeight3.increase(oldBlock4.header)
 
-    blockchain.save(block1, Nil, weight1, saveAsBestBlock = true)
-    blockchain.save(oldBlock2, receipts, oldWeight2, saveAsBestBlock = true)
-    blockchain.save(oldBlock3, Nil, oldWeight3, saveAsBestBlock = true)
-    blockchain.save(oldBlock4, Nil, oldWeight4, saveAsBestBlock = true)
+    blockchainWriter.save(block1, Nil, weight1, saveAsBestBlock = true)
+    blockchainWriter.save(oldBlock2, receipts, oldWeight2, saveAsBestBlock = true)
+    blockchainWriter.save(oldBlock3, Nil, oldWeight3, saveAsBestBlock = true)
+    blockchainWriter.save(oldBlock4, Nil, oldWeight4, saveAsBestBlock = true)
 
     val ancestorForValidation: Block = getBlock(0, difficulty = 1)
-    blockchain.save(ancestorForValidation, Nil, ChainWeight.totalDifficultyOnly(1), saveAsBestBlock = false)
+    blockchainWriter.save(ancestorForValidation, Nil, ChainWeight.totalDifficultyOnly(1), saveAsBestBlock = false)
 
     val oldBranch = List(oldBlock2, oldBlock3, oldBlock4)
     val newBranch = List(newBlock2, newBlock3)
@@ -186,8 +186,8 @@ class BlockImportSpec extends AnyFlatSpec with Matchers with ScalaFutures {
     }
 
     // Saving new blocks, because it's part of executeBlocks method mechanism
-    blockchain.save(blockData2.block, blockData2.receipts, blockData2.weight, saveAsBestBlock = true)
-    blockchain.save(blockData3.block, blockData3.receipts, blockData3.weight, saveAsBestBlock = true)
+    blockchainWriter.save(blockData2.block, blockData2.receipts, blockData2.weight, saveAsBestBlock = true)
+    blockchainWriter.save(blockData3.block, blockData3.receipts, blockData3.weight, saveAsBestBlock = true)
 
     //saving to cache the value of the best block from the initial chain. This recreates the bug ETCM-626, where (possibly) because of the thread of execution
     // dying before updating the storage but after updating the cache, inconsistency is created
@@ -209,12 +209,12 @@ class BlockImportSpec extends AnyFlatSpec with Matchers with ScalaFutures {
     val oldWeight2 = weight1.increase(oldBlock2.header)
     val oldWeight3 = oldWeight2.increase(oldBlock3.header)
 
-    blockchain.save(block1, Nil, weight1, saveAsBestBlock = true)
-    blockchain.save(oldBlock2, receipts, oldWeight2, saveAsBestBlock = true)
-    blockchain.save(oldBlock3, Nil, oldWeight3, saveAsBestBlock = true)
+    blockchainWriter.save(block1, Nil, weight1, saveAsBestBlock = true)
+    blockchainWriter.save(oldBlock2, receipts, oldWeight2, saveAsBestBlock = true)
+    blockchainWriter.save(oldBlock3, Nil, oldWeight3, saveAsBestBlock = true)
 
     val ancestorForValidation: Block = getBlock(0, difficulty = 1)
-    blockchain.save(ancestorForValidation, Nil, ChainWeight.totalDifficultyOnly(1), saveAsBestBlock = false)
+    blockchainWriter.save(ancestorForValidation, Nil, ChainWeight.totalDifficultyOnly(1), saveAsBestBlock = false)
 
     val newBranch = List(newBlock2, newBlock3)
     val blockData2 = BlockData(newBlock2, Seq.empty[Receipt], newWeight2)
@@ -303,13 +303,13 @@ class BlockImportSpec extends AnyFlatSpec with Matchers with ScalaFutures {
     val newWeight2 = weight1.increase(newBlock2.header)
     val newWeight3 = newWeight2.increase(newBlock3WithOmmer.header)
 
-    blockchain.save(ancestorForValidation, Nil, ChainWeight.totalDifficultyOnly(1), saveAsBestBlock = false)
-    blockchain.save(ancestorForValidation1, Nil, ChainWeight.totalDifficultyOnly(3), saveAsBestBlock = false)
-    blockchain.save(ancestorForValidation2, Nil, ChainWeight.totalDifficultyOnly(6), saveAsBestBlock = false)
+    blockchainWriter.save(ancestorForValidation, Nil, ChainWeight.totalDifficultyOnly(1), saveAsBestBlock = false)
+    blockchainWriter.save(ancestorForValidation1, Nil, ChainWeight.totalDifficultyOnly(3), saveAsBestBlock = false)
+    blockchainWriter.save(ancestorForValidation2, Nil, ChainWeight.totalDifficultyOnly(6), saveAsBestBlock = false)
 
-    blockchain.save(block1, Nil, weight1, saveAsBestBlock = true)
-    blockchain.save(oldBlock2, receipts, oldWeight2, saveAsBestBlock = true)
-    blockchain.save(oldBlock3, Nil, oldWeight3, saveAsBestBlock = true)
+    blockchainWriter.save(block1, Nil, weight1, saveAsBestBlock = true)
+    blockchainWriter.save(oldBlock2, receipts, oldWeight2, saveAsBestBlock = true)
+    blockchainWriter.save(oldBlock3, Nil, oldWeight3, saveAsBestBlock = true)
 
     val oldBranch = List(oldBlock2, oldBlock3)
     val newBranch = List(newBlock2, newBlock3WithOmmer)
@@ -326,8 +326,8 @@ class BlockImportSpec extends AnyFlatSpec with Matchers with ScalaFutures {
     }
 
     // Saving new blocks, because it's part of executeBlocks method mechanism
-    blockchain.save(blockData2.block, blockData2.receipts, blockData2.weight, saveAsBestBlock = true)
-    blockchain.save(blockData3.block, blockData3.receipts, blockData3.weight, saveAsBestBlock = true)
+    blockchainWriter.save(blockData2.block, blockData2.receipts, blockData2.weight, saveAsBestBlock = true)
+    blockchainWriter.save(blockData3.block, blockData3.receipts, blockData3.weight, saveAsBestBlock = true)
 
     blockchain.getBestBlock().get shouldEqual newBlock3WithOmmer
   }
@@ -341,8 +341,8 @@ class BlockImportSpec extends AnyFlatSpec with Matchers with ScalaFutures {
     val weightRegular = weightParent.increase(regularBlock.header)
     val weightCheckpoint = weightParent.increase(checkpointBlock.header)
 
-    blockchain.save(parentBlock, Nil, weightParent, saveAsBestBlock = true)
-    blockchain.save(regularBlock, Nil, weightRegular, saveAsBestBlock = true)
+    blockchainWriter.save(parentBlock, Nil, weightParent, saveAsBestBlock = true)
+    blockchainWriter.save(regularBlock, Nil, weightRegular, saveAsBestBlock = true)
 
     (blockImportWithMockedBlockExecution.blockExecution.executeAndValidateBlocks _)
       .expects(List(checkpointBlock), *)
@@ -357,7 +357,7 @@ class BlockImportSpec extends AnyFlatSpec with Matchers with ScalaFutures {
     }
 
     // Saving new blocks, because it's part of executeBlocks method mechanism
-    blockchain.save(checkpointBlock, Nil, weightCheckpoint, saveAsBestBlock = true)
+    blockchainWriter.save(checkpointBlock, Nil, weightCheckpoint, saveAsBestBlock = true)
 
     blockchain.getBestBlock().get shouldEqual checkpointBlock
     blockchain.getChainWeightByHash(checkpointBlock.hash) shouldEqual Some(weightCheckpoint)
@@ -373,8 +373,8 @@ class BlockImportSpec extends AnyFlatSpec with Matchers with ScalaFutures {
     val weightParent = ChainWeight.totalDifficultyOnly(parentBlock.header.difficulty + 999)
     val weightCheckpoint = weightParent.increase(checkpointBlock.header)
 
-    blockchain.save(parentBlock, Nil, weightParent, saveAsBestBlock = true)
-    blockchain.save(checkpointBlock, Nil, weightCheckpoint, saveAsBestBlock = true)
+    blockchainWriter.save(parentBlock, Nil, weightParent, saveAsBestBlock = true)
+    blockchainWriter.save(checkpointBlock, Nil, weightCheckpoint, saveAsBestBlock = true)
 
     whenReady(blockImportWithMockedBlockExecution.importBlock(regularBlock).runToFuture)(_ shouldEqual BlockEnqueued)
 

--- a/src/test/scala/io/iohk/ethereum/ledger/BlockValidationSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/BlockValidationSpec.scala
@@ -1,12 +1,14 @@
 package io.iohk.ethereum.ledger
 
 import akka.util.ByteString
+
 import org.bouncycastle.util.encoders.Hex
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 import io.iohk.ethereum.Mocks
+import io.iohk.ethereum.blockchain.sync.EphemBlockchainTestSetup
 import io.iohk.ethereum.consensus.validators.std.StdBlockValidator
 import io.iohk.ethereum.domain._
 import io.iohk.ethereum.utils.ByteStringUtils._

--- a/src/test/scala/io/iohk/ethereum/ledger/BlockValidationSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/BlockValidationSpec.scala
@@ -1,7 +1,6 @@
 package io.iohk.ethereum.ledger
 
 import akka.util.ByteString
-
 import org.bouncycastle.util.encoders.Hex
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.matchers.should.Matchers
@@ -42,7 +41,7 @@ class BlockValidationSpec extends AnyWordSpec with Matchers with MockFactory {
 
   // scalastyle:off magic.number
   object BlockValidationTestSetup {
-    private val setup = new io.iohk.ethereum.blockchain.sync.ScenarioSetup {
+    private val setup = new EphemBlockchainTestSetup {
       override lazy val blockchainReader: BlockchainReader = mock[BlockchainReader]
       override lazy val blockchain: BlockchainImpl = mock[BlockchainImpl]
 

--- a/src/test/scala/io/iohk/ethereum/ledger/LedgerTestSetup.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/LedgerTestSetup.scala
@@ -197,9 +197,9 @@ trait BlockchainSetup extends TestSetup {
   )
   val validBlockBodyWithNoTxs: BlockBody = BlockBody(Nil, Nil)
 
-  blockchain
+  blockchainWriter
     .storeBlockHeader(validBlockParentHeader)
-    .and(blockchain.storeBlockBody(validBlockParentHeader.hash, validBlockBodyWithNoTxs))
+    .and(blockchainWriter.storeBlockBody(validBlockParentHeader.hash, validBlockBodyWithNoTxs))
     .and(storagesInstance.storages.appStateStorage.putBestBlockNumber(validBlockParentHeader.number))
     .and(storagesInstance.storages.chainWeightStorage.put(validBlockParentHeader.hash, ChainWeight.zero))
     .commit()

--- a/src/test/scala/io/iohk/ethereum/ledger/LedgerTestSetup.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/LedgerTestSetup.scala
@@ -375,11 +375,13 @@ trait TestSetupWithVmAndValidators extends EphemBlockchainTestSetup {
     new BlockImport(
       blockchain,
       blockchainReader,
+      blockchainWriter,
       blockQueue,
       blockValidation,
       new BlockExecution(
         blockchain,
         blockchainReader,
+        blockchainWriter,
         storagesInstance.storages.evmCodeStorage,
         blockchainConfig,
         consensuz.blockPreparator,
@@ -409,6 +411,7 @@ trait TestSetupWithVmAndValidators extends EphemBlockchainTestSetup {
 trait MockBlockchain extends MockFactory { self: TestSetupWithVmAndValidators =>
   //+ cake overrides
   override lazy val blockchainReader: BlockchainReader = mock[BlockchainReader]
+  override lazy val blockchainWriter: BlockchainWriter = mock[BlockchainWriter]
   override lazy val blockchain: BlockchainImpl = mock[BlockchainImpl]
   //- cake overrides
 
@@ -443,7 +446,7 @@ trait MockBlockchain extends MockFactory { self: TestSetupWithVmAndValidators =>
       weight: ChainWeight,
       saveAsBestBlock: Boolean
   ): CallHandler4[Block, Seq[Receipt], ChainWeight, Boolean, Unit] =
-    (blockchain
+    (blockchainWriter
       .save(_: Block, _: Seq[Receipt], _: ChainWeight, _: Boolean))
       .expects(block, receipts, weight, saveAsBestBlock)
       .once()

--- a/src/test/scala/io/iohk/ethereum/ledger/StxLedgerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/StxLedgerSpec.scala
@@ -238,7 +238,7 @@ trait ScenarioSetup extends EphemBlockchainTestSetup {
   val genesisWeight: ChainWeight = ChainWeight.zero.increase(genesisHeader)
   val lastBlockGasLimit: BigInt = genesisBlock.header.gasLimit
 
-  blockchain
+  blockchainWriter
     .storeBlock(genesisBlock)
     .and(blockchain.storeReceipts(genesisHash, Nil))
     .and(blockchain.storeChainWeight(genesisHash, genesisWeight))

--- a/src/test/scala/io/iohk/ethereum/ledger/StxLedgerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/StxLedgerSpec.scala
@@ -10,7 +10,6 @@ import io.iohk.ethereum.blockchain.sync.EphemBlockchainTestSetup
 import io.iohk.ethereum.crypto.ECDSASignature
 import io.iohk.ethereum.domain.Block.BlockDec
 import io.iohk.ethereum.domain._
-import io.iohk.ethereum.ledger.TxResult
 import io.iohk.ethereum.mpt.MerklePatriciaTrie
 import io.iohk.ethereum.mpt.MerklePatriciaTrie.MPTException
 import io.iohk.ethereum.utils._
@@ -240,7 +239,7 @@ trait ScenarioSetup extends EphemBlockchainTestSetup {
 
   blockchainWriter
     .storeBlock(genesisBlock)
-    .and(blockchain.storeReceipts(genesisHash, Nil))
-    .and(blockchain.storeChainWeight(genesisHash, genesisWeight))
+    .and(blockchainWriter.storeReceipts(genesisHash, Nil))
+    .and(blockchainWriter.storeChainWeight(genesisHash, genesisWeight))
     .commit()
 }

--- a/src/test/scala/io/iohk/ethereum/network/EtcPeerManagerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/network/EtcPeerManagerSpec.scala
@@ -292,7 +292,7 @@ class EtcPeerManagerSpec extends AnyFlatSpec with Matchers {
   trait TestSetup extends EphemBlockchainTestSetup {
     implicit override lazy val system: ActorSystem = ActorSystem("PeersInfoHolderSpec_System")
 
-    blockchain.storeBlockHeader(Fixtures.Blocks.Genesis.header).commit()
+    blockchainWriter.storeBlockHeader(Fixtures.Blocks.Genesis.header).commit()
 
     override lazy val blockchainConfig = Config.blockchains.blockchainConfig
     val forkResolver = new ForkResolver.EtcForkResolver(blockchainConfig.daoForkConfig.get)

--- a/src/test/scala/io/iohk/ethereum/network/handshaker/EtcHandshakerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/network/handshaker/EtcHandshakerSpec.scala
@@ -72,7 +72,7 @@ class EtcHandshakerSpec extends AnyFlatSpec with Matchers {
 
     val newChainWeight = ChainWeight.zero.increase(genesisBlock.header).increase(firstBlock.header)
 
-    blockchain.save(firstBlock, Nil, newChainWeight, saveAsBestBlock = true)
+    blockchainWriter.save(firstBlock, Nil, newChainWeight, saveAsBestBlock = true)
 
     val newLocalStatusMsg =
       localStatusMsg.copy(totalDifficulty = newChainWeight.totalDifficulty, bestHash = firstBlock.header.hash)
@@ -98,7 +98,7 @@ class EtcHandshakerSpec extends AnyFlatSpec with Matchers {
 
     val newChainWeight = ChainWeight.zero.increase(genesisBlock.header).increase(firstBlock.header)
 
-    blockchain.save(firstBlock, Nil, newChainWeight, saveAsBestBlock = true)
+    blockchainWriter.save(firstBlock, Nil, newChainWeight, saveAsBestBlock = true)
 
     val newLocalStatusMsg =
       localStatusMsg
@@ -269,7 +269,7 @@ class EtcHandshakerSpec extends AnyFlatSpec with Matchers {
 
     val forkBlockHeader = Fixtures.Blocks.DaoForkBlock.header
 
-    blockchain.save(genesisBlock, Nil, genesisWeight, saveAsBestBlock = true)
+    blockchainWriter.save(genesisBlock, Nil, genesisWeight, saveAsBestBlock = true)
 
     val nodeStatus: NodeStatus = NodeStatus(
       key = generateKeyPair(secureRandom),

--- a/src/test/scala/io/iohk/ethereum/network/p2p/PeerActorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/network/p2p/PeerActorSpec.scala
@@ -535,7 +535,7 @@ class PeerActorSpec
     val genesisBlock = Fixtures.Blocks.Genesis.block
     val genesisWeight: ChainWeight = ChainWeight.totalDifficultyOnly(genesisBlock.header.difficulty)
 
-    blockchain.save(genesisBlock, Nil, genesisWeight, saveAsBestBlock = true)
+    blockchainWriter.save(genesisBlock, Nil, genesisWeight, saveAsBestBlock = true)
 
     val daoForkBlockNumber = 1920000
 

--- a/src/test/scala/io/iohk/ethereum/network/p2p/PeerActorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/network/p2p/PeerActorSpec.scala
@@ -301,7 +301,7 @@ class PeerActorSpec
         .copy(difficulty = daoForkBlockChainTotalDifficulty + 100000, number = 3000000)
     storagesInstance.storages.appStateStorage
       .putBestBlockNumber(3000000) // after the fork
-      .and(blockchain.storeBlockHeader(header))
+      .and(blockchainWriter.storeBlockHeader(header))
       .and(storagesInstance.storages.blockNumberMappingStorage.put(3000000, header.hash))
       .commit()
 
@@ -366,7 +366,7 @@ class PeerActorSpec
 
   it should "respond to fork block request during the handshake" in new TestSetup {
     //Save dao fork block
-    blockchain.storeBlockHeader(Fixtures.Blocks.DaoForkBlock.header).commit()
+    blockchainWriter.storeBlockHeader(Fixtures.Blocks.DaoForkBlock.header).commit()
 
     //Handshake till EtcForkBlockExchangeState
     peer ! PeerActor.ConnectTo(new URI("encode://localhost:9000"))

--- a/src/test/scala/io/iohk/ethereum/transactions/TransactionHistoryServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/transactions/TransactionHistoryServiceSpec.scala
@@ -81,10 +81,10 @@ class TransactionHistoryServiceSpec
 
     for {
       _ <- Task {
-        blockchain
+        blockchainWriter
           .storeBlock(blockWithTx1)
           .and(blockchain.storeReceipts(blockWithTx1.hash, blockTx1Receipts))
-          .and(blockchain.storeBlock(blockWithTxs2and3))
+          .and(blockchainWriter.storeBlock(blockWithTxs2and3))
           .and(blockchain.storeReceipts(blockWithTxs2and3.hash, blockTx2And3Receipts))
           .commit()
       }
@@ -107,7 +107,7 @@ class TransactionHistoryServiceSpec
         Seq(ExtendedTransactionData(signedTx.tx, isOutgoing = true, None))
 
       for {
-        _ <- Task(blockchain.storeBlock(blockWithTx).commit())
+        _ <- Task(blockchainWriter.storeBlock(blockWithTx).commit())
         _ <- Task(pendingTransactionManager.ref ! PendingTransactionsManager.AddTransactions(signedTx))
         response <- transactionHistoryService.getAccountTransactions(
           signedTx.senderAddress,


### PR DESCRIPTION
# Description
This PR starts the refactoring of the "write layer" by moving the methods `save` and `storeBlock` to a `BlockchainWriter`. 
By consequence `storeReceipts`, `storeChainWeight`, `storeBlockHeader`, `storeBlockBody` were also moved
`BlockchainWriter` is not a final name.  
The `bestKnownBlockAndLatestCheckpoint` was also moved to a `BlockchainMetadata` class

