### PR TITLE
ETCM-986 Remove method storeEvmCode from Blockchain

### DIFF
--- a/src/it/scala/io/iohk/ethereum/txExecTest/util/DumpChainApp.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/util/DumpChainApp.scala
@@ -191,8 +191,6 @@ class BlockchainMock(genesisHash: ByteString) extends Blockchain {
 
   override def storeReceipts(blockHash: ByteString, receipts: Seq[Receipt]): DataSourceBatchUpdate = ???
 
-  override def storeEvmCode(hash: ByteString, evmCode: ByteString): DataSourceBatchUpdate = ???
-
   override def storeChainWeight(blockhash: ByteString, chainWeight: ChainWeight): DataSourceBatchUpdate = ???
 
   override def saveNode(nodeHash: NodeHash, nodeEncoded: NodeEncoded, blockNumber: BigInt): Unit = ???

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/fast/SyncStateScheduler.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/fast/SyncStateScheduler.scala
@@ -132,10 +132,8 @@ class SyncStateScheduler(
     nodes.foreach { case (hash, (data, reqType)) =>
       bloomFilter.put(hash)
       reqType match {
-        case _: CodeRequest =>
-          blockchain.storeEvmCode(hash, data).commit()
-        case _: NodeRequest =>
-          blockchain.saveNode(hash, data.toArray, targetBlockNumber)
+        case _: CodeRequest => evmCodeStorage.put(hash, data).commit()
+        case _: NodeRequest => blockchain.saveNode(hash, data.toArray, targetBlockNumber)
       }
     }
     newState

--- a/src/main/scala/io/iohk/ethereum/db/components/Storages.scala
+++ b/src/main/scala/io/iohk/ethereum/db/components/Storages.scala
@@ -31,7 +31,7 @@ object Storages {
 
       override val nodeStorage: NodeStorage = new NodeStorage(dataSource)
 
-      override val cachedNodeStorage: CachedNodeStorage = new CachedNodeStorage(nodeStorage, caches.nodeCache)
+      val cachedNodeStorage: CachedNodeStorage = new CachedNodeStorage(nodeStorage, caches.nodeCache)
 
       override val fastSyncStateStorage: FastSyncStateStorage = new FastSyncStateStorage(dataSource)
 

--- a/src/main/scala/io/iohk/ethereum/domain/Blockchain.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/Blockchain.scala
@@ -111,8 +111,6 @@ trait Blockchain {
 
   def storeReceipts(blockHash: ByteString, receipts: Seq[Receipt]): DataSourceBatchUpdate
 
-  def storeEvmCode(hash: ByteString, evmCode: ByteString): DataSourceBatchUpdate
-
   def storeChainWeight(blockhash: ByteString, weight: ChainWeight): DataSourceBatchUpdate
 
   def saveBestKnownBlocks(bestBlockNumber: BigInt, latestCheckpointNumber: Option[BigInt] = None): Unit
@@ -137,7 +135,6 @@ class BlockchainImpl(
     protected val blockBodiesStorage: BlockBodiesStorage,
     protected val blockNumberMappingStorage: BlockNumberMappingStorage,
     protected val receiptStorage: ReceiptStorage,
-    protected val evmCodeStorage: EvmCodeStorage,
     protected val chainWeightStorage: ChainWeightStorage,
     protected val transactionMappingStorage: TransactionMappingStorage,
     protected val appStateStorage: AppStateStorage,
@@ -305,9 +302,6 @@ class BlockchainImpl(
   override def storeReceipts(blockHash: ByteString, receipts: Seq[Receipt]): DataSourceBatchUpdate =
     receiptStorage.put(blockHash, receipts)
 
-  override def storeEvmCode(hash: ByteString, evmCode: ByteString): DataSourceBatchUpdate =
-    evmCodeStorage.put(hash, evmCode)
-
   override def saveBestKnownBlocks(bestBlockNumber: BigInt, latestCheckpointNumber: Option[BigInt] = None): Unit =
     latestCheckpointNumber match {
       case Some(number) =>
@@ -463,7 +457,6 @@ trait BlockchainStorages {
   val chainWeightStorage: ChainWeightStorage
   val transactionMappingStorage: TransactionMappingStorage
   val appStateStorage: AppStateStorage
-  val cachedNodeStorage: CachedNodeStorage
   val stateStorage: StateStorage
 }
 
@@ -474,7 +467,6 @@ object BlockchainImpl {
       blockBodiesStorage = storages.blockBodiesStorage,
       blockNumberMappingStorage = storages.blockNumberMappingStorage,
       receiptStorage = storages.receiptStorage,
-      evmCodeStorage = storages.evmCodeStorage,
       chainWeightStorage = storages.chainWeightStorage,
       transactionMappingStorage = storages.transactionMappingStorage,
       appStateStorage = storages.appStateStorage,

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/TestService.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/TestService.scala
@@ -21,6 +21,7 @@ import io.iohk.ethereum.consensus.ConsensusConfig
 import io.iohk.ethereum.consensus.blocks._
 import io.iohk.ethereum.crypto
 import io.iohk.ethereum.crypto.kec256
+import io.iohk.ethereum.db.storage.EvmCodeStorage
 import io.iohk.ethereum.db.storage.StateStorage
 import io.iohk.ethereum.db.storage.TransactionMappingStorage
 import io.iohk.ethereum.domain
@@ -133,6 +134,7 @@ class TestService(
     blockchain: BlockchainImpl,
     blockchainReader: BlockchainReader,
     stateStorage: StateStorage,
+    evmCodeStorage: EvmCodeStorage,
     pendingTransactionsManager: ActorRef,
     consensusConfig: ConsensusConfig,
     testModeComponentsProvider: TestModeComponentsProvider,
@@ -243,7 +245,7 @@ class TestService(
   private def storeGenesisAccountCodes(accounts: Map[String, GenesisAccount]): Unit =
     accounts
       .collect { case (_, GenesisAccount(_, _, Some(code), _, _)) => code }
-      .foreach(code => blockchain.storeEvmCode(kec256(code), code).commit())
+      .foreach(code => evmCodeStorage.put(kec256(code), code).commit())
 
   private def storeGenesisAccountStorageData(accounts: Map[String, GenesisAccount]): Unit = {
     val emptyStorage = domain.EthereumUInt256Mpt.storageMpt(

--- a/src/main/scala/io/iohk/ethereum/ledger/BlockExecution.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/BlockExecution.scala
@@ -7,7 +7,6 @@ import scala.annotation.tailrec
 import io.iohk.ethereum.db.storage.EvmCodeStorage
 import io.iohk.ethereum.domain._
 import io.iohk.ethereum.ledger.BlockExecutionError.MissingParentError
-import io.iohk.ethereum.ledger.BlockResult
 import io.iohk.ethereum.mpt.MerklePatriciaTrie.MPTException
 import io.iohk.ethereum.utils.BlockchainConfig
 import io.iohk.ethereum.utils.DaoForkConfig

--- a/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
@@ -441,6 +441,7 @@ trait TestServiceBuilder {
       blockchain,
       blockchainReader,
       storagesInstance.storages.stateStorage,
+      storagesInstance.storages.evmCodeStorage,
       pendingTransactionsManager,
       consensusConfig,
       testModeComponentsProvider,

--- a/src/main/scala/io/iohk/ethereum/testmode/TestBlockchainBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/testmode/TestBlockchainBuilder.scala
@@ -14,7 +14,6 @@ trait TestBlockchainBuilder extends BlockchainBuilder {
       blockBodiesStorage = storages.blockBodiesStorage,
       blockNumberMappingStorage = storages.blockNumberMappingStorage,
       receiptStorage = storages.receiptStorage,
-      evmCodeStorage = storages.evmCodeStorage,
       chainWeightStorage = storages.chainWeightStorage,
       transactionMappingStorage = storages.transactionMappingStorage,
       appStateStorage = storages.appStateStorage,

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/BlockchainHostActorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/BlockchainHostActorSpec.scala
@@ -245,7 +245,7 @@ class BlockchainHostActorSpec extends AnyFlatSpec with Matchers {
     val fakeEvmCode = ByteString(Hex.decode("ffddaaffddaaffddaaffddaaffddaa"))
     val evmCodeHash: ByteString = ByteString(crypto.kec256(fakeEvmCode.toArray[Byte]))
 
-    blockchain.storeEvmCode(evmCodeHash, fakeEvmCode).commit()
+    storagesInstance.storages.evmCodeStorage.put(evmCodeHash, fakeEvmCode).commit()
 
     //when
     blockchainHost ! MessageFromPeer(GetNodeData(Seq(evmCodeHash)), peerId)

--- a/src/test/scala/io/iohk/ethereum/domain/BlockchainSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/domain/BlockchainSpec.scala
@@ -298,7 +298,6 @@ class BlockchainSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyCh
           storagesInstance.storages.nodeStorage
           storagesInstance.storages.pruningMode
           val appStateStorage = storagesInstance.storages.appStateStorage
-          val cachedNodeStorage = storagesInstance.storages.cachedNodeStorage
           val stateStorage = stubStateStorage
         }
         override val blockchainReaderWithStubPersisting = BlockchainReader(blockchainStoragesWithStubPersisting)


### PR DESCRIPTION
# Description

Remove method storeEvmCode from Blockchain class and use EvmCodestorage direclty

# Proposed Solution
The method "storeEvmCode" just makes a direct call to the EvmStorage and is only used by a class and a couple of test classes

The code will be modified to have the EvmStorage called directly
