### PR TITLE
[kaizen] Create EmptyBlochainBranch 

### DIFF
--- a/src/it/scala/io/iohk/ethereum/sync/RegularSyncItSpec.scala
+++ b/src/it/scala/io/iohk/ethereum/sync/RegularSyncItSpec.scala
@@ -124,7 +124,7 @@ class RegularSyncItSpec extends FreeSpecBase with Matchers with BeforeAndAfterAl
       _ <- peer2.importBlocksUntil(30)(IdentityUpdate)
       _ <- peer1.startRegularSync()
       _ <- peer2.startRegularSync()
-      _ <- peer2.addCheckpointedBlock(peer2.blockchainReader.getBestBranch().get.getBlockByNumber(25).get)
+      _ <- peer2.addCheckpointedBlock(peer2.blockchainReader.getBestBranch().getBlockByNumber(25).get)
       _ <- peer2.waitForRegularSyncLoadLastBlock(length)
       _ <- peer1.connectToPeers(Set(peer2.node))
       _ <- peer1.waitForRegularSyncLoadLastBlock(length)
@@ -181,8 +181,8 @@ class RegularSyncItSpec extends FreeSpecBase with Matchers with BeforeAndAfterAl
         )
       )
       (
-        peer1.blockchainReader.getBestBranch().get.getBlockByNumber(blockNumer + 1),
-        peer2.blockchainReader.getBestBranch().get.getBlockByNumber(blockNumer + 1)
+        peer1.blockchainReader.getBestBranch().getBlockByNumber(blockNumer + 1),
+        peer2.blockchainReader.getBestBranch().getBlockByNumber(blockNumer + 1)
       ) match {
         case (Some(blockP1), Some(blockP2)) =>
           assert(peer1.bl.getChainWeightByHash(blockP1.hash) == peer2.bl.getChainWeightByHash(blockP2.hash))

--- a/src/it/scala/io/iohk/ethereum/sync/util/RegularSyncItSpecUtils.scala
+++ b/src/it/scala/io/iohk/ethereum/sync/util/RegularSyncItSpecUtils.scala
@@ -185,7 +185,6 @@ object RegularSyncItSpecUtils {
         case Some(bNumber) =>
           blockchainReader
             .getBestBranch()
-            .get
             .getBlockByNumber(bNumber)
             .getOrElse(throw new RuntimeException(s"block by number: $bNumber doesn't exist"))
         case None => blockchainReader.getBestBlock().get

--- a/src/it/scala/io/iohk/ethereum/txExecTest/util/DumpChainApp.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/util/DumpChainApp.scala
@@ -104,7 +104,7 @@ object DumpChainApp
   val blockchain: Blockchain = new BlockchainMock(genesisHash)
   val blockchainReader: BlockchainReader = mock[BlockchainReader]
   val bestChain: BlockchainBranch = mock[BlockchainBranch]
-  (blockchainReader.getBestBranch _).expects().anyNumberOfTimes().returning(Some(bestChain))
+  (blockchainReader.getBestBranch _).expects().anyNumberOfTimes().returning(bestChain)
   (bestChain.getHashByBlockNumber _).expects(*).returning(Some(genesisHash))
 
   val nodeStatus: NodeStatus =

--- a/src/main/scala/io/iohk/ethereum/consensus/pow/validators/OmmersValidator.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/pow/validators/OmmersValidator.scala
@@ -33,7 +33,7 @@ trait OmmersValidator {
     val getNBlocksBack: (ByteString, Int) => List[Block] =
       (_, n) =>
         ((blockNumber - n) until blockNumber).toList
-          .flatMap(nb => bestBranch.flatMap(_.getBlockByNumber(nb)))
+          .flatMap(nb => bestBranch.getBlockByNumber(nb))
 
     validate(parentHash, blockNumber, ommers, getBlockHeaderByHash, getNBlocksBack)
   }

--- a/src/main/scala/io/iohk/ethereum/domain/Blockchain.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/Blockchain.scala
@@ -107,8 +107,7 @@ class BlockchainImpl(
   override def isInChain(hash: ByteString): Boolean =
     (for {
       header <- blockchainReader.getBlockHeaderByHash(hash) if header.number <= blockchainReader.getBestBlockNumber()
-      bestBranch <- blockchainReader.getBestBranch()
-      hash <- bestBranch.getHashByBlockNumber(header.number)
+      hash <- blockchainReader.getBestBranch().getHashByBlockNumber(header.number)
     } yield header.hash == hash).getOrElse(false)
 
   override def getChainWeightByHash(blockhash: ByteString): Option[ChainWeight] = chainWeightStorage.get(blockhash)
@@ -231,7 +230,7 @@ class BlockchainImpl(
     val latestCheckpointNumber = getLatestCheckpointBlockNumber()
 
     val blockNumberMappingUpdates =
-      if (blockchainReader.getBestBranch().flatMap(_.getHashByBlockNumber(block.number)).contains(blockHash))
+      if (blockchainReader.getBestBranch().getHashByBlockNumber(block.number).contains(blockHash))
         removeBlockNumberMapping(block.number)
       else blockNumberMappingStorage.emptyBatchUpdate
 
@@ -300,7 +299,7 @@ class BlockchainImpl(
   ): BigInt =
     if (blockNumberToCheck > 0) {
       val maybePreviousCheckpointBlockNumber = for {
-        currentBlock <- blockchainReader.getBestBranch().flatMap(_.getBlockByNumber(blockNumberToCheck))
+        currentBlock <- blockchainReader.getBestBranch().getBlockByNumber(blockNumberToCheck)
         if currentBlock.hasCheckpoint &&
           currentBlock.number < latestCheckpointBlockNumber
       } yield currentBlock.number

--- a/src/main/scala/io/iohk/ethereum/domain/BlockchainReader.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/BlockchainReader.scala
@@ -10,6 +10,7 @@ import io.iohk.ethereum.db.storage.ReceiptStorage
 import io.iohk.ethereum.db.storage.StateStorage
 import io.iohk.ethereum.domain.branch.BestBlockchainBranch
 import io.iohk.ethereum.domain.branch.BlockchainBranch
+import io.iohk.ethereum.domain.branch.EmptyBlockchainBranch
 import io.iohk.ethereum.mpt.MptNode
 import io.iohk.ethereum.utils.Logger
 
@@ -70,16 +71,16 @@ class BlockchainReader(
   def getReceiptsByHash(blockhash: ByteString): Option[Seq[Receipt]] = receiptStorage.get(blockhash)
 
   /** get the current best stored branch */
-  // FIXME this should not be an option as we should always have the genesis
-  // but some tests prevent it to simply be BlockchainBranch for now
-  def getBestBranch(): Option[BlockchainBranch] =
-    getBestBlock().map { block =>
-      new BestBlockchainBranch(
-        block.header,
-        blockNumberMappingStorage,
-        this
-      )
-    }
+  def getBestBranch(): BlockchainBranch =
+    getBestBlock()
+      .map { block =>
+        new BestBlockchainBranch(
+          block.header,
+          blockNumberMappingStorage,
+          this
+        )
+      }
+      .getOrElse(EmptyBlockchainBranch)
 
   def getBestBlockNumber(): BigInt = {
     val bestSavedBlockNumber = appStateStorage.getBestBlockNumber()

--- a/src/main/scala/io/iohk/ethereum/domain/branch/EmptyBlockchainBranch.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/branch/EmptyBlockchainBranch.scala
@@ -1,0 +1,11 @@
+package io.iohk.ethereum.domain.branch
+import akka.util.ByteString
+
+import io.iohk.ethereum.domain.Block
+
+object EmptyBlockchainBranch extends BlockchainBranch {
+
+  override def getBlockByNumber(number: BigInt): Option[Block] = None
+
+  override def getHashByBlockNumber(number: BigInt): Option[ByteString] = None
+}

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/CheckpointingService.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/CheckpointingService.scala
@@ -36,7 +36,7 @@ class CheckpointingService(
       req.parentCheckpoint.forall(blockchainReader.getBlockHeaderByHash(_).exists(_.number < blockToReturnNum))
 
     Task {
-      blockchainReader.getBestBranch().flatMap(_.getBlockByNumber(blockToReturnNum))
+      blockchainReader.getBestBranch().getBlockByNumber(blockToReturnNum)
     }.flatMap {
       case Some(b) if isValidParent =>
         Task.now(Right(GetLatestBlockResponse(Some(BlockInfo(b.hash, b.number)))))

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/EthProofService.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/EthProofService.scala
@@ -206,7 +206,7 @@ class EthProofService(
     def getBlock(number: BigInt): Either[JsonRpcError, Block] =
       blockchainReader
         .getBestBranch()
-        .flatMap(_.getBlockByNumber(number))
+        .getBlockByNumber(number)
         .toRight(JsonRpcError.InvalidParams(s"Block $number not found"))
 
     def getLatestBlock(): Either[JsonRpcError, Block] =

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/EthTxService.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/EthTxService.scala
@@ -158,7 +158,7 @@ class EthTxService(
     Task {
       val bestBranch = blockchainReader.getBestBranch()
       val gasPrice = ((bestBlock - blockDifference) to bestBlock)
-        .flatMap(nb => bestBranch.flatMap(_.getBlockByNumber(nb)))
+        .flatMap(nb => bestBranch.getBlockByNumber(nb))
         .flatMap(_.body.transactionList)
         .map(_.tx.gasPrice)
       if (gasPrice.nonEmpty) {

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/ResolveBlock.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/ResolveBlock.scala
@@ -35,7 +35,7 @@ trait ResolveBlock {
   private def getBlock(number: BigInt): Either[JsonRpcError, Block] =
     blockchainReader
       .getBestBranch()
-      .flatMap(_.getBlockByNumber(number))
+      .getBlockByNumber(number)
       .toRight(JsonRpcError.InvalidParams(s"Block $number not found"))
 
   private def getLatestBlock(): Either[JsonRpcError, Block] =

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/TestService.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/TestService.scala
@@ -372,7 +372,7 @@ class TestService(
 
     val blockOpt = request.parameters.blockHashOrNumber
       .fold(
-        number => blockchainReader.getBestBranch().flatMap(_.getBlockByNumber(number)),
+        number => blockchainReader.getBestBranch().getBlockByNumber(number),
         blockHash => blockchainReader.getBlockByHash(blockHash)
       )
 
@@ -412,7 +412,7 @@ class TestService(
 
     val blockOpt = request.parameters.blockHashOrNumber
       .fold(
-        number => blockchainReader.getBestBranch().flatMap(_.getBlockByNumber(number)),
+        number => blockchainReader.getBestBranch().getBlockByNumber(number),
         hash => blockchainReader.getBlockByHash(hash)
       )
 

--- a/src/main/scala/io/iohk/ethereum/ledger/BlockImport.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/BlockImport.scala
@@ -305,7 +305,7 @@ class BlockImport(
   private def removeBlocksUntil(parent: ByteString, fromNumber: BigInt): List[BlockData] = {
     @tailrec
     def removeBlocksUntil(parent: ByteString, fromNumber: BigInt, acc: List[BlockData]): List[BlockData] =
-      blockchainReader.getBestBranch().flatMap(_.getBlockByNumber(fromNumber)) match {
+      blockchainReader.getBestBranch().getBlockByNumber(fromNumber) match {
         case Some(block) if block.header.hash == parent || fromNumber == 0 =>
           acc
 

--- a/src/main/scala/io/iohk/ethereum/ledger/BlockValidation.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/BlockValidation.scala
@@ -43,7 +43,7 @@ class BlockValidation(
           val numbers = (block.header.number - remaining) until block.header.number
           val bestBranch = blockchainReader.getBestBranch()
           val blocks =
-            (numbers.toList.flatMap(nb => bestBranch.flatMap(_.getBlockByNumber(nb))) :+ block) ::: queuedBlocks
+            (numbers.toList.flatMap(nb => bestBranch.getBlockByNumber(nb)) :+ block) ::: queuedBlocks
           blocks
       }
     }

--- a/src/main/scala/io/iohk/ethereum/ledger/BranchResolution.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/BranchResolution.scala
@@ -75,7 +75,7 @@ class BranchResolution(blockchain: Blockchain, blockchainReader: BlockchainReade
   private def getTopBlocksFromNumber(from: BigInt): List[Block] = {
     val bestBranch = blockchainReader.getBestBranch()
     (from to blockchainReader.getBestBlockNumber())
-      .flatMap(nb => bestBranch.flatMap(_.getBlockByNumber(nb)))
+      .flatMap(nb => bestBranch.getBlockByNumber(nb))
       .toList
   }
 }

--- a/src/main/scala/io/iohk/ethereum/testmode/TestEthBlockServiceWrapper.scala
+++ b/src/main/scala/io/iohk/ethereum/testmode/TestEthBlockServiceWrapper.scala
@@ -75,7 +75,7 @@ class TestEthBlockServiceWrapper(
     .getBlockByNumber(request)
     .map(
       _.map { blockByBlockResponse =>
-        val bestBranch = blockchainReader.getBestBranch().get
+        val bestBranch = blockchainReader.getBestBranch()
         val fullBlock = bestBranch.getBlockByNumber(blockByBlockResponse.blockResponse.get.number).get
         BlockByNumberResponse(blockByBlockResponse.blockResponse.map(response => toEthResponse(fullBlock, response)))
       }

--- a/src/main/scala/io/iohk/ethereum/transactions/TransactionHistoryService.scala
+++ b/src/main/scala/io/iohk/ethereum/transactions/TransactionHistoryService.scala
@@ -33,7 +33,7 @@ class TransactionHistoryService(
     val getLastCheckpoint = Task(blockchain.getLatestCheckpointBlockNumber()).memoizeOnSuccess
     val txnsFromBlocks = Observable
       .from(fromBlocks.reverse)
-      .mapParallelOrdered(10)(blockNr => Task(blockchainReader.getBestBranch().flatMap(_.getBlockByNumber(blockNr))))(
+      .mapParallelOrdered(10)(blockNr => Task(blockchainReader.getBestBranch().getBlockByNumber(blockNr)))(
         OverflowStrategy.Unbounded
       )
       .collect { case Some(block) => block }

--- a/src/test/scala/io/iohk/ethereum/consensus/pow/validators/StdOmmersValidatorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/pow/validators/StdOmmersValidatorSpec.scala
@@ -81,7 +81,7 @@ class StdOmmersValidatorSpec extends AnyFlatSpec with Matchers with ScalaCheckPr
     val getNBlocksBack: (ByteString, Int) => List[Block] =
       (_, n) =>
         ((ommersBlockNumber - n) until ommersBlockNumber).toList
-          .flatMap(nb => blockchainReader.getBestBranch().flatMap(_.getBlockByNumber(nb)))
+          .flatMap(nb => blockchainReader.getBestBranch().getBlockByNumber(nb))
 
     ommersValidator.validateOmmersAncestors(
       ommersBlockParentHash,

--- a/src/test/scala/io/iohk/ethereum/domain/BlockchainSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/domain/BlockchainSpec.scala
@@ -45,7 +45,7 @@ class BlockchainSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyCh
     val validBlock = Fixtures.Blocks.ValidBlock.block
     blockchainWriter.storeBlock(validBlock).commit()
     blockchain.saveBestKnownBlocks(validBlock.number)
-    val block = blockchainReader.getBestBranch().get.getBlockByNumber(validBlock.header.number)
+    val block = blockchainReader.getBestBranch().getBlockByNumber(validBlock.header.number)
     block.isDefined should ===(true)
     validBlock should ===(block.get)
   }
@@ -70,7 +70,7 @@ class BlockchainSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyCh
   it should "not return a value if not stored" in new EphemBlockchainTestSetup {
     blockchainReader
       .getBestBranch()
-      .flatMap(_.getBlockByNumber(Fixtures.Blocks.ValidBlock.header.number)) shouldBe None
+      .getBlockByNumber(Fixtures.Blocks.ValidBlock.header.number) shouldBe None
     blockchainReader.getBlockByHash(Fixtures.Blocks.ValidBlock.header.hash) shouldBe None
   }
 

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/CheckpointingServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/CheckpointingServiceSpec.scala
@@ -187,7 +187,7 @@ class CheckpointingServiceSpec
     val blockchain: BlockchainImpl = mock[BlockchainImpl]
     val blockchainReader: BlockchainReader = mock[BlockchainReader]
     val bestChain: BlockchainBranch = mock[BlockchainBranch]
-    (blockchainReader.getBestBranch _).expects().anyNumberOfTimes().returning(Some(bestChain))
+    (blockchainReader.getBestBranch _).expects().anyNumberOfTimes().returning(bestChain)
     val blockQueue: BlockQueue = mock[BlockQueue]
     val syncController: TestProbe = TestProbe()
     val checkpointBlockGenerator: CheckpointBlockGenerator = new CheckpointBlockGenerator()

--- a/src/test/scala/io/iohk/ethereum/ledger/LedgerTestSetup.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/LedgerTestSetup.scala
@@ -415,7 +415,7 @@ trait MockBlockchain extends MockFactory { self: TestSetupWithVmAndValidators =>
   val bestChain: BlockchainBranch = mock[BlockchainBranch]
   override lazy val blockchainReader: BlockchainReader = mock[BlockchainReader]
   override lazy val blockchainWriter: BlockchainWriter = mock[BlockchainWriter]
-  (blockchainReader.getBestBranch _).expects().anyNumberOfTimes().returning(Some(bestChain))
+  (blockchainReader.getBestBranch _).expects().anyNumberOfTimes().returning(bestChain)
   override lazy val blockchain: BlockchainImpl = mock[BlockchainImpl]
   //- cake overrides
 


### PR DESCRIPTION
# Description

This is a proposal to make `getBestChain` usage more readable.

In my current PR #1039, `getBestChain` returns an `Option`. This does not really make sense as we at least should have a genesis so we always should be able to provide some chain. However the unit tests do not always set up a genesis so this assumption is not always true, and fixing this in the tests might be tricky. This means currently we have to put up  with an awkward `Option` and `flatMap`s in the code while in normal usage `None` would be a consistency error in the application.

This PR is a compromise where I introduce a new implementation with represent an empty chain (it always tell that a block is not in the chain). This way the interface is nicer, but we don't have to create a fully consistent test environment in unit tests. I'm not certain this is the best way because it does not exactly solves the problem at hand (we still have a concept of empty chain which does not exactly exist in the "real world"). But it seems to be that it is an easy way to have the interface we should have, with no real downside compared to a plain `Option`. 

Any thought ? 
