### PR TITLE
[ETCM-980] encode empty "to" address in transaction RPC reply

### DIFF
--- a/src/main/scala/io/iohk/ethereum/jsonrpc/serialization/JsonSerializers.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/serialization/JsonSerializers.scala
@@ -6,7 +6,6 @@ import org.bouncycastle.util.encoders.Hex
 import org.json4s.CustomSerializer
 import org.json4s.DefaultFormats
 import org.json4s.Formats
-import org.json4s.JNull
 import org.json4s.JString
 
 import io.iohk.ethereum.domain.Address
@@ -14,7 +13,7 @@ import io.iohk.ethereum.jsonrpc.JsonRpcError
 
 object JsonSerializers {
   implicit val formats: Formats =
-    DefaultFormats + UnformattedDataJsonSerializer + QuantitiesSerializer + OptionNoneToJNullSerializer + AddressJsonSerializer
+    DefaultFormats.preservingEmptyValues + UnformattedDataJsonSerializer + QuantitiesSerializer + AddressJsonSerializer
 
   object UnformattedDataJsonSerializer
       extends CustomSerializer[ByteString](_ =>
@@ -34,14 +33,6 @@ object JsonSerializers {
             else
               JString(s"0x${Hex.toHexString(n.toByteArray).dropWhile(_ == '0')}")
           }
-        )
-      )
-
-  object OptionNoneToJNullSerializer
-      extends CustomSerializer[Option[_]](formats =>
-        (
-          PartialFunction.empty,
-          { case None => JNull }
         )
       )
 

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/serialization/JsonSerializers.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/serialization/JsonSerializers.scala
@@ -5,15 +5,17 @@ import akka.util.ByteString
 import org.bouncycastle.util.encoders.Hex
 import org.json4s.CustomSerializer
 import org.json4s.DefaultFormats
+import org.json4s.Extraction
 import org.json4s.Formats
 import org.json4s.JString
 
 import io.iohk.ethereum.domain.Address
 import io.iohk.ethereum.jsonrpc.JsonRpcError
+import io.iohk.ethereum.testmode.EthTransactionResponse
 
 object JsonSerializers {
   implicit val formats: Formats =
-    DefaultFormats.preservingEmptyValues + UnformattedDataJsonSerializer + QuantitiesSerializer + AddressJsonSerializer
+    DefaultFormats + UnformattedDataJsonSerializer + QuantitiesSerializer + AddressJsonSerializer + EthTransactionResponseSerializer
 
   object UnformattedDataJsonSerializer
       extends CustomSerializer[ByteString](_ =>
@@ -52,4 +54,19 @@ object JsonSerializers {
         )
       )
 
+  /** Specific EthTransactionResponse serializer.
+    * It's purpose is to encode the optional "to" field, as requested by
+    * retesteth
+    */
+  object EthTransactionResponseSerializer
+      extends CustomSerializer[EthTransactionResponse](_ =>
+        (
+          PartialFunction.empty,
+          { case tx: EthTransactionResponse =>
+            implicit val formats =
+              DefaultFormats.preservingEmptyValues + UnformattedDataJsonSerializer + QuantitiesSerializer + AddressJsonSerializer
+            Extraction.decompose(tx)
+          }
+        )
+      )
 }

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerEthLegacyTransactionSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerEthLegacyTransactionSpec.scala
@@ -8,9 +8,7 @@ import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 
 import org.bouncycastle.util.encoders.Hex
-import org.json4s.DefaultFormats
 import org.json4s.Extraction
-import org.json4s.Formats
 import org.json4s.JsonAST._
 import org.json4s.JsonDSL._
 import org.scalatest.concurrent.Eventually
@@ -29,9 +27,6 @@ import io.iohk.ethereum.jsonrpc.EthTxService._
 import io.iohk.ethereum.jsonrpc.EthUserService._
 import io.iohk.ethereum.jsonrpc.FilterManager.TxLog
 import io.iohk.ethereum.jsonrpc.PersonalService._
-import io.iohk.ethereum.jsonrpc.serialization.JsonSerializers.OptionNoneToJNullSerializer
-import io.iohk.ethereum.jsonrpc.serialization.JsonSerializers.QuantitiesSerializer
-import io.iohk.ethereum.jsonrpc.serialization.JsonSerializers.UnformattedDataJsonSerializer
 import io.iohk.ethereum.transactions.PendingTransactionsManager.PendingTransaction
 
 // scalastyle:off magic.number
@@ -45,9 +40,6 @@ class JsonRpcControllerEthLegacyTransactionSpec
     with ScalaFutures
     with LongPatience
     with Eventually {
-
-  implicit val formats: Formats = DefaultFormats.preservingEmptyValues + OptionNoneToJNullSerializer +
-    QuantitiesSerializer + UnformattedDataJsonSerializer
 
   it should "handle eth_getTransactionByBlockHashAndIndex request" in new JsonRpcControllerFixture {
     val blockToRequest = Block(Fixtures.Blocks.Block3125369.header, Fixtures.Blocks.Block3125369.body)

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerEthSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerEthSpec.scala
@@ -8,9 +8,7 @@ import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 
 import org.bouncycastle.util.encoders.Hex
-import org.json4s.DefaultFormats
 import org.json4s.Extraction
-import org.json4s.Formats
 import org.json4s.JsonAST._
 import org.json4s.JsonDSL._
 import org.scalatest.concurrent.Eventually
@@ -40,9 +38,6 @@ import io.iohk.ethereum.jsonrpc.ProofService.GetProofResponse
 import io.iohk.ethereum.jsonrpc.ProofService.ProofAccount
 import io.iohk.ethereum.jsonrpc.ProofService.StorageProofKey
 import io.iohk.ethereum.jsonrpc.ProofService.StorageValueProof
-import io.iohk.ethereum.jsonrpc.serialization.JsonSerializers.OptionNoneToJNullSerializer
-import io.iohk.ethereum.jsonrpc.serialization.JsonSerializers.QuantitiesSerializer
-import io.iohk.ethereum.jsonrpc.serialization.JsonSerializers.UnformattedDataJsonSerializer
 import io.iohk.ethereum.ommers.OmmersPool
 import io.iohk.ethereum.ommers.OmmersPool.Ommers
 import io.iohk.ethereum.testing.ActorsTesting.simpleAutoPilot
@@ -58,9 +53,6 @@ class JsonRpcControllerEthSpec
     with ScalaFutures
     with LongPatience
     with Eventually {
-
-  implicit val formats: Formats = DefaultFormats.preservingEmptyValues + OptionNoneToJNullSerializer +
-    QuantitiesSerializer + UnformattedDataJsonSerializer
 
   it should "eth_protocolVersion" in new JsonRpcControllerFixture {
     val rpcRequest = newJsonRpcRequest("eth_protocolVersion")

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerPersonalSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerPersonalSpec.scala
@@ -10,8 +10,6 @@ import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 
 import org.bouncycastle.util.encoders.Hex
-import org.json4s.DefaultFormats
-import org.json4s.Formats
 import org.json4s.JsonAST._
 import org.json4s.JsonDSL._
 import org.scalatest.concurrent.Eventually
@@ -24,9 +22,6 @@ import io.iohk.ethereum.LongPatience
 import io.iohk.ethereum.WithActorSystemShutDown
 import io.iohk.ethereum.domain._
 import io.iohk.ethereum.jsonrpc.PersonalService._
-import io.iohk.ethereum.jsonrpc.serialization.JsonSerializers.OptionNoneToJNullSerializer
-import io.iohk.ethereum.jsonrpc.serialization.JsonSerializers.QuantitiesSerializer
-import io.iohk.ethereum.jsonrpc.serialization.JsonSerializers.UnformattedDataJsonSerializer
 
 class JsonRpcControllerPersonalSpec
     extends TestKit(ActorSystem("JsonRpcControllerPersonalSpec_System"))
@@ -38,9 +33,6 @@ class JsonRpcControllerPersonalSpec
     with ScalaFutures
     with LongPatience
     with Eventually {
-
-  implicit val formats: Formats = DefaultFormats.preservingEmptyValues + OptionNoneToJNullSerializer +
-    QuantitiesSerializer + UnformattedDataJsonSerializer
 
   it should "personal_importRawKey" in new JsonRpcControllerFixture {
     val key = "7a44789ed3cd85861c0bbf9693c7e1de1862dd4396c390147ecf1275099c6e6f"

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerSpec.scala
@@ -8,8 +8,6 @@ import monix.execution.Scheduler.Implicits.global
 
 import scala.concurrent.duration._
 
-import org.json4s.DefaultFormats
-import org.json4s.Formats
 import org.json4s.JArray
 import org.json4s.JObject
 import org.json4s.JString
@@ -28,9 +26,6 @@ import io.iohk.ethereum.jsonrpc.DebugService.ListPeersInfoResponse
 import io.iohk.ethereum.jsonrpc.NetService.ListeningResponse
 import io.iohk.ethereum.jsonrpc.NetService.PeerCountResponse
 import io.iohk.ethereum.jsonrpc.NetService.VersionResponse
-import io.iohk.ethereum.jsonrpc.serialization.JsonSerializers.OptionNoneToJNullSerializer
-import io.iohk.ethereum.jsonrpc.serialization.JsonSerializers.QuantitiesSerializer
-import io.iohk.ethereum.jsonrpc.serialization.JsonSerializers.UnformattedDataJsonSerializer
 import io.iohk.ethereum.jsonrpc.server.controllers.JsonRpcBaseController.JsonRpcConfig
 import io.iohk.ethereum.jsonrpc.server.http.JsonRpcHttpServer
 import io.iohk.ethereum.jsonrpc.server.ipc.JsonRpcIpcServer
@@ -49,9 +44,6 @@ class JsonRpcControllerSpec
     with ScalaFutures
     with LongPatience
     with Eventually {
-
-  implicit val formats: Formats = DefaultFormats.preservingEmptyValues + OptionNoneToJNullSerializer +
-    QuantitiesSerializer + UnformattedDataJsonSerializer
 
   "JsonRpcController" should "handle valid sha3 request" in new JsonRpcControllerFixture {
     val rpcRequest = newJsonRpcRequest("web3_sha3", JString("0x1234") :: Nil)


### PR DESCRIPTION
# Description

Transaction's field "to" was not encoded in contract creation since it was not set.
The facilitate ETS success, this field is expected to always be present.

# Proposed Solution

The fix allows the encoding of empty fields, and remove the duplicated (and not working) custom option serializer

