### PR TITLE
[ETCM-980] restore json OptionNoneToNullSerializer

### DIFF
--- a/src/main/scala/io/iohk/ethereum/jsonrpc/serialization/JsonSerializers.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/serialization/JsonSerializers.scala
@@ -7,6 +7,7 @@ import org.json4s.CustomSerializer
 import org.json4s.DefaultFormats
 import org.json4s.Extraction
 import org.json4s.Formats
+import org.json4s.JNull
 import org.json4s.JString
 
 import io.iohk.ethereum.domain.Address
@@ -15,7 +16,8 @@ import io.iohk.ethereum.testmode.EthTransactionResponse
 
 object JsonSerializers {
   implicit val formats: Formats =
-    DefaultFormats + UnformattedDataJsonSerializer + QuantitiesSerializer + AddressJsonSerializer + EthTransactionResponseSerializer
+    DefaultFormats + UnformattedDataJsonSerializer + QuantitiesSerializer +
+      OptionNoneToJNullSerializer + AddressJsonSerializer + EthTransactionResponseSerializer
 
   object UnformattedDataJsonSerializer
       extends CustomSerializer[ByteString](_ =>
@@ -35,6 +37,14 @@ object JsonSerializers {
             else
               JString(s"0x${Hex.toHexString(n.toByteArray).dropWhile(_ == '0')}")
           }
+        )
+      )
+
+  object OptionNoneToJNullSerializer
+      extends CustomSerializer[Option[_]](formats =>
+        (
+          PartialFunction.empty,
+          { case None => JNull }
         )
       )
 

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerEthLegacyTransactionSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerEthLegacyTransactionSpec.scala
@@ -8,7 +8,9 @@ import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 
 import org.bouncycastle.util.encoders.Hex
+import org.json4s.DefaultFormats
 import org.json4s.Extraction
+import org.json4s.Formats
 import org.json4s.JsonAST._
 import org.json4s.JsonDSL._
 import org.scalatest.concurrent.Eventually
@@ -27,6 +29,9 @@ import io.iohk.ethereum.jsonrpc.EthTxService._
 import io.iohk.ethereum.jsonrpc.EthUserService._
 import io.iohk.ethereum.jsonrpc.FilterManager.TxLog
 import io.iohk.ethereum.jsonrpc.PersonalService._
+import io.iohk.ethereum.jsonrpc.serialization.JsonSerializers.OptionNoneToJNullSerializer
+import io.iohk.ethereum.jsonrpc.serialization.JsonSerializers.QuantitiesSerializer
+import io.iohk.ethereum.jsonrpc.serialization.JsonSerializers.UnformattedDataJsonSerializer
 import io.iohk.ethereum.transactions.PendingTransactionsManager.PendingTransaction
 
 // scalastyle:off magic.number
@@ -40,6 +45,9 @@ class JsonRpcControllerEthLegacyTransactionSpec
     with ScalaFutures
     with LongPatience
     with Eventually {
+
+  implicit val formats: Formats = DefaultFormats.preservingEmptyValues + OptionNoneToJNullSerializer +
+    QuantitiesSerializer + UnformattedDataJsonSerializer
 
   it should "handle eth_getTransactionByBlockHashAndIndex request" in new JsonRpcControllerFixture {
     val blockToRequest = Block(Fixtures.Blocks.Block3125369.header, Fixtures.Blocks.Block3125369.body)

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerEthSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerEthSpec.scala
@@ -8,7 +8,9 @@ import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 
 import org.bouncycastle.util.encoders.Hex
+import org.json4s.DefaultFormats
 import org.json4s.Extraction
+import org.json4s.Formats
 import org.json4s.JsonAST._
 import org.json4s.JsonDSL._
 import org.scalatest.concurrent.Eventually
@@ -38,6 +40,9 @@ import io.iohk.ethereum.jsonrpc.ProofService.GetProofResponse
 import io.iohk.ethereum.jsonrpc.ProofService.ProofAccount
 import io.iohk.ethereum.jsonrpc.ProofService.StorageProofKey
 import io.iohk.ethereum.jsonrpc.ProofService.StorageValueProof
+import io.iohk.ethereum.jsonrpc.serialization.JsonSerializers.OptionNoneToJNullSerializer
+import io.iohk.ethereum.jsonrpc.serialization.JsonSerializers.QuantitiesSerializer
+import io.iohk.ethereum.jsonrpc.serialization.JsonSerializers.UnformattedDataJsonSerializer
 import io.iohk.ethereum.ledger.InMemoryWorldStateProxy
 import io.iohk.ethereum.ommers.OmmersPool
 import io.iohk.ethereum.ommers.OmmersPool.Ommers
@@ -55,6 +60,9 @@ class JsonRpcControllerEthSpec
     with ScalaFutures
     with LongPatience
     with Eventually {
+
+  implicit val formats: Formats = DefaultFormats.preservingEmptyValues + OptionNoneToJNullSerializer +
+    QuantitiesSerializer + UnformattedDataJsonSerializer
 
   it should "eth_protocolVersion" in new JsonRpcControllerFixture {
     val rpcRequest = newJsonRpcRequest("eth_protocolVersion")

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerPersonalSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerPersonalSpec.scala
@@ -10,6 +10,8 @@ import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 
 import org.bouncycastle.util.encoders.Hex
+import org.json4s.DefaultFormats
+import org.json4s.Formats
 import org.json4s.JsonAST._
 import org.json4s.JsonDSL._
 import org.scalatest.concurrent.Eventually
@@ -22,6 +24,9 @@ import io.iohk.ethereum.LongPatience
 import io.iohk.ethereum.WithActorSystemShutDown
 import io.iohk.ethereum.domain._
 import io.iohk.ethereum.jsonrpc.PersonalService._
+import io.iohk.ethereum.jsonrpc.serialization.JsonSerializers.OptionNoneToJNullSerializer
+import io.iohk.ethereum.jsonrpc.serialization.JsonSerializers.QuantitiesSerializer
+import io.iohk.ethereum.jsonrpc.serialization.JsonSerializers.UnformattedDataJsonSerializer
 
 class JsonRpcControllerPersonalSpec
     extends TestKit(ActorSystem("JsonRpcControllerPersonalSpec_System"))
@@ -33,6 +38,9 @@ class JsonRpcControllerPersonalSpec
     with ScalaFutures
     with LongPatience
     with Eventually {
+
+  implicit val formats: Formats = DefaultFormats.preservingEmptyValues + OptionNoneToJNullSerializer +
+    QuantitiesSerializer + UnformattedDataJsonSerializer
 
   it should "personal_importRawKey" in new JsonRpcControllerFixture {
     val key = "7a44789ed3cd85861c0bbf9693c7e1de1862dd4396c390147ecf1275099c6e6f"

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerSpec.scala
@@ -8,6 +8,8 @@ import monix.execution.Scheduler.Implicits.global
 
 import scala.concurrent.duration._
 
+import org.json4s.DefaultFormats
+import org.json4s.Formats
 import org.json4s.JArray
 import org.json4s.JObject
 import org.json4s.JString
@@ -26,6 +28,9 @@ import io.iohk.ethereum.jsonrpc.DebugService.ListPeersInfoResponse
 import io.iohk.ethereum.jsonrpc.NetService.ListeningResponse
 import io.iohk.ethereum.jsonrpc.NetService.PeerCountResponse
 import io.iohk.ethereum.jsonrpc.NetService.VersionResponse
+import io.iohk.ethereum.jsonrpc.serialization.JsonSerializers.OptionNoneToJNullSerializer
+import io.iohk.ethereum.jsonrpc.serialization.JsonSerializers.QuantitiesSerializer
+import io.iohk.ethereum.jsonrpc.serialization.JsonSerializers.UnformattedDataJsonSerializer
 import io.iohk.ethereum.jsonrpc.server.controllers.JsonRpcBaseController.JsonRpcConfig
 import io.iohk.ethereum.jsonrpc.server.http.JsonRpcHttpServer
 import io.iohk.ethereum.jsonrpc.server.ipc.JsonRpcIpcServer
@@ -43,6 +48,9 @@ class JsonRpcControllerSpec
     with ScalaFutures
     with LongPatience
     with Eventually {
+
+  implicit val formats: Formats = DefaultFormats.preservingEmptyValues + OptionNoneToJNullSerializer +
+    QuantitiesSerializer + UnformattedDataJsonSerializer
 
   "JsonRpcController" should "handle valid sha3 request" in new JsonRpcControllerFixture {
     val rpcRequest = newJsonRpcRequest("web3_sha3", JString("0x1234") :: Nil)


### PR DESCRIPTION
This reverts commit 357bc897d6d6d64492233fe0c8981565b6a5b208 regarding OptionNoneToNullSerializer.

# Description

ERC20 tests are not working anymore after ETCM-980 merge

# Proposed Solution

This is due to the removal of OptionNoneToNullSerializer

# Testing

Both ETCM-980 related tests and ERC-20 tests are passing
