### PR TITLE
[ETCM-844] Re-enable eth/63

### DIFF
--- a/src/main/resources/conf/chains/etc-chain.conf
+++ b/src/main/resources/conf/chains/etc-chain.conf
@@ -6,7 +6,7 @@
   # The ID of the accepted chain
   chain-id = "0x3d"
 
-  capabilities = ["eth/64"]
+  capabilities = ["eth/63", "eth/64"]
 
   # Possibility to set Proof of Work target time for testing purposes.
   # null means that the standard difficulty calculation rules are used

--- a/src/main/resources/conf/chains/eth-chain.conf
+++ b/src/main/resources/conf/chains/eth-chain.conf
@@ -3,7 +3,7 @@
   # 1 - mainnet, 3 - ropsten, 7 - mordor
   network-id = 1
 
-  capabilities = ["eth/64"]
+  capabilities = ["eth/63", "eth/64"]
 
   # Possibility to set Proof of Work target time for testing purposes.
   # null means that the standard difficulty calculation rules are used

--- a/src/main/resources/conf/chains/mordor-chain.conf
+++ b/src/main/resources/conf/chains/mordor-chain.conf
@@ -3,7 +3,7 @@
   # 1 - mainnet, 3 - ropsten, 7 - mordor
   network-id = 7
 
-  capabilities = ["eth/64"]
+  capabilities = ["eth/63", "eth/64"]
 
   # Possibility to set Proof of Work target time for testing purposes.
   # null means that the standard difficulty calculation rules are used

--- a/src/main/resources/conf/chains/ropsten-chain.conf
+++ b/src/main/resources/conf/chains/ropsten-chain.conf
@@ -3,7 +3,7 @@
   # 1 - mainnet, 3 - ropsten, 7 - mordor
   network-id = 3
 
-  capabilities = ["eth/64"]
+  capabilities = ["eth/63", "eth/64"]
 
   # Possibility to set Proof of Work target time for testing purposes.
   # null means that the standard difficulty calculation rules are used

--- a/src/main/resources/conf/chains/testnet-internal-nomad-chain.conf
+++ b/src/main/resources/conf/chains/testnet-internal-nomad-chain.conf
@@ -3,7 +3,7 @@
     # 1 - mainnet, 3 - ropsten, 7 - mordor
     network-id = 42
 
-    capabilities = ["eth/64"]
+    capabilities = ["eth/63", "eth/64"]
 
     # Possibility to set Proof of Work target time for testing purposes.
     # null means that the standard difficulty calculation rules are used


### PR DESCRIPTION
# Description
This PR re-enables the `eth/63` capability which was too eagerly dropped
