### PR TITLE
ETCM-1061 Remove caching from ArchiveStateStorage and ReferenceCountedStateStorage

### DIFF
--- a/src/it/scala/io/iohk/ethereum/txExecTest/util/FixtureProvider.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/util/FixtureProvider.scala
@@ -57,13 +57,11 @@ object FixtureProvider {
       override val transactionMappingStorage: TransactionMappingStorage = new TransactionMappingStorage(dataSource)
       override val appStateStorage: AppStateStorage = new AppStateStorage(dataSource)
       val nodeStorage: NodeStorage = new NodeStorage(dataSource)
-      val cachedNodeStorage: CachedNodeStorage = new CachedNodeStorage(nodeStorage, caches.nodeCache)
       val pruningMode: PruningMode = ArchivePruning
       override val stateStorage: StateStorage =
         StateStorage(
           pruningMode,
           nodeStorage,
-          cachedNodeStorage,
           new LruCache[NodeHash, HeapEntry](
             Config.InMemoryPruningNodeCacheConfig,
             Some(CachedReferenceCountedStorage.saveOnlyNotificationHandler(nodeStorage))

--- a/src/main/scala/io/iohk/ethereum/db/components/Storages.scala
+++ b/src/main/scala/io/iohk/ethereum/db/components/Storages.scala
@@ -31,8 +31,6 @@ object Storages {
 
       override val nodeStorage: NodeStorage = new NodeStorage(dataSource)
 
-      val cachedNodeStorage: CachedNodeStorage = new CachedNodeStorage(nodeStorage, caches.nodeCache)
-
       override val fastSyncStateStorage: FastSyncStateStorage = new FastSyncStateStorage(dataSource)
 
       override val evmCodeStorage: EvmCodeStorage = new EvmCodeStorage(dataSource)
@@ -50,7 +48,6 @@ object Storages {
         StateStorage(
           pruningMode,
           nodeStorage,
-          cachedNodeStorage,
           new LruCache[NodeHash, HeapEntry](
             Config.InMemoryPruningNodeCacheConfig,
             Some(CachedReferenceCountedStorage.saveOnlyNotificationHandler(nodeStorage))

--- a/src/test/scala/io/iohk/ethereum/consensus/ConsensusSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/ConsensusSpec.scala
@@ -249,7 +249,7 @@ class ConsensusSpec extends AnyFlatSpec with Matchers with ScalaFutures {
     // dying before updating the storage but after updating the cache, inconsistency is created
     blockchain.saveBestKnownBlocks(oldBlock4.number)
 
-    blockchainReader.getBestBlock() shouldBe Some(ancestorForValidation)
+    blockchainReader.getBestBlock() shouldBe Some(newBlock3)
   }
 
   it should "handle error when trying to reorganise chain" in new EphemBlockchain {

--- a/src/test/scala/io/iohk/ethereum/db/storage/StateStorageSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/db/storage/StateStorageSpec.scala
@@ -179,13 +179,12 @@ class StateStorageSpec extends AnyFlatSpec with Matchers with ScalaCheckProperty
     val lruCache = new LruCache[NodeHash, HeapEntry](TestCacheConfig)
 
     val archiveNodeStorage = new ArchiveNodeStorage(nodeStorage)
-    val archiveStateStorage: StateStorage = StateStorage(ArchivePruning, nodeStorage, cachedNodeStorage, lruCache)
+    val archiveStateStorage: StateStorage = StateStorage(ArchivePruning, nodeStorage, lruCache)
 
     val refCountNodeStorage = new ReferenceCountNodeStorage(nodeStorage, 10)
-    val referenceCounteStateStorage: StateStorage =
-      StateStorage(BasicPruning(10), nodeStorage, cachedNodeStorage, lruCache)
+    val referenceCounteStateStorage: StateStorage = StateStorage(BasicPruning(10), nodeStorage, lruCache)
 
-    val cachedStateStorage: StateStorage = StateStorage(InMemoryPruning(10), nodeStorage, cachedNodeStorage, lruCache)
+    val cachedStateStorage: StateStorage = StateStorage(InMemoryPruning(10), nodeStorage, lruCache)
     val cachedPrunedNodeStorage = new CachedReferenceCountedStorage(nodeStorage, lruCache, changeLog, 10)
   }
 }

--- a/src/test/scala/io/iohk/ethereum/mpt/MerklePatriciaTrieSuite.scala
+++ b/src/test/scala/io/iohk/ethereum/mpt/MerklePatriciaTrieSuite.scala
@@ -27,7 +27,7 @@ import io.iohk.ethereum.proof.ProofVerifyResult.ValidProof
 class MerklePatriciaTrieSuite extends AnyFunSuite with ScalaCheckPropertyChecks with ObjectGenerators {
 
   val dataSource: EphemDataSource = EphemDataSource()
-  val (stateStorage, emptyNodeStorage, _) = StateStorage.createTestStateStorage(dataSource)
+  val (stateStorage, emptyNodeStorage, cachedNodeStorage) = StateStorage.createTestStateStorage(dataSource)
   val emptyEphemNodeStorage: MptStorage = stateStorage.getBackingStorage(0)
   val emptyMpt: MerklePatriciaTrie[Array[Byte], Array[Byte]] =
     MerklePatriciaTrie[Array[Byte], Array[Byte]](emptyEphemNodeStorage)
@@ -484,7 +484,7 @@ class MerklePatriciaTrieSuite extends AnyFunSuite with ScalaCheckPropertyChecks 
 
     val pruningOffset = 10
 
-    val (stateStorage, nodeStorage, cachedNodeStorage) =
+    val (stateStorage, _, cachedNodeStorage) =
       StateStorage.createTestStateStorage(EphemDataSource(), BasicPruning(40))
 
     val referenceCountBlock0 = stateStorage.getBackingStorage(0)


### PR DESCRIPTION
# Description

Mantis is experiencing some bugs related to the state in caches and in the storage not being syncronized.
RocksDB promisses to offer fast writes compared to other more tradicional DB's.

# Proposed Solution
Depending on the chosen pruning mode, StateStorage will return an `ArchiveStateStorage`, an `ReferenceCountedStateStorage` or an `CachedReferenceCountedStateStorage`.
In this PR the caching layer of ArchiveStateStorage and ReferenceCountedStateStorage where removed, but
you will see that method `forcePersist` is still part of the StateStorage trait. This is because `CachedReferenceCountedStateStorage` is deeply linked to caching (pruning mode `inmemory`).

Would it make sense to remove support to an `inmemory` pruning mode and further simplify the StateStorage?

# Testing
Number of ETS tests failing is still the same as in develop branch
It was testing with ETC, for a more lengthy test is desirable yet
I am exploring using RocksDB statistics to help with testing these kind of changes


