### PR TITLE
[ETCM-1060] rewrite ommers validation to avoid using getBlockByNumber

### DIFF
--- a/src/main/scala/io/iohk/ethereum/consensus/pow/validators/OmmersValidator.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/pow/validators/OmmersValidator.scala
@@ -32,9 +32,9 @@ trait OmmersValidator {
     val getBlockHeaderByHash: ByteString => Option[BlockHeader] = blockchainReader.getBlockHeaderByHash
     val bestBranch = blockchainReader.getBestBranch()
     val getNBlocksBack: (ByteString, Int) => List[Block] =
-      (_, n) =>
+      (tailBlockHash, n) =>
         Iterator
-          .iterate(blockchainReader.getBlockByHash(parentHash))(
+          .iterate(blockchainReader.getBlockByHash(tailBlockHash))(
             _.flatMap(block => blockchainReader.getBlockByHash(block.header.parentHash))
           )
           .take(n)

--- a/src/main/scala/io/iohk/ethereum/ledger/BlockValidation.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/BlockValidation.scala
@@ -44,7 +44,8 @@ class BlockValidation(
           val remaining = n - queuedBlocks.length - 1
           val remainingBlocks = Iterator
             .iterate(blockchainReader.getBlockByHash(highestBlockInStorage.header.parentHash))(
-              _.flatMap(p => blockchainReader.getBlockByHash(p.header.parentHash))
+              _.filter(_.number > 0) // avoid trying to fetch parent of genesis
+                .flatMap(p => blockchainReader.getBlockByHash(p.header.parentHash))
             )
             .take(remaining)
             .collect { case Some(block) => block }

--- a/src/main/scala/io/iohk/ethereum/ledger/BlockValidation.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/BlockValidation.scala
@@ -39,15 +39,17 @@ class BlockValidation(
           // The in memory blocks aren't connected to the db ones, we don't have n blocks to return so we return none
           Nil
 
-        case Some(block) =>
+        case Some(highestBlockInStorage) =>
           // We already have |block +: queuedBlocks|
           val remaining = n - queuedBlocks.length - 1
-
-          val numbers = (block.header.number - remaining) until block.header.number
-          val bestBranch = blockchainReader.getBestBranch()
-          val blocks =
-            (numbers.toList.flatMap(nb => blockchainReader.getBlockByNumber(bestBranch, nb)) :+ block) ::: queuedBlocks
-          blocks
+          val remainingBlocks = Iterator
+            .iterate(blockchainReader.getBlockByHash(highestBlockInStorage.header.parentHash))(
+              _.flatMap(p => blockchainReader.getBlockByHash(p.header.parentHash))
+            )
+            .take(remaining)
+            .collect { case Some(block) => block }
+            .toList
+          (remainingBlocks :+ highestBlockInStorage) ::: queuedBlocks
       }
     }
   }


### PR DESCRIPTION
# Description

This PR rewrites `getNBlocksBack` in OmmersValidation so that it does not use `getBlockByNumber`.

 - It reduces our dependency on the block number mapping storage: The other parts that are using `getBlockByNumber` are out of the core flow of mantis (json rpc calls). This means that it opens a path to be able to switch the best branch just by changing a hash in the storage, and having the block number mapping built somewhere else. We can insert new blocks without rebuilding the index each time. 
 - We can validate ommers for any block without considering if it is on top of the best chain or not. In the end it will allow to have only one implementation instead of treating alternative branches are a special case (currently we have a different way of retrieving blocks if they are in the blockQueue).
