### PR TITLE
[Fix] Set sagano to capability ETC/64

### DIFF
--- a/src/main/resources/conf/chains/testnet-internal-nomad-chain.conf
+++ b/src/main/resources/conf/chains/testnet-internal-nomad-chain.conf
@@ -3,7 +3,7 @@
     # 1 - mainnet, 3 - ropsten, 7 - mordor
     network-id = 42
 
-    capabilities = ["eth/63", "eth/64"]
+    capabilities = ["etc/64"]
 
     # Possibility to set Proof of Work target time for testing purposes.
     # null means that the standard difficulty calculation rules are used


### PR DESCRIPTION
This change preserves compatibility with pre-eth/64 client versions.