### PR TITLE
fix buildkite checking out mantis-automation

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,3 +1,6 @@
+env:
+  BUILDKITE_CLEAN_CHECKOUT: "true"
+
 steps:
   - label: ":nix::point_right::pipeline:"
     command: |
@@ -6,8 +9,6 @@ steps:
       | buildkite-agent pipeline upload --no-interpolation
     agents:
       queue: project42
-    timeout_in_minutes: 60
-  - wait
   - label: "Mantis Automation"
     command:
     - "curl https://raw.githubusercontent.com/input-output-hk/mantis-automation/main/.buildkite/pipeline_erc20_pr.yml -o automation.yml"


### PR DESCRIPTION
# Description

Buildkite is erroneously checking out mantis-automation somehow do to some strange hook bug.

# Proposed Solution

A clean checkout looks like it is required to keep the repo's separate for whatever reason. Also @AurelienRichez's fix to add a `- wait` statement also was compounding the issue, since this caused the first step to not run at all, and skip directly to mantis automation step.