### PR TITLE
[ETCM-1053] extend PeerEventBus to support Akka Streams

### DIFF
--- a/src/main/scala/io/iohk/ethereum/network/Peer.scala
+++ b/src/main/scala/io/iohk/ethereum/network/Peer.scala
@@ -2,10 +2,14 @@ package io.iohk.ethereum.network
 
 import java.net.InetSocketAddress
 
+import akka.NotUsed
 import akka.actor.ActorRef
+import akka.pattern.Patterns.ask
+import akka.stream.scaladsl.Source
 import akka.util.ByteString
 
 import io.iohk.ethereum.blockchain.sync.Blacklist.BlacklistId
+import io.iohk.ethereum.network.p2p.Message
 
 final case class PeerId(value: String) extends BlacklistId
 
@@ -18,6 +22,7 @@ final case class Peer(
     remoteAddress: InetSocketAddress,
     ref: ActorRef,
     incomingConnection: Boolean,
+    source: Source[Message, NotUsed] = Source.empty,
     nodeId: Option[ByteString] = None,
     createTimeMillis: Long = System.currentTimeMillis
 )

--- a/src/main/scala/io/iohk/ethereum/network/PeerEventBusActor.scala
+++ b/src/main/scala/io/iohk/ethereum/network/PeerEventBusActor.scala
@@ -39,9 +39,8 @@ object PeerEventBusActor {
   def messageSource(peerEventBus: ActorRef, messageClassifier: MessageClassifier): Source[MessageFromPeer, NotUsed] =
     Source
       .fromMaterializer { (mat, _) =>
-        import mat.executionContext
         val (actorRef, src) = Source
-          .actorRef[MessageFromPeer](1, OverflowStrategy.fail)
+          .actorRef[MessageFromPeer](PartialFunction.empty, PartialFunction.empty, 1, OverflowStrategy.fail)
           .watch(peerEventBus)
           .preMaterialize()(mat)
         peerEventBus

--- a/src/main/scala/io/iohk/ethereum/network/PeerManagerActor.scala
+++ b/src/main/scala/io/iohk/ethereum/network/PeerManagerActor.scala
@@ -6,6 +6,7 @@ import java.util.Collections.newSetFromMap
 
 import akka.actor.SupervisorStrategy.Stop
 import akka.actor._
+import akka.stream.scaladsl.Source
 import akka.util.ByteString
 import akka.util.Timeout
 
@@ -323,9 +324,7 @@ class PeerManagerActor(
         PeerId.fromRef(ref),
         address,
         ref,
-        incomingConnection,
-        nodeId = None,
-        createTimeMillis = System.currentTimeMillis
+        incomingConnection
       )
 
     val newConnectedPeers = connectedPeers.addNewPendingPeer(pendingPeer)

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/fast/FastSyncBranchResolverSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/fast/FastSyncBranchResolverSpec.scala
@@ -181,7 +181,8 @@ class FastSyncBranchResolverSpec extends AnyWordSpec with Matchers with MockFact
       val blocksSavedInPeer: List[Block] =
         commonBlocks :++ BlockHelpers.generateChain(ourBestBlock + 1 - highestCommonBlock, commonBlocks.last)
 
-      val dummyPeer = Peer(PeerId("dummyPeer"), new InetSocketAddress("foo", 1), ActorRef.noSender, false, None, 0)
+      val dummyPeer =
+        Peer(PeerId("dummyPeer"), new InetSocketAddress("foo", 1), ActorRef.noSender, false, createTimeMillis = 0)
 
       val initialSearchState = SearchState(1, 10, dummyPeer)
       val ours = blocksSaved.map(b => (b.number, b)).toMap
@@ -256,7 +257,8 @@ class FastSyncBranchResolverSpec extends AnyWordSpec with Matchers with MockFact
       val blocksSaved: List[Block] = BlockHelpers.generateChain(8, BlockHelpers.genesis)
       val blocksSavedInPeer: List[Block] = BlockHelpers.generateChain(8, BlockHelpers.genesis)
 
-      val dummyPeer = Peer(PeerId("dummyPeer"), new InetSocketAddress("foo", 1), ActorRef.noSender, false, None, 0)
+      val dummyPeer =
+        Peer(PeerId("dummyPeer"), new InetSocketAddress("foo", 1), ActorRef.noSender, false, createTimeMillis = 0)
 
       val initialSearchState = SearchState(1, 8, dummyPeer)
       val ours = blocksSaved.map(b => (b.number, b)).toMap

--- a/src/test/scala/io/iohk/ethereum/network/EtcPeerManagerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/network/EtcPeerManagerSpec.scala
@@ -328,20 +328,20 @@ class EtcPeerManagerSpec extends AnyFlatSpec with Matchers {
 
     val peer1Probe: TestProbe = TestProbe()
     val peer1: Peer =
-      Peer(PeerId("peer1"), new InetSocketAddress("127.0.0.1", 1), peer1Probe.ref, false, Some(fakeNodeId))
+      Peer(PeerId("peer1"), new InetSocketAddress("127.0.0.1", 1), peer1Probe.ref, false, nodeId = Some(fakeNodeId))
     val peer1Info: PeerInfo = initialPeerInfo.withForkAccepted(false)
     val peer1InfoETC64: PeerInfo = initialPeerInfoETC64.withForkAccepted(false)
     val peer2Probe: TestProbe = TestProbe()
     val peer2: Peer =
-      Peer(PeerId("peer2"), new InetSocketAddress("127.0.0.1", 2), peer2Probe.ref, false, Some(fakeNodeId))
+      Peer(PeerId("peer2"), new InetSocketAddress("127.0.0.1", 2), peer2Probe.ref, false, nodeId = Some(fakeNodeId))
     val peer2Info: PeerInfo = initialPeerInfo.withForkAccepted(false)
     val peer3Probe: TestProbe = TestProbe()
     val peer3: Peer =
-      Peer(PeerId("peer3"), new InetSocketAddress("127.0.0.1", 3), peer3Probe.ref, false, Some(fakeNodeId))
+      Peer(PeerId("peer3"), new InetSocketAddress("127.0.0.1", 3), peer3Probe.ref, false, nodeId = Some(fakeNodeId))
 
     val freshPeerProbe: TestProbe = TestProbe()
     val freshPeer: Peer =
-      Peer(PeerId(""), new InetSocketAddress("127.0.0.1", 4), freshPeerProbe.ref, false, Some(fakeNodeId))
+      Peer(PeerId(""), new InetSocketAddress("127.0.0.1", 4), freshPeerProbe.ref, false, nodeId = Some(fakeNodeId))
     val freshPeerInfo: PeerInfo = initialPeerInfo.withForkAccepted(false)
 
     val peerManager: TestProbe = TestProbe()

--- a/src/test/scala/io/iohk/ethereum/network/PeerEventBusActorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/network/PeerEventBusActorSpec.scala
@@ -10,6 +10,7 @@ import akka.stream.scaladsl.Flow
 import akka.stream.scaladsl.Keep
 import akka.stream.scaladsl.Sink
 import akka.stream.scaladsl.Source
+import akka.testkit.TestActor
 import akka.testkit.TestProbe
 import akka.util.ByteString
 
@@ -31,7 +32,6 @@ import io.iohk.ethereum.network.p2p.Message
 import io.iohk.ethereum.network.p2p.messages.Capability
 import io.iohk.ethereum.network.p2p.messages.WireProtocol.Ping
 import io.iohk.ethereum.network.p2p.messages.WireProtocol.Pong
-import akka.testkit.TestActor
 
 class PeerEventBusActorSpec extends AnyFlatSpec with Matchers with ScalaFutures with NormalPatience {
 

--- a/src/test/scala/io/iohk/ethereum/network/PeerEventBusActorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/network/PeerEventBusActorSpec.scala
@@ -82,10 +82,13 @@ class PeerEventBusActorSpec extends AnyFlatSpec with Matchers with ScalaFutures 
     peerEventBusProbe.expectMsgType[PeerEventBusActor.Subscribe]
 
     val msgFromPeer = MessageFromPeer(Ping(), PeerId("1"))
-    peerEventBusActor ! PeerEventBusActor.Publish(msgFromPeer)
+    peerEventBusProbe.ref ! PeerEventBusActor.Publish(msgFromPeer)
 
     val msgFromPeer2 = MessageFromPeer(Ping(), PeerId("99"))
-    peerEventBusActor ! PeerEventBusActor.Publish(msgFromPeer2)
+    peerEventBusProbe.ref ! PeerEventBusActor.Publish(msgFromPeer2)
+
+    peerEventBusProbe.expectMsgType[PeerEventBusActor.Publish]
+    peerEventBusProbe.expectMsgType[PeerEventBusActor.Publish]
 
     peerEventBusProbe.ref ! PoisonPill
 

--- a/src/test/scala/io/iohk/ethereum/network/PeerManagerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/network/PeerManagerSpec.scala
@@ -195,7 +195,8 @@ class PeerManagerSpec
 
     // It should have created the next peer for the first incoming connection (probably using a synchronous test scheduler).
     val probe2: TestProbe = createdPeers(2).probe
-    val peer = Peer(PeerId("peer"), incomingPeerAddress1, probe2.ref, incomingConnection = true, Some(incomingNodeId1))
+    val peer =
+      Peer(PeerId("peer"), incomingPeerAddress1, probe2.ref, incomingConnection = true, nodeId = Some(incomingNodeId1))
     probe2.expectMsg(PeerActor.HandleConnection(incomingConnection1.ref, incomingPeerAddress1))
     probe2.reply(PeerEvent.PeerHandshakeSuccessful(peer, initialPeerInfo))
 
@@ -213,7 +214,13 @@ class PeerManagerSpec
     val probe3: TestProbe = createdPeers(3).probe
 
     val secondPeer =
-      Peer(PeerId("secondPeer"), incomingPeerAddress2, probe3.ref, incomingConnection = true, Some(incomingNodeId2))
+      Peer(
+        PeerId("secondPeer"),
+        incomingPeerAddress2,
+        probe3.ref,
+        incomingConnection = true,
+        nodeId = Some(incomingNodeId2)
+      )
 
     probe3.expectMsg(PeerActor.HandleConnection(incomingConnection2.ref, incomingPeerAddress2))
     probe3.reply(PeerEvent.PeerHandshakeSuccessful(secondPeer, initialPeerInfo))
@@ -287,7 +294,7 @@ class PeerManagerSpec
       peerAsIncomingAddress,
       peerAsIncomingProbe.ref,
       incomingConnection = true,
-      Some(nodeId)
+      nodeId = Some(nodeId)
     )
 
     peerAsIncomingProbe.expectMsg(
@@ -322,7 +329,7 @@ class PeerManagerSpec
       peerAsIncomingAddress,
       peerAsIncomingProbe.ref,
       incomingConnection = true,
-      Some(nodeId)
+      nodeId = Some(nodeId)
     )
 
     peerAsIncomingProbe.expectMsg(


### PR DESCRIPTION
... and use it for the Peer case class as specified in the ticket.

However, I'm a bit skeptical we want to go down the route of managing and materializing a separate source per actor. Instead I think it will be more practical to use one source with the messages from different peers. That way we won't need to worry about setup and teardown and precise synchronisation of these things. Look at the added spec for an example of this (there's a `Thread.sleep` in there.)

A possible improvement would be to materialize a future that completes when the subscription is performed (via ask-pattern with the `PeerEventBusActor`) to aid in this synchronisation. I was playing around with this but it only made sense for the specs, and I think we should avoid this kind of stuff for production code.

There's also a small bugfix in there to unsubscribe when the subscribing actor dies, which might cause memory leaks otherwise.