### PR TITLE
ETCM-974 Increase the number of rolling logs from 10 to 50

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -32,7 +32,7 @@
         <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
             <fileNamePattern>${LOGSDIR}/${LOGSFILENAME}.%i.log.zip</fileNamePattern>
             <minIndex>1</minIndex>
-            <maxIndex>10</maxIndex>
+            <maxIndex>50</maxIndex>
         </rollingPolicy>
         <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
             <maxFileSize>10MB</maxFileSize>


### PR DESCRIPTION
# Description

When users report us issues send us their logs, the logs are always too old an don't allow us to see where/when the issue started

# Proposed Solution
Increase the number of rolling logs from 10 to 50


