### PR TITLE
[ETCM-987] Fix saving the best block number without adding a mapping between block number and block hash

### DIFF
--- a/src/it/scala/io/iohk/ethereum/sync/util/FastSyncItSpecUtils.scala
+++ b/src/it/scala/io/iohk/ethereum/sync/util/FastSyncItSpecUtils.scala
@@ -34,6 +34,7 @@ object FastSyncItSpecUtils {
       FastSync.props(
         storagesInstance.storages.fastSyncStateStorage,
         storagesInstance.storages.appStateStorage,
+        storagesInstance.storages.blockNumberMappingStorage,
         bl,
         blockchainReader,
         blockchainWriter,

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/SyncController.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/SyncController.scala
@@ -12,6 +12,7 @@ import io.iohk.ethereum.blockchain.sync.regular.RegularSync
 import io.iohk.ethereum.consensus.Consensus
 import io.iohk.ethereum.consensus.validators.Validators
 import io.iohk.ethereum.db.storage.AppStateStorage
+import io.iohk.ethereum.db.storage.BlockNumberMappingStorage
 import io.iohk.ethereum.db.storage.EvmCodeStorage
 import io.iohk.ethereum.db.storage.FastSyncStateStorage
 import io.iohk.ethereum.db.storage.NodeStorage
@@ -28,6 +29,7 @@ class SyncController(
     blockchainReader: BlockchainReader,
     blockchainWriter: BlockchainWriter,
     appStateStorage: AppStateStorage,
+    blockNumberMappingStorage: BlockNumberMappingStorage,
     evmCodeStorage: EvmCodeStorage,
     stateStorage: StateStorage,
     nodeStorage: NodeStorage,
@@ -96,6 +98,7 @@ class SyncController(
       FastSync.props(
         fastSyncStateStorage,
         appStateStorage,
+        blockNumberMappingStorage,
         blockchain,
         blockchainReader,
         blockchainWriter,
@@ -151,6 +154,7 @@ object SyncController {
       blockchainReader: BlockchainReader,
       blockchainWriter: BlockchainWriter,
       appStateStorage: AppStateStorage,
+      blockNumberMappingStorage: BlockNumberMappingStorage,
       evmCodeStorage: EvmCodeStorage,
       stateStorage: StateStorage,
       nodeStorage: NodeStorage,
@@ -171,6 +175,7 @@ object SyncController {
         blockchainReader,
         blockchainWriter,
         appStateStorage,
+        blockNumberMappingStorage,
         evmCodeStorage,
         stateStorage,
         nodeStorage,

--- a/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
@@ -756,6 +756,7 @@ trait SyncControllerBuilder {
       blockchainReader,
       blockchainWriter,
       storagesInstance.storages.appStateStorage,
+      storagesInstance.storages.blockNumberMappingStorage,
       storagesInstance.storages.evmCodeStorage,
       storagesInstance.storages.stateStorage,
       storagesInstance.storages.nodeStorage,

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/FastSyncSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/FastSyncSpec.scala
@@ -78,6 +78,7 @@ class FastSyncSpec
       FastSync.props(
         fastSyncStateStorage = storagesInstance.storages.fastSyncStateStorage,
         appStateStorage = storagesInstance.storages.appStateStorage,
+        blockNumberMappingStorage = storagesInstance.storages.blockNumberMappingStorage,
         blockchain = blockchain,
         blockchainReader = blockchainReader,
         blockchainWriter = blockchainWriter,

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/SyncControllerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/SyncControllerSpec.scala
@@ -552,6 +552,7 @@ class SyncControllerSpec
           blockchainReader,
           blockchainWriter,
           storagesInstance.storages.appStateStorage,
+          storagesInstance.storages.blockNumberMappingStorage,
           storagesInstance.storages.evmCodeStorage,
           storagesInstance.storages.stateStorage,
           storagesInstance.storages.nodeStorage,


### PR DESCRIPTION

# Description
Calling `appStateStorage.putBestBlockNumber` that makes an update to the best block number without calling `blockNumberMappingStorage.put` to add the mapping between the block number and block hash can result on a `None` when calling `blockchain.getBestBlock`.
I wanted to add these two calls together in the blockchain or blockchainwriter class, but it is not that straight forward.

In order to be able to test this modification already I applied the fix in FastSync and created ETCM-1089 for a proper refactor

# Testing
This has been tested against mainnet. 
