### PR TITLE
[ETCM-1069-partial] Create ConsensusAdapter with prevalidation

### DIFF
--- a/src/it/scala/io/iohk/ethereum/ledger/BlockImporterItSpec.scala
+++ b/src/it/scala/io/iohk/ethereum/ledger/BlockImporterItSpec.scala
@@ -3,20 +3,16 @@ package io.iohk.ethereum.ledger
 import akka.actor.ActorRef
 import akka.testkit.TestProbe
 import akka.util.ByteString
-
 import cats.data.NonEmptyList
-
 import monix.execution.Scheduler
 import monix.execution.schedulers.SchedulerService
 
 import scala.concurrent.duration._
-
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.Eventually
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
-
 import io.iohk.ethereum.Fixtures
 import io.iohk.ethereum.Mocks
 import io.iohk.ethereum.NormalPatience
@@ -26,7 +22,7 @@ import io.iohk.ethereum.blockchain.sync.regular.BlockFetcher
 import io.iohk.ethereum.blockchain.sync.regular.BlockImporter
 import io.iohk.ethereum.blockchain.sync.regular.BlockImporter.NewCheckpoint
 import io.iohk.ethereum.checkpointing.CheckpointingTestHelpers
-import io.iohk.ethereum.consensus.Consensus
+import io.iohk.ethereum.consensus.{Consensus, ConsensusAdapter}
 import io.iohk.ethereum.consensus.blocks.CheckpointBlockGenerator
 import io.iohk.ethereum.consensus.pow.validators.OmmersValidator
 import io.iohk.ethereum.consensus.pow.validators.StdOmmersValidator
@@ -235,7 +231,7 @@ class TestFixture extends TestSetupWithVmAndValidators {
     override val ommersValidator: OmmersValidator = new StdOmmersValidator(blockHeaderValidator)
   }
 
-  override lazy val consensus: Consensus = mkConsensus(
+  override lazy val consensusAdapter: ConsensusAdapter = mkConsensus(
     validators = successValidators,
     blockExecutionOpt = Some(
       new BlockExecution(
@@ -258,7 +254,7 @@ class TestFixture extends TestSetupWithVmAndValidators {
   val blockImporter: ActorRef = system.actorOf(
     BlockImporter.props(
       fetcherProbe.ref,
-      consensus,
+      consensusAdapter,
       blockchainReader,
       storagesInstance.storages.stateStorage,
       new BranchResolution(blockchainReader),

--- a/src/it/scala/io/iohk/ethereum/ledger/BlockImporterItSpec.scala
+++ b/src/it/scala/io/iohk/ethereum/ledger/BlockImporterItSpec.scala
@@ -3,16 +3,20 @@ package io.iohk.ethereum.ledger
 import akka.actor.ActorRef
 import akka.testkit.TestProbe
 import akka.util.ByteString
+
 import cats.data.NonEmptyList
+
 import monix.execution.Scheduler
 import monix.execution.schedulers.SchedulerService
 
 import scala.concurrent.duration._
+
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.Eventually
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
+
 import io.iohk.ethereum.Fixtures
 import io.iohk.ethereum.Mocks
 import io.iohk.ethereum.NormalPatience
@@ -22,7 +26,8 @@ import io.iohk.ethereum.blockchain.sync.regular.BlockFetcher
 import io.iohk.ethereum.blockchain.sync.regular.BlockImporter
 import io.iohk.ethereum.blockchain.sync.regular.BlockImporter.NewCheckpoint
 import io.iohk.ethereum.checkpointing.CheckpointingTestHelpers
-import io.iohk.ethereum.consensus.{Consensus, ConsensusAdapter}
+import io.iohk.ethereum.consensus.Consensus
+import io.iohk.ethereum.consensus.ConsensusAdapter
 import io.iohk.ethereum.consensus.blocks.CheckpointBlockGenerator
 import io.iohk.ethereum.consensus.pow.validators.OmmersValidator
 import io.iohk.ethereum.consensus.pow.validators.StdOmmersValidator

--- a/src/it/scala/io/iohk/ethereum/sync/util/RegularSyncItSpecUtils.scala
+++ b/src/it/scala/io/iohk/ethereum/sync/util/RegularSyncItSpecUtils.scala
@@ -4,11 +4,14 @@ import akka.actor.ActorRef
 import akka.actor.typed
 import akka.actor.typed.scaladsl.adapter._
 import akka.util.ByteString
+
 import cats.effect.Resource
+
 import monix.eval.Task
 import monix.execution.Scheduler
 
 import scala.concurrent.duration._
+
 import io.iohk.ethereum.Mocks.MockValidatorsAlwaysSucceed
 import io.iohk.ethereum.blockchain.sync.PeersClient
 import io.iohk.ethereum.blockchain.sync.SyncProtocol
@@ -23,11 +26,14 @@ import io.iohk.ethereum.blockchain.sync.regular.BlockImporter.Start
 import io.iohk.ethereum.blockchain.sync.regular.RegularSync
 import io.iohk.ethereum.blockchain.sync.regular.RegularSync.NewCheckpoint
 import io.iohk.ethereum.checkpointing.CheckpointingTestHelpers
-import io.iohk.ethereum.consensus.{Consensus, ConsensusAdapter, ConsensusImpl, pow}
+import io.iohk.ethereum.consensus.Consensus
+import io.iohk.ethereum.consensus.ConsensusAdapter
+import io.iohk.ethereum.consensus.ConsensusImpl
 import io.iohk.ethereum.consensus.blocks.CheckpointBlockGenerator
 import io.iohk.ethereum.consensus.mining.FullMiningConfig
 import io.iohk.ethereum.consensus.mining.MiningConfig
 import io.iohk.ethereum.consensus.mining.Protocol.NoAdditionalPoWData
+import io.iohk.ethereum.consensus.pow
 import io.iohk.ethereum.consensus.pow.EthashConfig
 import io.iohk.ethereum.consensus.pow.PoWMining
 import io.iohk.ethereum.consensus.pow.validators.ValidatorsExecutor

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/SyncController.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/SyncController.scala
@@ -6,10 +6,9 @@ import akka.actor.ActorRef
 import akka.actor.PoisonPill
 import akka.actor.Props
 import akka.actor.Scheduler
-
 import io.iohk.ethereum.blockchain.sync.fast.FastSync
 import io.iohk.ethereum.blockchain.sync.regular.RegularSync
-import io.iohk.ethereum.consensus.Consensus
+import io.iohk.ethereum.consensus.{Consensus, ConsensusAdapter}
 import io.iohk.ethereum.consensus.validators.Validators
 import io.iohk.ethereum.db.storage.AppStateStorage
 import io.iohk.ethereum.db.storage.BlockNumberMappingStorage
@@ -34,7 +33,7 @@ class SyncController(
     stateStorage: StateStorage,
     nodeStorage: NodeStorage,
     fastSyncStateStorage: FastSyncStateStorage,
-    consensus: Consensus,
+    consensus: ConsensusAdapter,
     validators: Validators,
     peerEventBus: ActorRef,
     pendingTransactionsManager: ActorRef,
@@ -159,7 +158,7 @@ object SyncController {
       stateStorage: StateStorage,
       nodeStorage: NodeStorage,
       syncStateStorage: FastSyncStateStorage,
-      consensus: Consensus,
+      consensus: ConsensusAdapter,
       validators: Validators,
       peerEventBus: ActorRef,
       pendingTransactionsManager: ActorRef,

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/SyncController.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/SyncController.scala
@@ -6,9 +6,11 @@ import akka.actor.ActorRef
 import akka.actor.PoisonPill
 import akka.actor.Props
 import akka.actor.Scheduler
+
 import io.iohk.ethereum.blockchain.sync.fast.FastSync
 import io.iohk.ethereum.blockchain.sync.regular.RegularSync
-import io.iohk.ethereum.consensus.{Consensus, ConsensusAdapter}
+import io.iohk.ethereum.consensus.Consensus
+import io.iohk.ethereum.consensus.ConsensusAdapter
 import io.iohk.ethereum.consensus.validators.Validators
 import io.iohk.ethereum.db.storage.AppStateStorage
 import io.iohk.ethereum.db.storage.BlockNumberMappingStorage

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/regular/BlockImporter.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/regular/BlockImporter.scala
@@ -7,17 +7,21 @@ import akka.actor.ActorRef
 import akka.actor.NotInfluenceReceiveTimeout
 import akka.actor.Props
 import akka.actor.ReceiveTimeout
+
 import cats.data.NonEmptyList
 import cats.implicits._
+
 import monix.eval.Task
 import monix.execution.Scheduler
 
 import scala.concurrent.duration._
+
 import io.iohk.ethereum.blockchain.sync.Blacklist.BlacklistReason
 import io.iohk.ethereum.blockchain.sync.regular.BlockBroadcast.BlockToBroadcast
 import io.iohk.ethereum.blockchain.sync.regular.BlockBroadcasterActor.BroadcastBlocks
 import io.iohk.ethereum.blockchain.sync.regular.RegularSync.ProgressProtocol
-import io.iohk.ethereum.consensus.{Consensus, ConsensusAdapter}
+import io.iohk.ethereum.consensus.Consensus
+import io.iohk.ethereum.consensus.ConsensusAdapter
 import io.iohk.ethereum.crypto.kec256
 import io.iohk.ethereum.db.storage.StateStorage
 import io.iohk.ethereum.domain._

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/regular/BlockImporter.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/regular/BlockImporter.scala
@@ -7,20 +7,17 @@ import akka.actor.ActorRef
 import akka.actor.NotInfluenceReceiveTimeout
 import akka.actor.Props
 import akka.actor.ReceiveTimeout
-
 import cats.data.NonEmptyList
 import cats.implicits._
-
 import monix.eval.Task
 import monix.execution.Scheduler
 
 import scala.concurrent.duration._
-
 import io.iohk.ethereum.blockchain.sync.Blacklist.BlacklistReason
 import io.iohk.ethereum.blockchain.sync.regular.BlockBroadcast.BlockToBroadcast
 import io.iohk.ethereum.blockchain.sync.regular.BlockBroadcasterActor.BroadcastBlocks
 import io.iohk.ethereum.blockchain.sync.regular.RegularSync.ProgressProtocol
-import io.iohk.ethereum.consensus.Consensus
+import io.iohk.ethereum.consensus.{Consensus, ConsensusAdapter}
 import io.iohk.ethereum.crypto.kec256
 import io.iohk.ethereum.db.storage.StateStorage
 import io.iohk.ethereum.domain._
@@ -38,7 +35,7 @@ import io.iohk.ethereum.utils.FunctorOps._
 
 class BlockImporter(
     fetcher: ActorRef,
-    consensus: Consensus,
+    consensus: ConsensusAdapter,
     blockchainReader: BlockchainReader,
     stateStorage: StateStorage,
     branchResolution: BranchResolution,
@@ -331,7 +328,7 @@ object BlockImporter {
   // scalastyle:off parameter.number
   def props(
       fetcher: ActorRef,
-      consensus: Consensus,
+      consensus: ConsensusAdapter,
       blockchainReader: BlockchainReader,
       stateStorage: StateStorage,
       branchResolution: BranchResolution,

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/regular/RegularSync.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/regular/RegularSync.scala
@@ -10,7 +10,6 @@ import akka.actor.Scheduler
 import akka.actor.SupervisorStrategy
 import akka.actor.typed.scaladsl.adapter._
 import akka.actor.typed.{ActorRef => TypedActorRef}
-
 import io.iohk.ethereum.blockchain.sync.Blacklist
 import io.iohk.ethereum.blockchain.sync.SyncProtocol
 import io.iohk.ethereum.blockchain.sync.SyncProtocol.Status
@@ -19,7 +18,7 @@ import io.iohk.ethereum.blockchain.sync.regular.BlockFetcher.InternalLastBlockIm
 import io.iohk.ethereum.blockchain.sync.regular.RegularSync.NewCheckpoint
 import io.iohk.ethereum.blockchain.sync.regular.RegularSync.ProgressProtocol
 import io.iohk.ethereum.blockchain.sync.regular.RegularSync.ProgressState
-import io.iohk.ethereum.consensus.Consensus
+import io.iohk.ethereum.consensus.{Consensus, ConsensusAdapter}
 import io.iohk.ethereum.consensus.validators.BlockValidator
 import io.iohk.ethereum.db.storage.StateStorage
 import io.iohk.ethereum.domain.Block
@@ -33,7 +32,7 @@ class RegularSync(
     peersClient: ActorRef,
     etcPeerManager: ActorRef,
     peerEventBus: ActorRef,
-    consensus: Consensus,
+    consensus: ConsensusAdapter,
     blockchainReader: BlockchainReader,
     stateStorage: StateStorage,
     branchResolution: BranchResolution,
@@ -137,7 +136,7 @@ object RegularSync {
       peersClient: ActorRef,
       etcPeerManager: ActorRef,
       peerEventBus: ActorRef,
-      consensus: Consensus,
+      consensus: ConsensusAdapter,
       blockchainReader: BlockchainReader,
       stateStorage: StateStorage,
       branchResolution: BranchResolution,

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/regular/RegularSync.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/regular/RegularSync.scala
@@ -10,6 +10,7 @@ import akka.actor.Scheduler
 import akka.actor.SupervisorStrategy
 import akka.actor.typed.scaladsl.adapter._
 import akka.actor.typed.{ActorRef => TypedActorRef}
+
 import io.iohk.ethereum.blockchain.sync.Blacklist
 import io.iohk.ethereum.blockchain.sync.SyncProtocol
 import io.iohk.ethereum.blockchain.sync.SyncProtocol.Status
@@ -18,7 +19,8 @@ import io.iohk.ethereum.blockchain.sync.regular.BlockFetcher.InternalLastBlockIm
 import io.iohk.ethereum.blockchain.sync.regular.RegularSync.NewCheckpoint
 import io.iohk.ethereum.blockchain.sync.regular.RegularSync.ProgressProtocol
 import io.iohk.ethereum.blockchain.sync.regular.RegularSync.ProgressState
-import io.iohk.ethereum.consensus.{Consensus, ConsensusAdapter}
+import io.iohk.ethereum.consensus.Consensus
+import io.iohk.ethereum.consensus.ConsensusAdapter
 import io.iohk.ethereum.consensus.validators.BlockValidator
 import io.iohk.ethereum.db.storage.StateStorage
 import io.iohk.ethereum.domain.Block

--- a/src/main/scala/io/iohk/ethereum/consensus/Consensus.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/Consensus.scala
@@ -12,8 +12,8 @@ import io.iohk.ethereum.utils.BlockchainConfig
   * still in progress
   */
 trait Consensus {
-  def evaluateBranchBlock(
-      block: Block
+  def evaluateBranch(
+      block: Seq[Block]
   )(implicit blockExecutionScheduler: Scheduler, blockchainConfig: BlockchainConfig): Task[BlockImportResult]
 
   /** Original interface from ETCM-1018, for temporary documentation purposes

--- a/src/main/scala/io/iohk/ethereum/consensus/ConsensusAdapter.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/ConsensusAdapter.scala
@@ -1,0 +1,17 @@
+package io.iohk.ethereum.consensus
+
+import io.iohk.ethereum.blockchain.sync.regular.BlockImportResult
+import io.iohk.ethereum.domain.Block
+import io.iohk.ethereum.utils.BlockchainConfig
+import monix.eval.Task
+import monix.execution.Scheduler
+
+/** This is a temporary class to isolate the real Consensus and extract responsibilities which should not
+  * be part of the consensus in the final design, but are currently needed.
+  */
+class ConsensusAdapter(consensus: Consensus) {
+  def evaluateBranchBlock(
+      block: Block
+  )(implicit blockExecutionScheduler: Scheduler, blockchainConfig: BlockchainConfig): Task[BlockImportResult] =
+    consensus.evaluateBranch(Seq(block))
+}

--- a/src/main/scala/io/iohk/ethereum/consensus/ConsensusAdapter.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/ConsensusAdapter.scala
@@ -44,6 +44,7 @@ class ConsensusAdapter(
           }
         }
       case None =>
+        log.error("Couldn't find the current best block")
         Task.now(BlockImportFailed("Couldn't find the current best block"))
     }
 

--- a/src/main/scala/io/iohk/ethereum/consensus/ConsensusAdapter.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/ConsensusAdapter.scala
@@ -1,17 +1,58 @@
 package io.iohk.ethereum.consensus
 
-import io.iohk.ethereum.blockchain.sync.regular.BlockImportResult
-import io.iohk.ethereum.domain.Block
-import io.iohk.ethereum.utils.BlockchainConfig
+import io.iohk.ethereum.blockchain.sync.regular.{BlockImportFailed, BlockImportResult, DuplicateBlock}
+import io.iohk.ethereum.domain.{Block, BlockHeader, BlockchainReader}
+import io.iohk.ethereum.ledger.BlockExecutionError.ValidationBeforeExecError
+import io.iohk.ethereum.ledger.{BlockExecutionSuccess, BlockQueue, BlockValidation}
+import io.iohk.ethereum.utils.{BlockchainConfig, Logger}
 import monix.eval.Task
+import io.iohk.ethereum.utils.FunctorOps._
 import monix.execution.Scheduler
 
 /** This is a temporary class to isolate the real Consensus and extract responsibilities which should not
   * be part of the consensus in the final design, but are currently needed.
   */
-class ConsensusAdapter(consensus: Consensus) {
+class ConsensusAdapter(
+    consensus: Consensus,
+    blockchainReader: BlockchainReader,
+    blockQueue: BlockQueue,
+    blockValidation: BlockValidation,
+    validationScheduler: Scheduler
+) extends Logger {
   def evaluateBranchBlock(
       block: Block
   )(implicit blockExecutionScheduler: Scheduler, blockchainConfig: BlockchainConfig): Task[BlockImportResult] =
-    consensus.evaluateBranch(Seq(block))
+    blockchainReader.getBestBlock() match {
+      case Some(bestBlock) =>
+        if (isBlockADuplicate(block.header, bestBlock.header.number)) {
+          log.debug("Ignoring duplicated block: {}", block.idTag)
+          Task.now(DuplicateBlock)
+        } else {
+          doBlockPreValidation(block).flatMap {
+            case Left(error) =>
+              Task.now(BlockImportFailed(error.reason.toString))
+            case Right(BlockExecutionSuccess) =>
+              consensus.evaluateBranch(Seq(block))
+          }
+        }
+    }
+
+  private def doBlockPreValidation(block: Block)(implicit
+      blockchainConfig: BlockchainConfig
+  ): Task[Either[ValidationBeforeExecError, BlockExecutionSuccess]] =
+    Task
+      .evalOnce(blockValidation.validateBlockBeforeExecution(block))
+      .tap {
+        case Left(error) =>
+          log.error("Error while validating block with hash {} before execution: {}", block.hash, error.reason)
+        case Right(_) => log.debug("Block with hash {} validated successfully", block.hash)
+      }
+      .executeOn(validationScheduler)
+
+  private def isBlockADuplicate(block: BlockHeader, currentBestBlockNumber: BigInt): Boolean = {
+    val hash = block.hash
+    blockchainReader.getBlockByHash(hash).isDefined &&
+    block.number <= currentBestBlockNumber ||
+    blockQueue.isQueued(hash)
+  }
 }

--- a/src/main/scala/io/iohk/ethereum/consensus/ConsensusAdapter.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/ConsensusAdapter.scala
@@ -15,6 +15,7 @@ import io.iohk.ethereum.ledger.BlockQueue
 import io.iohk.ethereum.ledger.BlockValidation
 import io.iohk.ethereum.utils.BlockchainConfig
 import io.iohk.ethereum.utils.FunctorOps._
+import io.iohk.ethereum.utils.Hex
 import io.iohk.ethereum.utils.Logger
 
 /** This is a temporary class to isolate the real Consensus and extract responsibilities which should not
@@ -55,8 +56,12 @@ class ConsensusAdapter(
       .evalOnce(blockValidation.validateBlockBeforeExecution(block))
       .tap {
         case Left(error) =>
-          log.error("Error while validating block with hash {} before execution: {}", block.hash, error.reason)
-        case Right(_) => log.debug("Block with hash {} validated successfully", block.hash)
+          log.error(
+            "Error while validating block with hash {} before execution: {}",
+            Hex.toHexString(block.hash.toArray),
+            error.reason.toString
+          )
+        case Right(_) => log.debug("Block with hash {} validated successfully", Hex.toHexString(block.hash.toArray))
       }
       .executeOn(validationScheduler)
 

--- a/src/main/scala/io/iohk/ethereum/consensus/ConsensusAdapter.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/ConsensusAdapter.scala
@@ -1,13 +1,21 @@
 package io.iohk.ethereum.consensus
 
-import io.iohk.ethereum.blockchain.sync.regular.{BlockImportFailed, BlockImportResult, DuplicateBlock}
-import io.iohk.ethereum.domain.{Block, BlockHeader, BlockchainReader}
-import io.iohk.ethereum.ledger.BlockExecutionError.ValidationBeforeExecError
-import io.iohk.ethereum.ledger.{BlockExecutionSuccess, BlockQueue, BlockValidation}
-import io.iohk.ethereum.utils.{BlockchainConfig, Logger}
 import monix.eval.Task
-import io.iohk.ethereum.utils.FunctorOps._
 import monix.execution.Scheduler
+
+import io.iohk.ethereum.blockchain.sync.regular.BlockImportFailed
+import io.iohk.ethereum.blockchain.sync.regular.BlockImportResult
+import io.iohk.ethereum.blockchain.sync.regular.DuplicateBlock
+import io.iohk.ethereum.domain.Block
+import io.iohk.ethereum.domain.BlockHeader
+import io.iohk.ethereum.domain.BlockchainReader
+import io.iohk.ethereum.ledger.BlockExecutionError.ValidationBeforeExecError
+import io.iohk.ethereum.ledger.BlockExecutionSuccess
+import io.iohk.ethereum.ledger.BlockQueue
+import io.iohk.ethereum.ledger.BlockValidation
+import io.iohk.ethereum.utils.BlockchainConfig
+import io.iohk.ethereum.utils.FunctorOps._
+import io.iohk.ethereum.utils.Logger
 
 /** This is a temporary class to isolate the real Consensus and extract responsibilities which should not
   * be part of the consensus in the final design, but are currently needed.

--- a/src/main/scala/io/iohk/ethereum/consensus/ConsensusAdapter.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/ConsensusAdapter.scala
@@ -35,6 +35,8 @@ class ConsensusAdapter(
               consensus.evaluateBranch(Seq(block))
           }
         }
+      case None =>
+        Task.now(BlockImportFailed("Couldn't find the current best block"))
     }
 
   private def doBlockPreValidation(block: Block)(implicit

--- a/src/main/scala/io/iohk/ethereum/consensus/ConsensusImpl.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/ConsensusImpl.scala
@@ -63,9 +63,10 @@ class ConsensusImpl(
     *   - [[DuplicateBlock]]     - block already exists either in the main chain or in the queue
     *   - [[BlockImportFailed]]  - block failed to execute (when importing to top or reorganising the chain)
     */
-  override def evaluateBranchBlock(
-      block: Block
-  )(implicit blockExecutionScheduler: Scheduler, blockchainConfig: BlockchainConfig): Task[BlockImportResult] =
+  override def evaluateBranch(
+      branch: Seq[Block]
+  )(implicit blockExecutionScheduler: Scheduler, blockchainConfig: BlockchainConfig): Task[BlockImportResult] = {
+    val block = branch.head
     blockchainReader.getBestBlock() match {
       case Some(bestBlock) =>
         if (isBlockADuplicate(block.header, bestBlock.header.number)) {
@@ -83,6 +84,7 @@ class ConsensusImpl(
         }
       case None => returnNoBestBlock()
     }
+  }
 
   private def handleBlockImport(block: Block, bestBlock: Block, weight: ChainWeight)(implicit
       blockExecutionScheduler: Scheduler,

--- a/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
@@ -2,10 +2,13 @@ package io.iohk.ethereum.nodebuilder
 
 import java.time.Clock
 import java.util.concurrent.atomic.AtomicReference
+
 import akka.actor.ActorRef
 import akka.actor.ActorSystem
 import akka.util.ByteString
+
 import cats.implicits._
+
 import monix.eval.Task
 import monix.execution.Scheduler
 
@@ -14,13 +17,17 @@ import scala.concurrent.duration._
 import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
+
 import org.bouncycastle.crypto.AsymmetricCipherKeyPair
+
 import io.iohk.ethereum.blockchain.data.GenesisDataLoader
 import io.iohk.ethereum.blockchain.sync.Blacklist
 import io.iohk.ethereum.blockchain.sync.BlockchainHostActor
 import io.iohk.ethereum.blockchain.sync.CacheBasedBlacklist
 import io.iohk.ethereum.blockchain.sync.SyncController
-import io.iohk.ethereum.consensus.{Consensus, ConsensusAdapter, ConsensusImpl}
+import io.iohk.ethereum.consensus.Consensus
+import io.iohk.ethereum.consensus.ConsensusAdapter
+import io.iohk.ethereum.consensus.ConsensusImpl
 import io.iohk.ethereum.consensus.blocks.CheckpointBlockGenerator
 import io.iohk.ethereum.consensus.mining.MiningBuilder
 import io.iohk.ethereum.consensus.mining.MiningConfigBuilder

--- a/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
@@ -199,13 +199,17 @@ trait ConsensusBuilder {
       blockchainReader,
       blockchainWriter,
       blockQueue,
-      blockValidation,
-      blockExecution,
-      Scheduler(system.dispatchers.lookup("validation-context"))
+      blockExecution
     )
 
   lazy val consensusAdapter: ConsensusAdapter =
-    new ConsensusAdapter(consensus)
+    new ConsensusAdapter(
+      consensus,
+      blockchainReader,
+      blockQueue,
+      blockValidation,
+      Scheduler(system.dispatchers.lookup("validation-context"))
+    )
 }
 
 trait ForkResolverBuilder {

--- a/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
@@ -2,13 +2,10 @@ package io.iohk.ethereum.nodebuilder
 
 import java.time.Clock
 import java.util.concurrent.atomic.AtomicReference
-
 import akka.actor.ActorRef
 import akka.actor.ActorSystem
 import akka.util.ByteString
-
 import cats.implicits._
-
 import monix.eval.Task
 import monix.execution.Scheduler
 
@@ -17,16 +14,13 @@ import scala.concurrent.duration._
 import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
-
 import org.bouncycastle.crypto.AsymmetricCipherKeyPair
-
 import io.iohk.ethereum.blockchain.data.GenesisDataLoader
 import io.iohk.ethereum.blockchain.sync.Blacklist
 import io.iohk.ethereum.blockchain.sync.BlockchainHostActor
 import io.iohk.ethereum.blockchain.sync.CacheBasedBlacklist
 import io.iohk.ethereum.blockchain.sync.SyncController
-import io.iohk.ethereum.consensus.Consensus
-import io.iohk.ethereum.consensus.ConsensusImpl
+import io.iohk.ethereum.consensus.{Consensus, ConsensusAdapter, ConsensusImpl}
 import io.iohk.ethereum.consensus.blocks.CheckpointBlockGenerator
 import io.iohk.ethereum.consensus.mining.MiningBuilder
 import io.iohk.ethereum.consensus.mining.MiningConfigBuilder
@@ -209,6 +203,9 @@ trait ConsensusBuilder {
       blockExecution,
       Scheduler(system.dispatchers.lookup("validation-context"))
     )
+
+  lazy val consensusAdapter: ConsensusAdapter =
+    new ConsensusAdapter(consensus)
 }
 
 trait ForkResolverBuilder {
@@ -755,7 +752,7 @@ trait SyncControllerBuilder {
       storagesInstance.storages.stateStorage,
       storagesInstance.storages.nodeStorage,
       storagesInstance.storages.fastSyncStateStorage,
-      consensus,
+      consensusAdapter,
       mining.validators,
       peerEventBus,
       pendingTransactionsManager,

--- a/src/main/scala/io/iohk/ethereum/testmode/TestModeComponentsProvider.scala
+++ b/src/main/scala/io/iohk/ethereum/testmode/TestModeComponentsProvider.scala
@@ -48,10 +48,12 @@ class TestModeComponentsProvider(
         blockchainReader,
         blockchainWriter,
         node.blockQueue,
-        blockValidation,
-        blockExecution,
-        validationExecutionContext
-      )
+        blockExecution
+      ),
+      blockchainReader,
+      node.blockQueue,
+      blockValidation,
+      validationExecutionContext
     )
   }
 

--- a/src/main/scala/io/iohk/ethereum/testmode/TestModeComponentsProvider.scala
+++ b/src/main/scala/io/iohk/ethereum/testmode/TestModeComponentsProvider.scala
@@ -1,11 +1,8 @@
 package io.iohk.ethereum.testmode
 
 import akka.util.ByteString
-
 import monix.execution.Scheduler
-
-import io.iohk.ethereum.consensus.Consensus
-import io.iohk.ethereum.consensus.ConsensusImpl
+import io.iohk.ethereum.consensus.{Consensus, ConsensusAdapter, ConsensusImpl}
 import io.iohk.ethereum.consensus.mining.MiningConfig
 import io.iohk.ethereum.crypto
 import io.iohk.ethereum.db.storage.EvmCodeStorage
@@ -31,7 +28,7 @@ class TestModeComponentsProvider(
 
   def getConsensus(
       preimageCache: collection.concurrent.Map[ByteString, UInt256]
-  ): Consensus = {
+  ): ConsensusAdapter = {
     val consensuz = consensus()
     val blockValidation = new BlockValidation(consensuz, blockchainReader, node.blockQueue)
     val blockExecution =
@@ -45,14 +42,16 @@ class TestModeComponentsProvider(
         (key: UInt256) => preimageCache.put(crypto.kec256(key.bytes), key)
       )
 
-    new ConsensusImpl(
-      blockchain,
-      blockchainReader,
-      blockchainWriter,
-      node.blockQueue,
-      blockValidation,
-      blockExecution,
-      validationExecutionContext
+    new ConsensusAdapter(
+      new ConsensusImpl(
+        blockchain,
+        blockchainReader,
+        blockchainWriter,
+        node.blockQueue,
+        blockValidation,
+        blockExecution,
+        validationExecutionContext
+      )
     )
   }
 

--- a/src/main/scala/io/iohk/ethereum/testmode/TestModeComponentsProvider.scala
+++ b/src/main/scala/io/iohk/ethereum/testmode/TestModeComponentsProvider.scala
@@ -1,8 +1,12 @@
 package io.iohk.ethereum.testmode
 
 import akka.util.ByteString
+
 import monix.execution.Scheduler
-import io.iohk.ethereum.consensus.{Consensus, ConsensusAdapter, ConsensusImpl}
+
+import io.iohk.ethereum.consensus.Consensus
+import io.iohk.ethereum.consensus.ConsensusAdapter
+import io.iohk.ethereum.consensus.ConsensusImpl
 import io.iohk.ethereum.consensus.mining.MiningConfig
 import io.iohk.ethereum.crypto
 import io.iohk.ethereum.db.storage.EvmCodeStorage

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/ScenarioSetup.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/ScenarioSetup.scala
@@ -95,10 +95,12 @@ trait ScenarioSetup extends StdTestMiningBuilder with StxLedgerBuilder {
         blockchainReader,
         blockchainWriter,
         blockQueue,
-        blockValidation,
-        blockExecutionOpt.getOrElse(mkBlockExecution(validators)),
-        Scheduler(system.dispatchers.lookup("validation-context"))
-      )
+        blockExecutionOpt.getOrElse(mkBlockExecution(validators))
+      ),
+      blockchainReader,
+      blockQueue,
+      blockValidation,
+      Scheduler(system.dispatchers.lookup("validation-context"))
     )
   }
 

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/ScenarioSetup.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/ScenarioSetup.scala
@@ -1,13 +1,17 @@
 package io.iohk.ethereum.blockchain.sync
 
 import java.util.concurrent.Executors
+
 import monix.execution.Scheduler
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.ExecutionContextExecutor
+
 import io.iohk.ethereum.Mocks
 import io.iohk.ethereum.Mocks.MockVM
-import io.iohk.ethereum.consensus.{Consensus, ConsensusAdapter, ConsensusImpl}
+import io.iohk.ethereum.consensus.Consensus
+import io.iohk.ethereum.consensus.ConsensusAdapter
+import io.iohk.ethereum.consensus.ConsensusImpl
 import io.iohk.ethereum.consensus.mining.Mining
 import io.iohk.ethereum.consensus.mining.Protocol
 import io.iohk.ethereum.consensus.mining.StdTestMiningBuilder

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/SyncControllerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/SyncControllerSpec.scala
@@ -557,7 +557,7 @@ class SyncControllerSpec
           storagesInstance.storages.stateStorage,
           storagesInstance.storages.nodeStorage,
           storagesInstance.storages.fastSyncStateStorage,
-          consensus,
+          consensusAdapter,
           validators,
           peerMessageBus.ref,
           pendingTransactionsManager.ref,

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/regular/RegularSyncFixtures.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/regular/RegularSyncFixtures.scala
@@ -1,6 +1,7 @@
 package io.iohk.ethereum.blockchain.sync.regular
 
 import java.net.InetSocketAddress
+
 import akka.actor.ActorRef
 import akka.actor.ActorSystem
 import akka.actor.PoisonPill
@@ -10,9 +11,11 @@ import akka.testkit.TestKitBase
 import akka.testkit.TestProbe
 import akka.util.ByteString
 import akka.util.Timeout
+
 import cats.Eq
 import cats.data.NonEmptyList
 import cats.implicits._
+
 import monix.eval.Task
 import monix.execution.Scheduler
 import monix.reactive.Observable
@@ -23,11 +26,15 @@ import scala.concurrent.duration.DurationInt
 import scala.concurrent.duration.FiniteDuration
 import scala.math.BigInt
 import scala.reflect.ClassTag
+
 import org.scalamock.scalatest.AsyncMockFactory
 import org.scalatest.matchers.should.Matchers
+
 import io.iohk.ethereum.BlockHelpers
 import io.iohk.ethereum.blockchain.sync._
-import io.iohk.ethereum.consensus.{Consensus, ConsensusAdapter, ConsensusImpl}
+import io.iohk.ethereum.consensus.Consensus
+import io.iohk.ethereum.consensus.ConsensusAdapter
+import io.iohk.ethereum.consensus.ConsensusImpl
 import io.iohk.ethereum.consensus.blocks.CheckpointBlockGenerator
 import io.iohk.ethereum.db.storage.StateStorage
 import io.iohk.ethereum.domain.BlockHeaderImplicits._

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/regular/RegularSyncSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/regular/RegularSyncSpec.scala
@@ -8,8 +8,10 @@ import akka.testkit.TestActor.AutoPilot
 import akka.testkit.TestKit
 import akka.testkit.TestProbe
 import akka.util.ByteString
+
 import cats.effect.Resource
 import cats.syntax.traverse._
+
 import monix.eval.Task
 import monix.execution.Scheduler
 
@@ -18,11 +20,13 @@ import scala.concurrent.Future
 import scala.concurrent.Promise
 import scala.concurrent.duration._
 import scala.math.BigInt
+
 import org.scalamock.scalatest.AsyncMockFactory
 import org.scalatest.Assertion
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.diagrams.Diagrams
 import org.scalatest.matchers.should.Matchers
+
 import io.iohk.ethereum.BlockHelpers
 import io.iohk.ethereum.ObjectGenerators
 import io.iohk.ethereum.ResourceFixtures
@@ -34,7 +38,9 @@ import io.iohk.ethereum.blockchain.sync.SyncProtocol.Status
 import io.iohk.ethereum.blockchain.sync.SyncProtocol.Status.Progress
 import io.iohk.ethereum.blockchain.sync.regular.BlockFetcher.Start
 import io.iohk.ethereum.blockchain.sync.regular.RegularSync.NewCheckpoint
-import io.iohk.ethereum.consensus.{Consensus, ConsensusAdapter, ConsensusImpl}
+import io.iohk.ethereum.consensus.Consensus
+import io.iohk.ethereum.consensus.ConsensusAdapter
+import io.iohk.ethereum.consensus.ConsensusImpl
 import io.iohk.ethereum.crypto.kec256
 import io.iohk.ethereum.domain.BlockHeaderImplicits._
 import io.iohk.ethereum.domain._

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/regular/RegularSyncSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/regular/RegularSyncSpec.scala
@@ -290,8 +290,11 @@ class RegularSyncSpec
           override lazy val blockchain: BlockchainImpl = stub[BlockchainImpl]
           override lazy val blockchainReader: BlockchainReader = stub[BlockchainReader]
           (blockchainReader.getBestBlockNumber _).when().onCall(() => bestBlock.number)
-          override lazy val consensus: Consensus = new FakeConsensus()
-          override lazy val consensusAdapter: ConsensusAdapter = new ConsensusAdapter(consensus)
+          override lazy val consensusAdapter: ConsensusAdapter = stub[ConsensusAdapter]
+          (consensusAdapter
+            .evaluateBranchBlock(_: Block)(_: Scheduler, _: BlockchainConfig))
+            .when(*, *, *)
+            .onCall((block, scheduler, conf) => fakeEvaluateBlock(block)(scheduler, conf))
           override lazy val branchResolution: BranchResolution = new FakeBranchResolution()
           override lazy val syncConfig = defaultSyncConfig.copy(
             blockHeadersPerRequest = 5,
@@ -347,7 +350,11 @@ class RegularSyncSpec
         override lazy val blockchainReader: BlockchainReader = stub[BlockchainReader]
         override lazy val blockchain: BlockchainImpl = stub[BlockchainImpl]
         (blockchainReader.getBestBlockNumber _).when().onCall(() => bestBlock.number)
-        override lazy val consensus: Consensus = new FakeConsensus()
+        override lazy val consensusAdapter: ConsensusAdapter = stub[ConsensusAdapter]
+        (consensusAdapter
+          .evaluateBranchBlock(_: Block)(_: Scheduler, _: BlockchainConfig))
+          .when(*, *, *)
+          .onCall((block, scheduler, conf) => fakeEvaluateBlock(block)(scheduler, conf))
         override lazy val branchResolution: BranchResolution = new FakeBranchResolution()
         override lazy val syncConfig = defaultSyncConfig.copy(
           syncRetryInterval = 1.second,

--- a/src/test/scala/io/iohk/ethereum/consensus/ConsensusSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/ConsensusSpec.scala
@@ -46,12 +46,12 @@ class ConsensusSpec extends AnyFlatSpec with Matchers with ScalaFutures {
     setBlockExists(block1, inChain = true, inQueue = false)
     setBestBlock(bestBlock)
 
-    whenReady(consensus.evaluateBranchBlock(block1).runToFuture)(_ shouldEqual DuplicateBlock)
+    whenReady(consensusAdapter.evaluateBranchBlock(block1).runToFuture)(_ shouldEqual DuplicateBlock)
 
     setBlockExists(block2, inChain = false, inQueue = true)
     setBestBlock(bestBlock)
 
-    whenReady(consensus.evaluateBranchBlock(block2).runToFuture)(_ shouldEqual DuplicateBlock)
+    whenReady(consensusAdapter.evaluateBranchBlock(block2).runToFuture)(_ shouldEqual DuplicateBlock)
   }
 
   it should "import a block to the top of the main chain" in new ImportBlockTestSetup {
@@ -111,7 +111,7 @@ class ConsensusSpec extends AnyFlatSpec with Matchers with ScalaFutures {
 
     (blockQueue.removeSubtree _).expects(*)
 
-    whenReady(consensus.evaluateBranchBlock(block).runToFuture)(
+    whenReady(consensusAdapter.evaluateBranchBlock(block).runToFuture)(
       _ shouldBe BlockImportFailed("MPTError(io.iohk.ethereum.mpt.MerklePatriciaTrie$MPTException: Invalid Node)")
     )
   }
@@ -123,7 +123,7 @@ class ConsensusSpec extends AnyFlatSpec with Matchers with ScalaFutures {
     (blockchainReader.getBestBlock _).expects().returning(None)
     setChainWeightForBlock(bestBlock, currentWeight)
 
-    whenReady(consensus.evaluateBranchBlock(block).runToFuture)(
+    whenReady(consensusAdapter.evaluateBranchBlock(block).runToFuture)(
       _ shouldBe BlockImportFailed("Couldn't find the current best block")
     )
   }
@@ -137,7 +137,7 @@ class ConsensusSpec extends AnyFlatSpec with Matchers with ScalaFutures {
 
     (blockchainReader.getBlockHeaderByHash _).expects(*).returning(Some(block.header))
 
-    whenReady(consensus.evaluateBranchBlock(block).runToFuture) { result =>
+    whenReady(consensusAdapter.evaluateBranchBlock(block).runToFuture) { result =>
       result shouldBe a[BlockImportFailed]
       result
         .asInstanceOf[BlockImportFailed]
@@ -256,7 +256,7 @@ class ConsensusSpec extends AnyFlatSpec with Matchers with ScalaFutures {
       .expects(newBlock.header, *, *)
       .returning(Left(HeaderParentNotFoundError))
 
-    whenReady(consensus.evaluateBranchBlock(newBlock).runToFuture)(
+    whenReady(consensusAdapter.evaluateBranchBlock(newBlock).runToFuture)(
       _ shouldEqual BlockImportFailed("HeaderParentNotFoundError")
     )
   }
@@ -276,7 +276,7 @@ class ConsensusSpec extends AnyFlatSpec with Matchers with ScalaFutures {
       .expects(newBlock.header, *, *)
       .returning(Left(HeaderDifficultyError))
 
-    whenReady(consensus.evaluateBranchBlock(newBlock).runToFuture) {
+    whenReady(consensusAdapter.evaluateBranchBlock(newBlock).runToFuture) {
       _ shouldEqual BlockImportFailed(HeaderDifficultyError.toString)
     }
   }

--- a/src/test/scala/io/iohk/ethereum/consensus/blocks/BlockGeneratorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/blocks/BlockGeneratorSpec.scala
@@ -109,7 +109,7 @@ class BlockGeneratorSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
     )
 
     // Import Block, to create some existing state
-    consensus.evaluateBranchBlock(fullBlock).runSyncUnsafe()
+    consensusAdapter.evaluateBranchBlock(fullBlock).runSyncUnsafe()
 
     // Create new pending block, with updated stateRootHash
     val pendBlockAndState = blockGenerator.generateBlock(

--- a/src/test/scala/io/iohk/ethereum/ledger/LedgerTestSetup.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/LedgerTestSetup.scala
@@ -434,7 +434,7 @@ trait MockBlockchain extends MockFactory { self: TestSetupWithVmAndValidators =>
   }
 
   def setBestBlock(block: Block): CallHandler0[BigInt] = {
-    (blockchainReader.getBestBlock _).expects().returning(Some(block))
+    (blockchainReader.getBestBlock _).expects().anyNumberOfTimes().returning(Some(block))
     (blockchainReader.getBestBlockNumber _).expects().anyNumberOfTimes().returning(block.header.number)
   }
 

--- a/src/test/scala/io/iohk/ethereum/ledger/LedgerTestSetup.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/LedgerTestSetup.scala
@@ -2,8 +2,11 @@ package io.iohk.ethereum.ledger
 
 import akka.util.ByteString
 import akka.util.ByteString.{empty => bEmpty}
+
 import cats.data.NonEmptyList
+
 import monix.execution.Scheduler
+
 import org.bouncycastle.crypto.AsymmetricCipherKeyPair
 import org.bouncycastle.crypto.params.ECPublicKeyParameters
 import org.bouncycastle.util.encoders.Hex
@@ -12,11 +15,14 @@ import org.scalamock.handlers.CallHandler1
 import org.scalamock.handlers.CallHandler2
 import org.scalamock.handlers.CallHandler4
 import org.scalamock.scalatest.MockFactory
+
 import io.iohk.ethereum.Fixtures
 import io.iohk.ethereum.Mocks
 import io.iohk.ethereum.ObjectGenerators
 import io.iohk.ethereum.blockchain.sync.EphemBlockchainTestSetup
-import io.iohk.ethereum.consensus.{Consensus, ConsensusAdapter, ConsensusImpl}
+import io.iohk.ethereum.consensus.Consensus
+import io.iohk.ethereum.consensus.ConsensusAdapter
+import io.iohk.ethereum.consensus.ConsensusImpl
 import io.iohk.ethereum.consensus.blocks.CheckpointBlockGenerator
 import io.iohk.ethereum.consensus.mining.GetBlockHeaderByHash
 import io.iohk.ethereum.consensus.mining.TestMining

--- a/src/test/scala/io/iohk/ethereum/ledger/LedgerTestSetup.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/LedgerTestSetup.scala
@@ -378,7 +378,6 @@ trait TestSetupWithVmAndValidators extends EphemBlockchainTestSetup {
       blockchainReader,
       blockchainWriter,
       blockQueue,
-      blockValidation,
       new BlockExecution(
         blockchain,
         blockchainReader,
@@ -402,10 +401,15 @@ trait TestSetupWithVmAndValidators extends EphemBlockchainTestSetup {
           )
           Right(BlockResult(emptyWorld).receipts)
         }
-      },
+      }
+    )
+    new ConsensusAdapter(
+      consensus,
+      blockchainReader,
+      blockQueue,
+      blockValidation,
       Scheduler(system.dispatchers.lookup("validation-context"))
     )
-    new ConsensusAdapter(consensus)
   }
 }
 


### PR DESCRIPTION
# Description

This PR introduces the `ConsensusAdapter`. It will do much more later but the modifier code is getting quite big so I prefer to create a first small PR with a partial implementation and have another PR(s) with the bigger changes. 

The `ConsensusAdapter` wraps the Consensus. For now, it only does prevalidation and duplicate checks.

