### PR TITLE
[ETCM-1045] Move getChainWeight to BlockchainReader

### DIFF
--- a/src/it/scala/io/iohk/ethereum/ledger/BlockImporterItSpec.scala
+++ b/src/it/scala/io/iohk/ethereum/ledger/BlockImporterItSpec.scala
@@ -61,7 +61,7 @@ class BlockImporterItSpec
         mkConsensus(validators = successValidators),
         blockchainReader,
         storagesInstance.storages.stateStorage,
-        new BranchResolution(blockchain, blockchainReader),
+        new BranchResolution(blockchainReader),
         syncConfig,
         ommersPoolProbe.ref,
         broadcasterProbe.ref,
@@ -174,7 +174,7 @@ class BlockImporterItSpec
         mkConsensus(validators = successValidators),
         blockchainReader,
         storagesInstance.storages.stateStorage,
-        new BranchResolution(blockchain, blockchainReader),
+        new BranchResolution(blockchainReader),
         syncConfig,
         ommersPoolProbe.ref,
         broadcasterProbe.ref,
@@ -203,7 +203,7 @@ class BlockImporterItSpec
 
 class TestFixture extends TestSetupWithVmAndValidators {
 
-  override lazy val blockQueue: BlockQueue = BlockQueue(blockchain, blockchainReader, SyncConfig(Config.config))
+  override lazy val blockQueue: BlockQueue = BlockQueue(blockchainReader, SyncConfig(Config.config))
 
   val genesis: Block = Block(
     Fixtures.Blocks.Genesis.header.copy(stateRoot = ByteString(MerklePatriciaTrie.EmptyRootHash)),
@@ -261,7 +261,7 @@ class TestFixture extends TestSetupWithVmAndValidators {
       consensus,
       blockchainReader,
       storagesInstance.storages.stateStorage,
-      new BranchResolution(blockchain, blockchainReader),
+      new BranchResolution(blockchainReader),
       syncConfig,
       ommersPoolProbe.ref,
       broadcasterProbe.ref,

--- a/src/it/scala/io/iohk/ethereum/sync/RegularSyncItSpec.scala
+++ b/src/it/scala/io/iohk/ethereum/sync/RegularSyncItSpec.scala
@@ -178,16 +178,23 @@ class RegularSyncItSpec extends FreeSpecBase with Matchers with BeforeAndAfterAl
       _ <- peer2.waitForRegularSyncLoadLastBlock(blockNumer + 3)
     } yield {
       assert(
-        peer1.bl.getChainWeightByHash(peer1.blockchainReader.getBestBlock().get.hash) == peer2.bl.getChainWeightByHash(
-          peer2.blockchainReader.getBestBlock().get.hash
-        )
+        peer1.blockchainReader.getChainWeightByHash(
+          peer1.blockchainReader.getBestBlock().get.hash
+        ) == peer2.blockchainReader
+          .getChainWeightByHash(
+            peer2.blockchainReader.getBestBlock().get.hash
+          )
       )
       (
         peer1.blockchainReader.getBlockByNumber(peer1.blockchainReader.getBestBranch(), blockNumer + 1),
         peer2.blockchainReader.getBlockByNumber(peer2.blockchainReader.getBestBranch(), blockNumer + 1)
       ) match {
         case (Some(blockP1), Some(blockP2)) =>
-          assert(peer1.bl.getChainWeightByHash(blockP1.hash) == peer2.bl.getChainWeightByHash(blockP2.hash))
+          assert(
+            peer1.blockchainReader.getChainWeightByHash(blockP1.hash) == peer2.blockchainReader.getChainWeightByHash(
+              blockP2.hash
+            )
+          )
         case (_, _) => fail("invalid difficulty validation")
       }
     }

--- a/src/it/scala/io/iohk/ethereum/sync/util/CommonFakePeer.scala
+++ b/src/it/scala/io/iohk/ethereum/sync/util/CommonFakePeer.scala
@@ -283,7 +283,7 @@ abstract class CommonFakePeer(peerName: String, fakePeerCustomConfig: FakePeerCu
   def getCurrentState(): BlockchainState = {
     val bestBlock = blockchainReader.getBestBlock().get
     val currentWorldState = getMptForBlock(bestBlock)
-    val currentWeight = bl.getChainWeightByHash(bestBlock.hash).get
+    val currentWeight = blockchainReader.getChainWeightByHash(bestBlock.hash).get
     BlockchainState(bestBlock, currentWorldState, currentWeight)
   }
 
@@ -356,7 +356,7 @@ abstract class CommonFakePeer(peerName: String, fakePeerCustomConfig: FakePeerCu
       currentBestBlock: Block
   )(updateWorldForBlock: (BigInt, InMemoryWorldStateProxy) => InMemoryWorldStateProxy): Task[Unit] =
     Task {
-      val currentWeight = bl.getChainWeightByHash(currentBestBlock.hash).get
+      val currentWeight = blockchainReader.getChainWeightByHash(currentBestBlock.hash).get
       val currentWorld = getMptForBlock(currentBestBlock)
       val (newBlock, newWeight, _) =
         createChildBlock(currentBestBlock, currentWeight, currentWorld)(updateWorldForBlock)

--- a/src/it/scala/io/iohk/ethereum/sync/util/RegularSyncItSpecUtils.scala
+++ b/src/it/scala/io/iohk/ethereum/sync/util/RegularSyncItSpecUtils.scala
@@ -94,7 +94,7 @@ object RegularSyncItSpecUtils {
 
     lazy val mining: PoWMining = buildEthashMining()
 
-    lazy val blockQueue: BlockQueue = BlockQueue(bl, blockchainReader, syncConfig)
+    lazy val blockQueue: BlockQueue = BlockQueue(blockchainReader, syncConfig)
     lazy val blockValidation = new BlockValidation(mining, blockchainReader, blockQueue)
     lazy val blockExecution =
       new BlockExecution(
@@ -150,7 +150,7 @@ object RegularSyncItSpecUtils {
         blockImport,
         blockchainReader,
         storagesInstance.storages.stateStorage,
-        new BranchResolution(bl, blockchainReader),
+        new BranchResolution(blockchainReader),
         syncConfig,
         ommersPool,
         broadcasterRef,
@@ -168,7 +168,7 @@ object RegularSyncItSpecUtils {
         blockImport,
         blockchainReader,
         storagesInstance.storages.stateStorage,
-        new BranchResolution(bl, blockchainReader),
+        new BranchResolution(blockchainReader),
         validators.blockValidator,
         blacklist,
         testSyncConfig,
@@ -194,7 +194,7 @@ object RegularSyncItSpecUtils {
         case None => blockchainReader.getBestBlock().get
       }).flatMap { block =>
         Task {
-          val currentWeight = bl
+          val currentWeight = blockchainReader
             .getChainWeightByHash(block.hash)
             .getOrElse(throw new RuntimeException(s"ChainWeight by hash: ${block.hash} doesn't exist"))
           val currentWorld = getMptForBlock(block)
@@ -210,7 +210,7 @@ object RegularSyncItSpecUtils {
         plusDifficulty: BigInt = 0
     )(updateWorldForBlock: (BigInt, InMemoryWorldStateProxy) => InMemoryWorldStateProxy): Task[Unit] = Task {
       val block: Block = blockchainReader.getBestBlock().get
-      val currentWeight = bl
+      val currentWeight = blockchainReader
         .getChainWeightByHash(block.hash)
         .getOrElse(throw new RuntimeException(s"ChainWeight by hash: ${block.hash} doesn't exist"))
       val currentWorld = getMptForBlock(block)

--- a/src/it/scala/io/iohk/ethereum/txExecTest/ContractTest.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/ContractTest.scala
@@ -22,7 +22,7 @@ class ContractTest extends AnyFlatSpec with Matchers {
 
     //block only with ether transfers
     override lazy val blockValidation =
-      new BlockValidation(mining, blockchainReader, BlockQueue(blockchain, blockchainReader, syncConfig))
+      new BlockValidation(mining, blockchainReader, BlockQueue(blockchainReader, syncConfig))
     override lazy val blockExecution =
       new BlockExecution(
         blockchain,

--- a/src/it/scala/io/iohk/ethereum/txExecTest/ECIP1017Test.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/ECIP1017Test.scala
@@ -84,7 +84,7 @@ class ECIP1017Test extends AnyFlatSpec with Matchers {
       val blockchainWriter = BlockchainWriter(storages)
       val blockchain = BlockchainImpl(storages, blockchainReader)
       val blockValidation =
-        new BlockValidation(mining, blockchainReader, BlockQueue(blockchain, blockchainReader, syncConfig))
+        new BlockValidation(mining, blockchainReader, BlockQueue(blockchainReader, syncConfig))
       val blockExecution =
         new BlockExecution(
           blockchain,

--- a/src/it/scala/io/iohk/ethereum/txExecTest/ForksTest.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/ForksTest.scala
@@ -60,7 +60,7 @@ class ForksTest extends AnyFlatSpec with Matchers {
       val blockchainWriter = BlockchainWriter(storages)
       val blockchain = BlockchainImpl(storages, blockchainReader)
       val blockValidation =
-        new BlockValidation(mining, blockchainReader, BlockQueue(blockchain, blockchainReader, syncConfig))
+        new BlockValidation(mining, blockchainReader, BlockQueue(blockchainReader, syncConfig))
       val blockExecution =
         new BlockExecution(
           blockchain,

--- a/src/it/scala/io/iohk/ethereum/txExecTest/util/DumpChainApp.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/util/DumpChainApp.scala
@@ -186,8 +186,6 @@ class BlockchainMock(genesisHash: ByteString) extends Blockchain {
 
   override def removeBlock(hash: ByteString): Unit = ???
 
-  def getAccount(address: Address, blockNumber: BigInt): Option[Account] = ???
-
   override def getAccountStorageAt(rootHash: ByteString, position: BigInt, ethCompatibleStorage: Boolean): ByteString =
     ???
 

--- a/src/it/scala/io/iohk/ethereum/txExecTest/util/DumpChainApp.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/util/DumpChainApp.scala
@@ -186,7 +186,7 @@ class BlockchainMock(genesisHash: ByteString) extends Blockchain {
 
   override def removeBlock(hash: ByteString): Unit = ???
 
-  override def getChainWeightByHash(blockhash: ByteString): Option[ChainWeight] = ???
+  def getAccount(address: Address, blockNumber: BigInt): Option[Account] = ???
 
   override def getAccountStorageAt(rootHash: ByteString, position: BigInt, ethCompatibleStorage: Boolean): ByteString =
     ???

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/SyncController.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/SyncController.scala
@@ -130,7 +130,7 @@ class SyncController(
         consensus,
         blockchainReader,
         stateStorage,
-        new BranchResolution(blockchain, blockchainReader),
+        new BranchResolution(blockchainReader),
         validators.blockValidator,
         blacklist,
         syncConfig,

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/fast/FastSync.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/fast/FastSync.scala
@@ -643,7 +643,7 @@ class FastSync(
         } yield (validatedHeader, parentWeight)
 
       def getParentChainWeight(header: BlockHeader) =
-        blockchain.getChainWeightByHash(header.parentHash).toRight(ParentChainWeightNotFound(header))
+        blockchainReader.getChainWeightByHash(header.parentHash).toRight(ParentChainWeightNotFound(header))
 
       @tailrec
       def processHeaders(headers: Seq[BlockHeader]): HeaderProcessingResult =

--- a/src/main/scala/io/iohk/ethereum/consensus/ConsensusImpl.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/ConsensusImpl.scala
@@ -72,7 +72,7 @@ class ConsensusImpl(
           log.debug("Ignoring duplicated block: {}", block.idTag)
           Task.now(DuplicateBlock)
         } else {
-          blockchain.getChainWeightByHash(bestBlock.header.hash) match {
+          blockchainReader.getChainWeightByHash(bestBlock.header.hash) match {
             case Some(weight) =>
               doBlockPreValidation(block).flatMap {
                 case Left(error) => Task.now(BlockImportFailed(error.reason.toString))
@@ -234,7 +234,7 @@ class ConsensusImpl(
     val reorgResult = for {
       parent <- newBranch.headOption
       parentHash = parent.header.parentHash
-      parentWeight <- blockchain.getChainWeightByHash(parentHash)
+      parentWeight <- blockchainReader.getChainWeightByHash(parentHash)
     } yield {
       log.debug(
         "Removing blocks starting from number {} and parent {}",
@@ -330,7 +330,7 @@ class ConsensusImpl(
 
           val blockDataOpt = for {
             receipts <- blockchainReader.getReceiptsByHash(hash)
-            weight <- blockchain.getChainWeightByHash(hash)
+            weight <- blockchainReader.getChainWeightByHash(hash)
           } yield BlockData(block, receipts, weight)
 
           blockchain.removeBlock(hash)

--- a/src/main/scala/io/iohk/ethereum/domain/Blockchain.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/Blockchain.scala
@@ -55,12 +55,6 @@ trait Blockchain {
     */
   def getReadOnlyMptStorage(): MptStorage
 
-  /** Looks up ChainWeight for a given chain
-    * @param blockhash Hash of top block in the chain
-    * @return ChainWeight if found
-    */
-  def getChainWeightByHash(blockhash: ByteString): Option[ChainWeight]
-
   def getLatestCheckpointBlockNumber(): BigInt
 
   def removeBlock(hash: ByteString): Unit
@@ -85,8 +79,6 @@ class BlockchainImpl(
     blockchainReader: BlockchainReader
 ) extends Blockchain
     with Logger {
-
-  override def getChainWeightByHash(blockhash: ByteString): Option[ChainWeight] = chainWeightStorage.get(blockhash)
 
   override def getLatestCheckpointBlockNumber(): BigInt = appStateStorage.getLatestCheckpointBlockNumber()
 

--- a/src/main/scala/io/iohk/ethereum/domain/BlockchainReader.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/BlockchainReader.scala
@@ -1,13 +1,15 @@
 package io.iohk.ethereum.domain
 
 import akka.util.ByteString
-
-import io.iohk.ethereum.db.storage.AppStateStorage
-import io.iohk.ethereum.db.storage.BlockBodiesStorage
-import io.iohk.ethereum.db.storage.BlockHeadersStorage
-import io.iohk.ethereum.db.storage.BlockNumberMappingStorage
-import io.iohk.ethereum.db.storage.ReceiptStorage
-import io.iohk.ethereum.db.storage.StateStorage
+import io.iohk.ethereum.db.storage.{
+  AppStateStorage,
+  BlockBodiesStorage,
+  BlockHeadersStorage,
+  BlockNumberMappingStorage,
+  ChainWeightStorage,
+  ReceiptStorage,
+  StateStorage
+}
 import io.iohk.ethereum.domain.branch.BestBranch
 import io.iohk.ethereum.domain.branch.Branch
 import io.iohk.ethereum.domain.branch.EmptyBranch
@@ -22,7 +24,8 @@ class BlockchainReader(
     blockNumberMappingStorage: BlockNumberMappingStorage,
     stateStorage: StateStorage,
     receiptStorage: ReceiptStorage,
-    appStateStorage: AppStateStorage
+    appStateStorage: AppStateStorage,
+    chainWeightStorage: ChainWeightStorage
 ) extends Logger {
 
   /** Allows to query a blockHeader by block hash
@@ -159,6 +162,12 @@ class BlockchainReader(
       case EmptyBranch => None
     }
 
+  /** Looks up ChainWeight for a given chain
+    * @param blockhash Hash of top block in the chain
+    * @return ChainWeight if found
+    */
+  def getChainWeightByHash(blockhash: ByteString): Option[ChainWeight] = chainWeightStorage.get(blockhash)
+
   /** Allows to query for a block based on it's number
     *
     * @param number Block number
@@ -198,7 +207,8 @@ object BlockchainReader {
     storages.blockNumberMappingStorage,
     storages.stateStorage,
     storages.receiptStorage,
-    storages.appStateStorage
+    storages.appStateStorage,
+    storages.chainWeightStorage
   )
 
 }

--- a/src/main/scala/io/iohk/ethereum/domain/BlockchainReader.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/BlockchainReader.scala
@@ -1,15 +1,14 @@
 package io.iohk.ethereum.domain
 
 import akka.util.ByteString
-import io.iohk.ethereum.db.storage.{
-  AppStateStorage,
-  BlockBodiesStorage,
-  BlockHeadersStorage,
-  BlockNumberMappingStorage,
-  ChainWeightStorage,
-  ReceiptStorage,
-  StateStorage
-}
+
+import io.iohk.ethereum.db.storage.AppStateStorage
+import io.iohk.ethereum.db.storage.BlockBodiesStorage
+import io.iohk.ethereum.db.storage.BlockHeadersStorage
+import io.iohk.ethereum.db.storage.BlockNumberMappingStorage
+import io.iohk.ethereum.db.storage.ChainWeightStorage
+import io.iohk.ethereum.db.storage.ReceiptStorage
+import io.iohk.ethereum.db.storage.StateStorage
 import io.iohk.ethereum.domain.branch.BestBranch
 import io.iohk.ethereum.domain.branch.Branch
 import io.iohk.ethereum.domain.branch.EmptyBranch

--- a/src/main/scala/io/iohk/ethereum/ledger/BlockQueue.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/BlockQueue.scala
@@ -17,9 +17,8 @@ object BlockQueue {
   case class QueuedBlock(block: Block, weight: Option[ChainWeight])
   case class Leaf(hash: ByteString, weight: ChainWeight)
 
-  def apply(blockchain: Blockchain, blockchainReader: BlockchainReader, syncConfig: SyncConfig): BlockQueue =
+  def apply(blockchainReader: BlockchainReader, syncConfig: SyncConfig): BlockQueue =
     new BlockQueue(
-      blockchain,
       blockchainReader,
       syncConfig.maxQueuedBlockNumberAhead,
       syncConfig.maxQueuedBlockNumberBehind
@@ -27,7 +26,6 @@ object BlockQueue {
 }
 
 class BlockQueue(
-    blockchain: Blockchain,
     blockchainReader: BlockchainReader,
     val maxQueuedBlockNumberAhead: Int,
     val maxQueuedBlockNumberBehind: Int
@@ -127,7 +125,7 @@ class BlockQueue(
           Nil
       }
 
-    recur(descendant, false).reverse
+    recur(hash = descendant, childShared = false).reverse
   }
 
   /** Removes a whole subtree begining with the ancestor. To be used when ancestor fails to execute

--- a/src/main/scala/io/iohk/ethereum/ledger/BlockQueue.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/BlockQueue.scala
@@ -65,7 +65,7 @@ class BlockQueue(
         None
 
       case None =>
-        val parentWeight = blockchain.getChainWeightByHash(parentHash)
+        val parentWeight = blockchainReader.getChainWeightByHash(parentHash)
 
         parentWeight match {
 

--- a/src/main/scala/io/iohk/ethereum/ledger/BranchResolution.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/BranchResolution.scala
@@ -4,12 +4,11 @@ import cats.data.NonEmptyList
 
 import io.iohk.ethereum.domain.Block
 import io.iohk.ethereum.domain.BlockHeader
-import io.iohk.ethereum.domain.Blockchain
 import io.iohk.ethereum.domain.BlockchainReader
 import io.iohk.ethereum.domain.ChainWeight
 import io.iohk.ethereum.utils.Logger
 
-class BranchResolution(blockchain: Blockchain, blockchainReader: BlockchainReader) extends Logger {
+class BranchResolution(blockchainReader: BlockchainReader) extends Logger {
 
   def resolveBranch(headers: NonEmptyList[BlockHeader]): BranchResolutionResult =
     if (!doHeadersFormChain(headers)) {
@@ -49,7 +48,7 @@ class BranchResolution(blockchain: Blockchain, blockchainReader: BlockchainReade
         .map(_.header)
         .orElse(newHeaders.headOption)
         .map { header =>
-          blockchain
+          blockchainReader
             .getChainWeightByHash(header.parentHash)
             .toRight(s"ChainWeight for ${header.idTag} not found when resolving branch: $newHeaders")
         }

--- a/src/main/scala/io/iohk/ethereum/network/Peer.scala
+++ b/src/main/scala/io/iohk/ethereum/network/Peer.scala
@@ -4,7 +4,6 @@ import java.net.InetSocketAddress
 
 import akka.NotUsed
 import akka.actor.ActorRef
-import akka.pattern.Patterns.ask
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
 

--- a/src/main/scala/io/iohk/ethereum/network/PeerActor.scala
+++ b/src/main/scala/io/iohk/ethereum/network/PeerActor.scala
@@ -6,7 +6,6 @@ import java.net.URI
 import akka.NotUsed
 import akka.actor.SupervisorStrategy.Escalate
 import akka.actor._
-import akka.stream.OverflowStrategy
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
 

--- a/src/main/scala/io/iohk/ethereum/network/PeerEventBusActor.scala
+++ b/src/main/scala/io/iohk/ethereum/network/PeerEventBusActor.scala
@@ -7,11 +7,7 @@ import akka.actor.Props
 import akka.actor.Terminated
 import akka.event.ActorEventBus
 import akka.stream.OverflowStrategy
-import akka.stream.WatchedActorTerminatedException
 import akka.stream.scaladsl.Source
-import akka.util.Timeout
-
-import scala.concurrent.Future
 
 import io.iohk.ethereum.network.PeerEventBusActor.PeerEvent.MessageFromPeer
 import io.iohk.ethereum.network.PeerEventBusActor.PeerEvent.PeerDisconnected
@@ -19,7 +15,6 @@ import io.iohk.ethereum.network.PeerEventBusActor.PeerEvent.PeerHandshakeSuccess
 import io.iohk.ethereum.network.PeerEventBusActor.SubscriptionClassifier._
 import io.iohk.ethereum.network.handshaker.Handshaker.HandshakeResult
 import io.iohk.ethereum.network.p2p.Message
-import io.iohk.ethereum.network.p2p.messages.Codes
 
 object PeerEventBusActor {
   def props: Props = Props(new PeerEventBusActor)

--- a/src/main/scala/io/iohk/ethereum/network/PeerManagerActor.scala
+++ b/src/main/scala/io/iohk/ethereum/network/PeerManagerActor.scala
@@ -6,7 +6,6 @@ import java.util.Collections.newSetFromMap
 
 import akka.actor.SupervisorStrategy.Stop
 import akka.actor._
-import akka.stream.scaladsl.Source
 import akka.util.ByteString
 import akka.util.Timeout
 

--- a/src/main/scala/io/iohk/ethereum/network/handshaker/EtcNodeStatus64ExchangeState.scala
+++ b/src/main/scala/io/iohk/ethereum/network/handshaker/EtcNodeStatus64ExchangeState.scala
@@ -19,7 +19,7 @@ case class EtcNodeStatus64ExchangeState(
 
   override protected def createStatusMsg(): MessageSerializable = {
     val bestBlockHeader = getBestBlockHeader()
-    val chainWeight = blockchain.getChainWeightByHash(bestBlockHeader.hash).get
+    val chainWeight = blockchainReader.getChainWeightByHash(bestBlockHeader.hash).get
 
     val status = ETC64.Status(
       protocolVersion = Capability.ETC64.version,

--- a/src/main/scala/io/iohk/ethereum/network/handshaker/EthNodeStatus63ExchangeState.scala
+++ b/src/main/scala/io/iohk/ethereum/network/handshaker/EthNodeStatus63ExchangeState.scala
@@ -20,7 +20,7 @@ case class EthNodeStatus63ExchangeState(
 
   override protected def createStatusMsg(): MessageSerializable = {
     val bestBlockHeader = getBestBlockHeader()
-    val chainWeight = blockchain.getChainWeightByHash(bestBlockHeader.hash).get
+    val chainWeight = blockchainReader.getChainWeightByHash(bestBlockHeader.hash).get
 
     val status = BaseETH6XMessages.Status(
       protocolVersion = Capability.ETH63.version,

--- a/src/main/scala/io/iohk/ethereum/network/handshaker/EthNodeStatus64ExchangeState.scala
+++ b/src/main/scala/io/iohk/ethereum/network/handshaker/EthNodeStatus64ExchangeState.scala
@@ -35,7 +35,7 @@ case class EthNodeStatus64ExchangeState(
 
   override protected def createStatusMsg(): MessageSerializable = {
     val bestBlockHeader = getBestBlockHeader()
-    val chainWeight = blockchain.getChainWeightByHash(bestBlockHeader.hash).get
+    val chainWeight = blockchainReader.getChainWeightByHash(bestBlockHeader.hash).get
     val genesisHash = blockchainReader.genesisHeader.hash
 
     val status = ETH64.Status(

--- a/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
@@ -183,7 +183,7 @@ trait BlockchainBuilder {
 trait BlockQueueBuilder {
   self: BlockchainBuilder with SyncConfigBuilder =>
 
-  lazy val blockQueue: BlockQueue = BlockQueue(blockchain, blockchainReader, syncConfig)
+  lazy val blockQueue: BlockQueue = BlockQueue(blockchainReader, syncConfig)
 }
 
 trait ConsensusBuilder {

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/regular/RegularSyncFixtures.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/regular/RegularSyncFixtures.scala
@@ -77,7 +77,7 @@ trait RegularSyncFixtures { self: Matchers with AsyncMockFactory =>
     val checkpointBlockGenerator: CheckpointBlockGenerator = new CheckpointBlockGenerator()
     val peersClient: TestProbe = TestProbe()
     val blacklist: CacheBasedBlacklist = CacheBasedBlacklist.empty(100)
-    lazy val branchResolution = new BranchResolution(blockchain, blockchainReader)
+    lazy val branchResolution = new BranchResolution(blockchainReader)
 
     val stateStorage: StateStorage = stub[StateStorage]
 
@@ -340,7 +340,7 @@ trait RegularSyncFixtures { self: Matchers with AsyncMockFactory =>
       }
     }
 
-    class FakeBranchResolution extends BranchResolution(stub[BlockchainImpl], stub[BlockchainReader]) {
+    class FakeBranchResolution extends BranchResolution(stub[BlockchainReader]) {
       override def resolveBranch(headers: NonEmptyList[BlockHeader]): BranchResolutionResult = {
         val importedHashes = importedBlocksSet.map(_.hash).toSet
 

--- a/src/test/scala/io/iohk/ethereum/consensus/ConsensusSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/ConsensusSpec.scala
@@ -133,7 +133,7 @@ class ConsensusSpec extends AnyFlatSpec with Matchers with ScalaFutures {
 
     setBlockExists(block, inChain = false, inQueue = false)
     setBestBlock(bestBlock)
-    (blockchain.getChainWeightByHash _).expects(*).returning(None)
+    (blockchainReader.getChainWeightByHash _).expects(*).returning(None)
 
     (blockchainReader.getBlockHeaderByHash _).expects(*).returning(Some(block.header))
 
@@ -191,7 +191,7 @@ class ConsensusSpec extends AnyFlatSpec with Matchers with ScalaFutures {
     blockchainWriter.save(blockData3.block, blockData3.receipts, blockData3.weight, saveAsBestBlock = true)
 
     blockchainReader.getBestBlock().get shouldEqual newBlock3
-    blockchain.getChainWeightByHash(newBlock3.header.hash) shouldEqual Some(newWeight3)
+    blockchainReader.getChainWeightByHash(newBlock3.header.hash) shouldEqual Some(newWeight3)
 
     blockQueue.isQueued(oldBlock2.header.hash) shouldBe true
     blockQueue.isQueued(oldBlock3.header.hash) shouldBe true
@@ -235,7 +235,7 @@ class ConsensusSpec extends AnyFlatSpec with Matchers with ScalaFutures {
     }
 
     blockchainReader.getBestBlock().get shouldEqual oldBlock3
-    blockchain.getChainWeightByHash(oldBlock3.header.hash) shouldEqual Some(oldWeight3)
+    blockchainReader.getChainWeightByHash(oldBlock3.header.hash) shouldEqual Some(oldWeight3)
 
     blockQueue.isQueued(newBlock2.header.hash) shouldBe true
     blockQueue.isQueued(newBlock3.header.hash) shouldBe false
@@ -348,7 +348,7 @@ class ConsensusSpec extends AnyFlatSpec with Matchers with ScalaFutures {
   it should "correctly import a checkpoint block" in new EphemBlockchain with CheckpointHelpers {
     val parentBlock: Block = getBlock(bestNum)
     val regularBlock: Block = getBlock(bestNum + 1, difficulty = 200, parent = parentBlock.hash)
-    val checkpointBlock: Block = getCheckpointBlock(parentBlock, difficulty = 100)
+    val checkpointBlock: Block = getCheckpointBlock(parentBlock)
 
     val weightParent = ChainWeight.totalDifficultyOnly(parentBlock.header.difficulty + 999)
     val weightRegular = weightParent.increase(regularBlock.header)
@@ -376,7 +376,7 @@ class ConsensusSpec extends AnyFlatSpec with Matchers with ScalaFutures {
     blockchainWriter.save(checkpointBlock, Nil, weightCheckpoint, saveAsBestBlock = true)
 
     blockchainReader.getBestBlock().get shouldEqual checkpointBlock
-    blockchain.getChainWeightByHash(checkpointBlock.hash) shouldEqual Some(weightCheckpoint)
+    blockchainReader.getChainWeightByHash(checkpointBlock.hash) shouldEqual Some(weightCheckpoint)
   }
 
   it should "not import a block with higher difficulty that does not follow a checkpoint" in new EphemBlockchain
@@ -384,7 +384,7 @@ class ConsensusSpec extends AnyFlatSpec with Matchers with ScalaFutures {
 
     val parentBlock: Block = getBlock(bestNum)
     val regularBlock: Block = getBlock(bestNum + 1, difficulty = 200, parent = parentBlock.hash)
-    val checkpointBlock: Block = getCheckpointBlock(parentBlock, difficulty = 100)
+    val checkpointBlock: Block = getCheckpointBlock(parentBlock)
 
     val weightParent = ChainWeight.totalDifficultyOnly(parentBlock.header.difficulty + 999)
     val weightCheckpoint = weightParent.increase(checkpointBlock.header)

--- a/src/test/scala/io/iohk/ethereum/consensus/blocks/BlockGeneratorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/blocks/BlockGeneratorSpec.scala
@@ -691,7 +691,7 @@ class BlockGeneratorSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
       mining.blockGenerator.withBlockTimestampProvider(blockTimestampProvider)
 
     override lazy val blockValidation =
-      new BlockValidation(mining, blockchainReader, BlockQueue(blockchain, blockchainReader, syncConfig))
+      new BlockValidation(mining, blockchainReader, BlockQueue(blockchainReader, syncConfig))
     override lazy val blockExecution =
       new BlockExecution(
         blockchain,

--- a/src/test/scala/io/iohk/ethereum/ledger/BlockExecutionSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/BlockExecutionSpec.scala
@@ -62,7 +62,7 @@ class BlockExecutionSpec extends AnyWordSpec with Matchers with ScalaCheckProper
         val mockValidators = new MockValidatorsFailOnSpecificBlockNumber(block1.header.number)
         val newMining: TestMining = mining.withVM(vm).withValidators(mockValidators)
         override lazy val blockValidation =
-          new BlockValidation(newMining, blockchainReader, BlockQueue(blockchain, blockchainReader, syncConfig))
+          new BlockValidation(newMining, blockchainReader, BlockQueue(blockchainReader, syncConfig))
         override lazy val blockExecution =
           new BlockExecution(
             blockchain,
@@ -104,7 +104,7 @@ class BlockExecutionSpec extends AnyWordSpec with Matchers with ScalaCheckProper
         val mockValidators = new MockValidatorsFailOnSpecificBlockNumber(block2.header.number)
         val newMining: TestMining = mining.withVM(mockVm).withValidators(mockValidators)
         override lazy val blockValidation =
-          new BlockValidation(newMining, blockchainReader, BlockQueue(blockchain, blockchainReader, syncConfig))
+          new BlockValidation(newMining, blockchainReader, BlockQueue(blockchainReader, syncConfig))
         override lazy val blockExecution =
           new BlockExecution(
             blockchain,
@@ -139,7 +139,7 @@ class BlockExecutionSpec extends AnyWordSpec with Matchers with ScalaCheckProper
         val mockValidators = new MockValidatorsFailOnSpecificBlockNumber(chain.last.number)
         val newMining: TestMining = mining.withVM(mockVm).withValidators(mockValidators)
         override lazy val blockValidation =
-          new BlockValidation(newMining, blockchainReader, BlockQueue(blockchain, blockchainReader, syncConfig))
+          new BlockValidation(newMining, blockchainReader, BlockQueue(blockchainReader, syncConfig))
         override lazy val blockExecution =
           new BlockExecution(
             blockchain,
@@ -170,7 +170,7 @@ class BlockExecutionSpec extends AnyWordSpec with Matchers with ScalaCheckProper
         val mockValidators = MockValidatorsAlwaysSucceed
         val newMining: TestMining = mining.withVM(vm).withValidators(mockValidators)
         override lazy val blockValidation =
-          new BlockValidation(newMining, blockchainReader, BlockQueue(blockchain, blockchainReader, syncConfig))
+          new BlockValidation(newMining, blockchainReader, BlockQueue(blockchainReader, syncConfig))
         override lazy val blockExecution =
           new BlockExecution(
             blockchain,
@@ -237,7 +237,7 @@ class BlockExecutionSpec extends AnyWordSpec with Matchers with ScalaCheckProper
         val newMining: TestMining = mining.withVM(mockVm)
 
         override lazy val blockValidation =
-          new BlockValidation(newMining, blockchainReader, BlockQueue(blockchain, blockchainReader, syncConfig))
+          new BlockValidation(newMining, blockchainReader, BlockQueue(blockchainReader, syncConfig))
         override lazy val blockExecution =
           new BlockExecution(
             blockchain,
@@ -262,7 +262,7 @@ class BlockExecutionSpec extends AnyWordSpec with Matchers with ScalaCheckProper
           originAddress -> UpdateBalance(-minerPaymentForTxs), // Origin payment for tx execution and nonce increase
           minerAddress -> UpdateBalance(minerPaymentForTxs) // Miner reward for tx execution
         )
-        val expectedStateRoot: ByteString = applyChanges(validBlockParentHeader.stateRoot, blockchainStorages, changes)
+        val expectedStateRoot: ByteString = applyChanges(validBlockParentHeader.stateRoot, changes)
         expectedStateRoot shouldBe InMemoryWorldStateProxy.persistState(resultingWorldState).stateRootHash
 
         // Check valid gasUsed
@@ -315,7 +315,7 @@ class BlockExecutionSpec extends AnyWordSpec with Matchers with ScalaCheckProper
 
           val newConsensus = mining.withValidators(mockValidators).withVM(mockVm)
           val blockValidation =
-            new BlockValidation(newConsensus, blockchainReader, BlockQueue(blockchain, blockchainReader, syncConfig))
+            new BlockValidation(newConsensus, blockchainReader, BlockQueue(blockchainReader, syncConfig))
           val blockExecution =
             new BlockExecution(
               blockchain,
@@ -340,7 +340,7 @@ class BlockExecutionSpec extends AnyWordSpec with Matchers with ScalaCheckProper
               originAddress -> UpdateBalance(-minerPaymentForTxs), // Origin payment for tx execution and nonce increase
               minerAddress -> UpdateBalance(minerPaymentForTxs) // Miner reward for tx execution
             ) ++ addressesToDelete.map(address => address -> DeleteAccount) // Delete all accounts to be deleted
-            val expectedStateRoot = applyChanges(validBlockParentHeader.stateRoot, blockchainStorages, changes)
+            val expectedStateRoot = applyChanges(validBlockParentHeader.stateRoot, changes)
             expectedStateRoot shouldBe InMemoryWorldStateProxy.persistState(resultingWorldState).stateRootHash
 
             // Check valid gasUsed
@@ -421,7 +421,7 @@ class BlockExecutionSpec extends AnyWordSpec with Matchers with ScalaCheckProper
           ommerAddress -> UpdateBalance(UInt256(ommerReward))
         }
 
-        val expectedStateRoot = applyChanges(validBlockParentHeader.stateRoot, blockchainStorages, changes)
+        val expectedStateRoot = applyChanges(validBlockParentHeader.stateRoot, changes)
 
         val blockHeader: BlockHeader = validBlockHeader.copy(stateRoot = expectedStateRoot)
         val blockBodyWithOmmers = validBlockBodyWithNoTxs.copy(
@@ -476,7 +476,7 @@ class BlockExecutionSpec extends AnyWordSpec with Matchers with ScalaCheckProper
       val changes = Seq(
         minerAddress -> UpdateBalance(UInt256(blockReward)) // Paying miner for block processing
       )
-      val expectedStateRoot: ByteString = applyChanges(validBlockParentHeader.stateRoot, blockchainStorages, changes)
+      val expectedStateRoot: ByteString = applyChanges(validBlockParentHeader.stateRoot, changes)
       val blockHeader: BlockHeader = validBlockHeader.copy(stateRoot = expectedStateRoot)
       val block = Block(blockHeader, validBlockBodyWithNoTxs)
 
@@ -517,7 +517,7 @@ class BlockExecutionSpec extends AnyWordSpec with Matchers with ScalaCheckProper
         mining.blockPreparator.blockRewardCalculator.calculateMiningReward(validBlockHeader.number, 0)
 
       val changes = Seq(minerAddress -> UpdateBalance(UInt256(blockReward))) //Paying miner for block processing
-      val correctStateRoot: ByteString = applyChanges(validBlockParentHeader.stateRoot, blockchainStorages, changes)
+      val correctStateRoot: ByteString = applyChanges(validBlockParentHeader.stateRoot, changes)
 
       val correctGasUsed: BigInt = 0
       val incorrectStateRoot: ByteString =
@@ -605,7 +605,7 @@ class BlockExecutionSpec extends AnyWordSpec with Matchers with ScalaCheckProper
           origin1Address -> UpdateBalance(-minerPaymentForTx1), // Origin payment for tx execution and nonce increase
           minerAddress -> UpdateBalance(minerPaymentForTx1) // Miner reward for tx execution
         )
-        val expectedStateRootTx1 = applyChanges(validBlockParentHeader.stateRoot, blockchainStorages, changesTx1)
+        val expectedStateRootTx1 = applyChanges(validBlockParentHeader.stateRoot, changesTx1)
 
         val Receipt(rootHashReceipt1, gasUsedReceipt1, logsBloomFilterReceipt1, logsReceipt1) = receipt1
         rootHashReceipt1 shouldBe HashOutcome(expectedStateRootTx1)
@@ -620,7 +620,7 @@ class BlockExecutionSpec extends AnyWordSpec with Matchers with ScalaCheckProper
           origin2Address -> UpdateBalance(-minerPaymentForTx2), // Origin payment for tx execution and nonce increase
           minerAddress -> UpdateBalance(minerPaymentForTx2) // Miner reward for tx execution
         )
-        val expectedStateRootTx2 = applyChanges(expectedStateRootTx1, blockchainStorages, changesTx2)
+        val expectedStateRootTx2 = applyChanges(expectedStateRootTx1, changesTx2)
 
         val Receipt(rootHashReceipt2, gasUsedReceipt2, logsBloomFilterReceipt2, logsReceipt2) = receipt2
         rootHashReceipt2 shouldBe HashOutcome(expectedStateRootTx2)
@@ -636,7 +636,7 @@ class BlockExecutionSpec extends AnyWordSpec with Matchers with ScalaCheckProper
         val changes = Seq(
           minerAddress -> UpdateBalance(UInt256(blockReward))
         )
-        val blockExpectedStateRoot = applyChanges(expectedStateRootTx2, blockchainStorages, changes)
+        val blockExpectedStateRoot = applyChanges(expectedStateRootTx2, changes)
 
         val blockWithCorrectStateAndGasUsed = block.copy(
           header = block.header.copy(stateRoot = blockExpectedStateRoot, gasUsed = gasUsedReceipt2)
@@ -685,7 +685,7 @@ class BlockExecutionSpec extends AnyWordSpec with Matchers with ScalaCheckProper
   trait BlockExecutionTestSetup extends BlockchainSetup {
 
     override lazy val blockValidation =
-      new BlockValidation(mining, blockchainReader, BlockQueue(blockchain, blockchainReader, syncConfig))
+      new BlockValidation(mining, blockchainReader, BlockQueue(blockchainReader, syncConfig))
     override lazy val blockExecution =
       new BlockExecution(
         blockchain,

--- a/src/test/scala/io/iohk/ethereum/ledger/BlockQueueSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/BlockQueueSpec.scala
@@ -176,7 +176,7 @@ class BlockQueueSpec extends AnyFlatSpec with Matchers with MockFactory {
         block: Block,
         weight: Option[ChainWeight] = None
     ): CallHandler1[ByteString, Option[ChainWeight]] =
-      (blockchain.getChainWeightByHash _).expects(block.header.parentHash).returning(weight)
+      (blockchainReader.getChainWeightByHash _).expects(block.header.parentHash).returning(weight)
 
     def randomHash(): ByteString =
       ObjectGenerators.byteStringOfLengthNGen(32).sample.get

--- a/src/test/scala/io/iohk/ethereum/ledger/BlockQueueSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/BlockQueueSpec.scala
@@ -167,7 +167,7 @@ class BlockQueueSpec extends AnyFlatSpec with Matchers with MockFactory {
       SyncConfig(Config.config).copy(maxQueuedBlockNumberAhead = 10, maxQueuedBlockNumberBehind = 10)
     val blockchainReader: BlockchainReader = mock[BlockchainReader]
     val blockchain: BlockchainImpl = mock[BlockchainImpl]
-    val blockQueue: BlockQueue = BlockQueue(blockchain, blockchainReader, syncConfig)
+    val blockQueue: BlockQueue = BlockQueue(blockchainReader, syncConfig)
 
     def setBestBlockNumber(n: BigInt): CallHandler0[BigInt] =
       (blockchainReader.getBestBlockNumber _).expects().returning(n)

--- a/src/test/scala/io/iohk/ethereum/ledger/BlockValidationSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/BlockValidationSpec.scala
@@ -59,7 +59,7 @@ class BlockValidationSpec extends AnyWordSpec with Matchers with MockFactory {
       new BlockValidation(
         setup.mining,
         setup.blockchainReader,
-        BlockQueue(setup.blockchain, setup.blockchainReader, setup.syncConfig)
+        BlockQueue(setup.blockchainReader, setup.syncConfig)
       )
 
     def hash2ByteString(hash: String): ByteString = ByteString(Hex.decode(hash))

--- a/src/test/scala/io/iohk/ethereum/ledger/BranchResolutionSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/BranchResolutionSpec.scala
@@ -26,14 +26,14 @@ class BranchResolutionSpec
   "BranchResolution" should {
 
     "check if headers are from chain" in new BlockchainSetup {
-      val branchResolution = new BranchResolution(blockchain, blockchainReader)
+      val branchResolution = new BranchResolution(blockchainReader)
       val parent: BlockHeader = defaultBlockHeader.copy(number = 1)
       val child: BlockHeader = defaultBlockHeader.copy(number = 2, parentHash = parent.hash)
       branchResolution.doHeadersFormChain(NonEmptyList.of(parent, child)) shouldBe true
     }
 
     "check if headers are not from chain" in new BlockchainSetup {
-      val branchResolution = new BranchResolution(blockchain, blockchainReader)
+      val branchResolution = new BranchResolution(blockchainReader)
       val parent: BlockHeader = defaultBlockHeader.copy(number = 1)
       val otherParent: BlockHeader = defaultBlockHeader.copy(number = 3)
       val child: BlockHeader = defaultBlockHeader.copy(number = 2, parentHash = parent.hash)
@@ -152,7 +152,7 @@ class BranchResolutionSpec
           val parentWeight = ChainWeight.zero.increase(commonParent.header)
           val checkpointBranch = NonEmptyList.fromListUnsafe {
             val beforeCheckpoint = commonParent :: getChain(2, checkpointPos - 1, commonParent.hash)
-            val checkpoint = getCheckpointBlock(beforeCheckpoint.last, commonParent.header.difficulty)
+            val checkpoint = getCheckpointBlock(beforeCheckpoint.last)
             val afterCheckpoint = getChain(checkpointPos + 1, checkpointBranchLength, checkpoint.hash)
             beforeCheckpoint.tail ::: checkpoint :: afterCheckpoint
           }
@@ -178,7 +178,7 @@ class BranchResolutionSpec
           val parentWeight = ChainWeight.zero.increase(commonParent.header)
           val checkpointBranch = NonEmptyList.fromListUnsafe {
             val beforeCheckpoint = commonParent :: getChain(2, checkpointPos - 1, commonParent.hash)
-            val checkpoint = getCheckpointBlock(beforeCheckpoint.last, commonParent.header.difficulty)
+            val checkpoint = getCheckpointBlock(beforeCheckpoint.last)
             val afterCheckpoint = getChain(checkpointPos + 1, checkpointBranchLength, checkpoint.hash)
             beforeCheckpoint.tail ::: checkpoint :: afterCheckpoint
           }
@@ -196,7 +196,7 @@ class BranchResolutionSpec
   }
 
   trait BranchResolutionTestSetup extends TestSetupWithVmAndValidators with MockBlockchain {
-    val branchResolution = new BranchResolution(blockchain, blockchainReader)
+    val branchResolution = new BranchResolution(blockchainReader)
   }
 
 }

--- a/src/test/scala/io/iohk/ethereum/network/PeerEventBusActorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/network/PeerEventBusActorSpec.scala
@@ -28,7 +28,6 @@ import io.iohk.ethereum.network.PeerEventBusActor.PeerEvent.PeerDisconnected
 import io.iohk.ethereum.network.PeerEventBusActor.PeerEvent.PeerHandshakeSuccessful
 import io.iohk.ethereum.network.PeerEventBusActor.PeerSelector
 import io.iohk.ethereum.network.PeerEventBusActor.SubscriptionClassifier._
-import io.iohk.ethereum.network.p2p.Message
 import io.iohk.ethereum.network.p2p.messages.Capability
 import io.iohk.ethereum.network.p2p.messages.WireProtocol.Ping
 import io.iohk.ethereum.network.p2p.messages.WireProtocol.Pong


### PR DESCRIPTION
# Description

In order to reduce the scope of the Blockchain class, getChainWeight was moved to BlockchainReader

# Testing
This branch was deployed in Staging

