### PR TITLE
[ETCM-921] transaction with access list

### DIFF
--- a/rlp/src/main/scala/io/iohk/ethereum/rlp/RLP.scala
+++ b/rlp/src/main/scala/io/iohk/ethereum/rlp/RLP.scala
@@ -113,6 +113,8 @@ private[rlp] object RLP {
         val inputAsBytes = value.bytes
         if (inputAsBytes.length == 1 && (inputAsBytes(0) & 0xff) < 0x80) inputAsBytes
         else encodeLength(inputAsBytes.length, OffsetShortItem) ++ inputAsBytes
+      case PrefixedRLPEncodable(prefix, prefixedRLPEncodeable) =>
+        prefix +: encode(prefixedRLPEncodeable)
     }
 
   /** This function transform a byte into byte array

--- a/rlp/src/main/scala/io/iohk/ethereum/rlp/package.scala
+++ b/rlp/src/main/scala/io/iohk/ethereum/rlp/package.scala
@@ -44,6 +44,8 @@ package object rlp {
     override def toString: String = s"RLPValue(${Hex.toHexString(bytes)})"
   }
 
+  case class PrefixedRLPEncodable(prefix: Byte, prefixedRLPEncodeable: RLPEncodeable) extends RLPEncodeable
+
   trait RLPEncoder[T] {
     def encode(obj: T): RLPEncodeable
   }

--- a/rlp/src/main/scala/io/iohk/ethereum/rlp/package.scala
+++ b/rlp/src/main/scala/io/iohk/ethereum/rlp/package.scala
@@ -44,7 +44,22 @@ package object rlp {
     override def toString: String = s"RLPValue(${Hex.toHexString(bytes)})"
   }
 
-  case class PrefixedRLPEncodable(prefix: Byte, prefixedRLPEncodeable: RLPEncodeable) extends RLPEncodeable
+  /** Modelise a RLPEncodable that should be binary prefixed by a raw byte.
+    *
+    * When converting this RLPEncodable to byte, the resulting value will be:
+    * prefix || prefixedRLPEncodable.toByte
+    * where || is the binary concatenation symbol.
+    *
+    * To be able to read back the data, use TypedTransaction.TypedTransactionsRLPAggregator
+    *
+    * This is for example used for typed transaction and typed receipt.
+    *
+    * @param prefix the raw byte
+    * @param prefixedRLPEncodeable the RLPEncodable to prefix with
+    */
+  case class PrefixedRLPEncodable(prefix: Byte, prefixedRLPEncodeable: RLPEncodeable) extends RLPEncodeable {
+    require(prefix <= 0x07f, "prefix should be lower than 0x7f")
+  }
 
   trait RLPEncoder[T] {
     def encode(obj: T): RLPEncodeable

--- a/rlp/src/main/scala/io/iohk/ethereum/rlp/package.scala
+++ b/rlp/src/main/scala/io/iohk/ethereum/rlp/package.scala
@@ -58,7 +58,7 @@ package object rlp {
     * @param prefixedRLPEncodeable the RLPEncodable to prefix with
     */
   case class PrefixedRLPEncodable(prefix: Byte, prefixedRLPEncodeable: RLPEncodeable) extends RLPEncodeable {
-    require(prefix <= 0x07f, "prefix should be lower than 0x7f")
+    require(prefix >= 0, "prefix should be in the range [0; 0x7f]")
   }
 
   trait RLPEncoder[T] {

--- a/src/benchmark/scala/io/iohk/ethereum/rlp/RLPSpeedSuite.scala
+++ b/src/benchmark/scala/io/iohk/ethereum/rlp/RLPSpeedSuite.scala
@@ -86,8 +86,7 @@ class RLPSpeedSuite
     ),
     pointSign = 28,
     signatureRandom = ByteString(Hex.decode("cfe3ad31d6612f8d787c45f115cc5b43fb22bcc210b62ae71dc7cbf0a6bea8df")),
-    signature = ByteString(Hex.decode("57db8998114fae3c337e99dbd8573d4085691880f4576c6c1f6c5bbfe67d6cf0")),
-    chainId = 0x3d.toByte
+    signature = ByteString(Hex.decode("57db8998114fae3c337e99dbd8573d4085691880f4576c6c1f6c5bbfe67d6cf0"))
   )
 
   lazy val blockGen: Gen[Block] = for {

--- a/src/main/scala/io/iohk/ethereum/domain/Block.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/Block.scala
@@ -43,12 +43,13 @@ object Block {
 
   implicit class BlockDec(val bytes: Array[Byte]) extends AnyVal {
     import io.iohk.ethereum.network.p2p.messages.BaseETH6XMessages.SignedTransactions._
+    import io.iohk.ethereum.network.p2p.messages.BaseETH6XMessages.TypedTransaction._
     def toBlock: Block = rawDecode(bytes) match {
       case RLPList(header: RLPList, stx: RLPList, uncles: RLPList) =>
         Block(
           header.toBlockHeader,
           BlockBody(
-            stx.items.map(_.toSignedTransaction),
+            stx.items.toTypedRLPEncodables.map(_.toSignedTransaction),
             uncles.items.map(_.toBlockHeader)
           )
         )

--- a/src/main/scala/io/iohk/ethereum/domain/BlockBody.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/BlockBody.scala
@@ -23,6 +23,8 @@ object BlockBody {
 
   val empty: BlockBody = BlockBody(Seq.empty, Seq.empty)
 
+  import io.iohk.ethereum.network.p2p.messages.BaseETH6XMessages.TypedTransaction._
+
   def blockBodyToRlpEncodable(
       blockBody: BlockBody,
       signedTxToRlpEncodable: SignedTransaction => RLPEncodeable,
@@ -57,7 +59,7 @@ object BlockBody {
     rlpEncodeable match {
       case RLPList((transactions: RLPList), (uncles: RLPList)) =>
         BlockBody(
-          transactions.items.map(rlpEncodableToSignedTransaction),
+          transactions.items.toTypedRLPEncodables.map(rlpEncodableToSignedTransaction),
           uncles.items.map(rlpEncodableToBlockHeader)
         )
       case _ => throw new RuntimeException("Cannot decode BlockBody")

--- a/src/main/scala/io/iohk/ethereum/domain/SignedTransaction.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/SignedTransaction.scala
@@ -50,22 +50,7 @@ object SignedTransaction {
   val valueForEmptyS = 0
 
   def apply(
-      tx: LegacyTransaction,
-      pointSign: Byte,
-      signatureRandom: ByteString,
-      signature: ByteString,
-      chainId: Byte
-  ): SignedTransaction = {
-    val txSignature = ECDSASignature(
-      r = new BigInteger(1, signatureRandom.toArray),
-      s = new BigInteger(1, signature.toArray),
-      v = pointSign
-    )
-    SignedTransaction(tx, txSignature)
-  }
-
-  def apply(
-      tx: LegacyTransaction,
+      tx: Transaction,
       pointSign: Byte,
       signatureRandom: ByteString,
       signature: ByteString
@@ -79,7 +64,7 @@ object SignedTransaction {
   }
 
   def sign(
-      tx: LegacyTransaction,
+      tx: Transaction,
       keyPair: AsymmetricCipherKeyPair,
       chainId: Option[Byte]
   ): SignedTransaction = {

--- a/src/main/scala/io/iohk/ethereum/domain/SignedTransaction.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/SignedTransaction.scala
@@ -165,7 +165,7 @@ object SignedTransaction {
   }
 }
 
-case class SignedTransaction(tx: LegacyTransaction, signature: ECDSASignature) {
+case class SignedTransaction(tx: Transaction, signature: ECDSASignature) {
 
   def safeSenderIsEqualTo(address: Address): Boolean =
     SignedTransaction.getSender(this).contains(address)

--- a/src/main/scala/io/iohk/ethereum/domain/Transaction.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/Transaction.scala
@@ -22,30 +22,9 @@ sealed trait Transaction extends Product with Serializable {
 }
 
 object Transaction {
-  val Type01: Int = 1
+  val Type01: Byte = 1.toByte
   val LegacyThresholdLowerBound: Int = 0xc0
   val LegacyThresholdUpperBound: Int = 0xfe
-
-  def typed(
-      nonce: BigInt,
-      gasPrice: BigInt,
-      gasLimit: BigInt,
-      receivingAddress: Address,
-      value: BigInt,
-      payload: ByteString,
-      accessList: Option[List[AccessListItem]]
-  ): Transaction =
-    TransactionWithAccessList(nonce, gasPrice, gasLimit, Some(receivingAddress), value, payload, accessList)
-
-  def legacy(
-      nonce: BigInt,
-      gasPrice: BigInt,
-      gasLimit: BigInt,
-      receivingAddress: Address,
-      value: BigInt,
-      payload: ByteString
-  ): Transaction =
-    LegacyTransaction(nonce, gasPrice, gasLimit, Some(receivingAddress), value, payload)
 
   def withGasLimit(gl: BigInt): Transaction => Transaction = {
     case tx: LegacyTransaction         => tx.copy(gasLimit = gl)
@@ -56,7 +35,6 @@ object Transaction {
 sealed trait TypedTransaction extends Transaction
 
 object LegacyTransaction {
-
   val NonceLength = 32
   val GasLength = 32
   val ValueLength = 32
@@ -70,7 +48,6 @@ object LegacyTransaction {
       payload: ByteString
   ): LegacyTransaction =
     LegacyTransaction(nonce, gasPrice, gasLimit, Some(receivingAddress), value, payload)
-
 }
 
 case class LegacyTransaction(
@@ -92,6 +69,19 @@ case class LegacyTransaction(
       s"}"
 }
 
+object TransactionWithAccessList {
+  def apply(
+      nonce: BigInt,
+      gasPrice: BigInt,
+      gasLimit: BigInt,
+      receivingAddress: Address,
+      value: BigInt,
+      payload: ByteString,
+      accessList: List[AccessListItem]
+  ): TransactionWithAccessList =
+    TransactionWithAccessList(nonce, gasPrice, gasLimit, Some(receivingAddress), value, payload, accessList)
+}
+
 case class TransactionWithAccessList(
     nonce: BigInt,
     gasPrice: BigInt,
@@ -99,7 +89,7 @@ case class TransactionWithAccessList(
     receivingAddress: Option[Address],
     value: BigInt,
     payload: ByteString,
-    accessList: Option[List[AccessListItem]]
+    accessList: List[AccessListItem]
 ) extends TypedTransaction {
   override def toString: String =
     s"TransactionWithAccessList {" +

--- a/src/main/scala/io/iohk/ethereum/domain/Transaction.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/Transaction.scala
@@ -4,7 +4,7 @@ import akka.util.ByteString
 
 import org.bouncycastle.util.encoders.Hex
 
-sealed trait Transaction {
+sealed trait Transaction extends Product with Serializable {
   def nonce: BigInt
   def gasPrice: BigInt
   def gasLimit: BigInt
@@ -25,6 +25,32 @@ object Transaction {
   val Type01: Int = 1
   val LegacyThresholdLowerBound: Int = 0xc0
   val LegacyThresholdUpperBound: Int = 0xfe
+
+  def typed(
+      nonce: BigInt,
+      gasPrice: BigInt,
+      gasLimit: BigInt,
+      receivingAddress: Address,
+      value: BigInt,
+      payload: ByteString,
+      accessList: Option[List[AccessListItem]]
+  ): Transaction =
+    TransactionWithAccessList(nonce, gasPrice, gasLimit, Some(receivingAddress), value, payload, accessList)
+
+  def legacy(
+      nonce: BigInt,
+      gasPrice: BigInt,
+      gasLimit: BigInt,
+      receivingAddress: Address,
+      value: BigInt,
+      payload: ByteString
+  ): Transaction =
+    LegacyTransaction(nonce, gasPrice, gasLimit, Some(receivingAddress), value, payload)
+
+  def withGasLimit(gl: BigInt): Transaction => Transaction = {
+    case tx: LegacyTransaction         => tx.copy(gasLimit = gl)
+    case tx: TransactionWithAccessList => tx.copy(gasLimit = gl)
+  }
 }
 
 sealed trait TypedTransaction extends Transaction
@@ -73,7 +99,7 @@ case class TransactionWithAccessList(
     receivingAddress: Option[Address],
     value: BigInt,
     payload: ByteString,
-    accessList: List[AccessListItem]
+    accessList: Option[List[AccessListItem]]
 ) extends TypedTransaction {
   override def toString: String =
     s"TransactionWithAccessList {" +

--- a/src/main/scala/io/iohk/ethereum/domain/Transaction.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/Transaction.scala
@@ -71,6 +71,7 @@ case class LegacyTransaction(
 
 object TransactionWithAccessList {
   def apply(
+      chainId: BigInt,
       nonce: BigInt,
       gasPrice: BigInt,
       gasLimit: BigInt,
@@ -79,10 +80,11 @@ object TransactionWithAccessList {
       payload: ByteString,
       accessList: List[AccessListItem]
   ): TransactionWithAccessList =
-    TransactionWithAccessList(nonce, gasPrice, gasLimit, Some(receivingAddress), value, payload, accessList)
+    TransactionWithAccessList(chainId, nonce, gasPrice, gasLimit, Some(receivingAddress), value, payload, accessList)
 }
 
 case class TransactionWithAccessList(
+    chainId: BigInt,
     nonce: BigInt,
     gasPrice: BigInt,
     gasLimit: BigInt,

--- a/src/main/scala/io/iohk/ethereum/domain/Transaction.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/Transaction.scala
@@ -23,12 +23,24 @@ sealed trait Transaction extends Product with Serializable {
 
 object Transaction {
   val Type01: Byte = 1.toByte
+
+  val MinAllowedType: Byte = 0
+  val MaxAllowedType: Byte = 0x7f
+
   val LegacyThresholdLowerBound: Int = 0xc0
   val LegacyThresholdUpperBound: Int = 0xfe
 
   def withGasLimit(gl: BigInt): Transaction => Transaction = {
     case tx: LegacyTransaction         => tx.copy(gasLimit = gl)
     case tx: TransactionWithAccessList => tx.copy(gasLimit = gl)
+  }
+
+  implicit class TransactionTypeValidator(val transactionType: Byte) extends AnyVal {
+    def isValidTransactionType: Boolean = transactionType >= MinAllowedType && transactionType <= MaxAllowedType
+  }
+
+  implicit class ByteArrayTransactionTypeValidator(val binaryData: Array[Byte]) extends AnyVal {
+    def isValidTransactionType: Boolean = binaryData.length == 1 && binaryData.head.isValidTransactionType
   }
 }
 

--- a/src/main/scala/io/iohk/ethereum/ledger/BlockPreparator.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/BlockPreparator.scala
@@ -98,14 +98,14 @@ class BlockPreparator(
     * @param tx Target transaction
     * @return Upfront cost
     */
-  private[ledger] def calculateUpfrontGas(tx: LegacyTransaction): UInt256 = UInt256(tx.gasLimit * tx.gasPrice)
+  private[ledger] def calculateUpfrontGas(tx: Transaction): UInt256 = UInt256(tx.gasLimit * tx.gasPrice)
 
   /** v0 ≡ Tg (Tx gas limit) * Tp (Tx gas price) + Tv (Tx value). See YP equation number (65)
     *
     * @param tx Target transaction
     * @return Upfront cost
     */
-  private[ledger] def calculateUpfrontCost(tx: LegacyTransaction): UInt256 =
+  private[ledger] def calculateUpfrontCost(tx: Transaction): UInt256 =
     UInt256(calculateUpfrontGas(tx) + tx.value)
 
   /** Increments account nonce by 1 stated in YP equation (69) and

--- a/src/main/scala/io/iohk/ethereum/ledger/StxLedger.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/StxLedger.scala
@@ -1,13 +1,15 @@
 package io.iohk.ethereum.ledger
 
 import scala.annotation.tailrec
-
 import io.iohk.ethereum.db.storage.EvmCodeStorage
-import io.iohk.ethereum.domain.Account
-import io.iohk.ethereum.domain.BlockHeader
-import io.iohk.ethereum.domain.BlockchainImpl
-import io.iohk.ethereum.domain.BlockchainReader
-import io.iohk.ethereum.domain.SignedTransactionWithSender
+import io.iohk.ethereum.domain.{
+  Account,
+  BlockHeader,
+  BlockchainImpl,
+  BlockchainReader,
+  SignedTransactionWithSender,
+  Transaction
+}
 import io.iohk.ethereum.ledger.TxResult
 import io.iohk.ethereum.nodebuilder.BlockchainConfigBuilder
 import io.iohk.ethereum.vm.EvmConfig
@@ -68,7 +70,11 @@ class StxLedger(
       highLimit
     } else {
       StxLedger.binaryChop(lowLimit, highLimit) { gasLimit =>
-        simulateTransaction(stx.copy(tx = tx.copy(tx = tx.tx.copy(gasLimit = gasLimit))), blockHeader, world).vmError
+        simulateTransaction(
+          stx.copy(tx = tx.copy(tx = Transaction.withGasLimit(gasLimit)(tx.tx))),
+          blockHeader,
+          world
+        ).vmError
       }
     }
   }

--- a/src/main/scala/io/iohk/ethereum/ledger/StxLedger.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/StxLedger.scala
@@ -1,15 +1,14 @@
 package io.iohk.ethereum.ledger
 
 import scala.annotation.tailrec
+
 import io.iohk.ethereum.db.storage.EvmCodeStorage
-import io.iohk.ethereum.domain.{
-  Account,
-  BlockHeader,
-  BlockchainImpl,
-  BlockchainReader,
-  SignedTransactionWithSender,
-  Transaction
-}
+import io.iohk.ethereum.domain.Account
+import io.iohk.ethereum.domain.BlockHeader
+import io.iohk.ethereum.domain.BlockchainImpl
+import io.iohk.ethereum.domain.BlockchainReader
+import io.iohk.ethereum.domain.SignedTransactionWithSender
+import io.iohk.ethereum.domain.Transaction
 import io.iohk.ethereum.ledger.TxResult
 import io.iohk.ethereum.nodebuilder.BlockchainConfigBuilder
 import io.iohk.ethereum.vm.EvmConfig

--- a/src/main/scala/io/iohk/ethereum/network/discovery/codecs/RLPCodecs.scala
+++ b/src/main/scala/io/iohk/ethereum/network/discovery/codecs/RLPCodecs.scala
@@ -17,7 +17,6 @@ import scodec.Err
 import scodec.bits.BitVector
 import scodec.bits.ByteVector
 
-import io.iohk.ethereum.domain.AccessListItem
 import io.iohk.ethereum.rlp
 import io.iohk.ethereum.rlp.RLPCodec
 import io.iohk.ethereum.rlp.RLPCodec.Ops
@@ -77,8 +76,6 @@ trait ContentCodecs {
           Node(id, address)
       }
     )
-
-  implicit val accessListItemCodec: RLPCodec[AccessListItem] = ???
 
   // https://github.com/ethereum/devp2p/blob/master/enr.md#rlp-encoding
   // content = [seq, k, v, ...]

--- a/src/main/scala/io/iohk/ethereum/network/discovery/codecs/RLPCodecs.scala
+++ b/src/main/scala/io/iohk/ethereum/network/discovery/codecs/RLPCodecs.scala
@@ -17,6 +17,7 @@ import scodec.Err
 import scodec.bits.BitVector
 import scodec.bits.ByteVector
 
+import io.iohk.ethereum.domain.AccessListItem
 import io.iohk.ethereum.rlp
 import io.iohk.ethereum.rlp.RLPCodec
 import io.iohk.ethereum.rlp.RLPCodec.Ops
@@ -76,6 +77,8 @@ trait ContentCodecs {
           Node(id, address)
       }
     )
+
+  implicit val accessListItemCodec: RLPCodec[AccessListItem] = ???
 
   // https://github.com/ethereum/devp2p/blob/master/enr.md#rlp-encoding
   // content = [seq, k, v, ...]

--- a/src/main/scala/io/iohk/ethereum/network/p2p/messages/BaseETH6XMessages.scala
+++ b/src/main/scala/io/iohk/ethereum/network/p2p/messages/BaseETH6XMessages.scala
@@ -13,6 +13,7 @@ import io.iohk.ethereum.rlp.RLPImplicitConversions._
 import io.iohk.ethereum.rlp.RLPImplicits._
 import io.iohk.ethereum.rlp._
 import io.iohk.ethereum.utils.ByteStringUtils.ByteStringOps
+import io.iohk.ethereum.utils.Config
 
 object BaseETH6XMessages {
   object Status {
@@ -62,7 +63,7 @@ object BaseETH6XMessages {
         case r: RLPList if r.items.isEmpty => AccessListItem(null, List.empty)
 
         case RLPList(rlpAddress, rlpStorageKeys: RLPList) =>
-          val address = rlpAddress.decodeAs[Address]("address ")
+          val address = rlpAddress.decodeAs[Address]("address")
           val storageKeys = fromRlpList[BigInt](rlpStorageKeys).toList
           AccessListItem(address, storageKeys)
       }
@@ -154,7 +155,7 @@ object BaseETH6XMessages {
 
   object SignedTransactions {
 
-    lazy val chainId: Byte = 1.toByte //Config.blockchains.blockchainConfig.chainId
+    lazy val chainId: Byte = Config.blockchains.blockchainConfig.chainId
 
     implicit class SignedTransactionEnc(val signedTx: SignedTransaction) extends RLPSerializable {
 

--- a/src/main/scala/io/iohk/ethereum/network/p2p/messages/BaseETH6XMessages.scala
+++ b/src/main/scala/io/iohk/ethereum/network/p2p/messages/BaseETH6XMessages.scala
@@ -8,11 +8,11 @@ import io.iohk.ethereum.domain.BlockHeaderImplicits._
 import io.iohk.ethereum.domain._
 import io.iohk.ethereum.network.p2p.Message
 import io.iohk.ethereum.network.p2p.MessageSerializableImplicit
+import io.iohk.ethereum.rlp.RLPCodec.Ops
 import io.iohk.ethereum.rlp.RLPImplicitConversions._
 import io.iohk.ethereum.rlp.RLPImplicits._
 import io.iohk.ethereum.rlp._
 import io.iohk.ethereum.utils.ByteStringUtils.ByteStringOps
-import io.iohk.ethereum.rlp.RLPCodec.Ops
 
 object BaseETH6XMessages {
   object Status {
@@ -172,7 +172,7 @@ object BaseETH6XMessages {
         signedTx.tx match {
           case TransactionWithAccessList(nonce, gasPrice, gasLimit, _, value, payload, accessList) =>
             RLPList(
-              chainId, // TODO improve how chainid is preserved in transactions
+              chainId, // TODO improve how chainid is preserved in transactions (ETCM-1096)
               nonce,
               gasPrice,
               gasLimit,
@@ -219,7 +219,7 @@ object BaseETH6XMessages {
 
       def toSignedTransaction: SignedTransaction = rlpEncodeable match {
         case RLPList(
-              _, // TODO improve how chainid is preserved in transactions
+              _, // TODO improve how chainid is preserved in transactions (ETCM-1096)
               nonce,
               gasPrice,
               gasLimit,

--- a/src/main/scala/io/iohk/ethereum/network/p2p/messages/BaseETH6XMessages.scala
+++ b/src/main/scala/io/iohk/ethereum/network/p2p/messages/BaseETH6XMessages.scala
@@ -254,7 +254,6 @@ object BaseETH6XMessages {
     implicit class SignedTransactionRlpEncodableDec(val rlpEncodeable: RLPEncodeable) extends AnyVal {
 
       // scalastyle:off method.length
-
       /** A signed transaction is either a RLPList representing a Legacy SignedTransaction
         * or a PrefixedRLPEncodable(transactionType, RLPList of typed transaction envelope)
         *
@@ -318,6 +317,7 @@ object BaseETH6XMessages {
           throw new RuntimeException("Cannot decode SignedTransaction")
       }
     }
+    // scalastyle:on method.length
 
     implicit class SignedTransactionDec(val bytes: Array[Byte]) extends AnyVal {
       def toSignedTransaction: SignedTransaction = {

--- a/src/main/scala/io/iohk/ethereum/network/p2p/messages/BaseETH6XMessages.scala
+++ b/src/main/scala/io/iohk/ethereum/network/p2p/messages/BaseETH6XMessages.scala
@@ -161,6 +161,8 @@ object BaseETH6XMessages {
   object TypedTransaction {
     implicit class TypedTransactionsRLPAggregator(val encodables: Seq[RLPEncodeable]) extends AnyVal {
 
+      import Transaction.ByteArrayTransactionTypeValidator
+
       /** Convert a Seq of RLPEncodable containing TypedTransaction informations into a Seq of
         * Prefixed RLPEncodable.
         *
@@ -181,7 +183,7 @@ object BaseETH6XMessages {
       def toTypedRLPEncodables: Seq[RLPEncodeable] =
         encodables match {
           case Seq() => Seq()
-          case Seq(RLPValue(v), rlpList: RLPList, tail @ _*) if v.length == 1 && v.head < 0x7f =>
+          case Seq(RLPValue(v), rlpList: RLPList, tail @ _*) if v.isValidTransactionType =>
             PrefixedRLPEncodable(v.head, rlpList) +: tail.toTypedRLPEncodables
           case Seq(head, tail @ _*) => head +: tail.toTypedRLPEncodables
         }

--- a/src/main/scala/io/iohk/ethereum/network/p2p/messages/BaseETH6XMessages.scala
+++ b/src/main/scala/io/iohk/ethereum/network/p2p/messages/BaseETH6XMessages.scala
@@ -155,8 +155,6 @@ object BaseETH6XMessages {
 
   object SignedTransactions {
 
-    lazy val chainId: Byte = Config.blockchains.blockchainConfig.chainId
-
     implicit class SignedTransactionEnc(val signedTx: SignedTransaction) extends RLPSerializable {
 
       override def toBytes: Array[Byte] =
@@ -171,9 +169,9 @@ object BaseETH6XMessages {
           .map(_.toArray)
           .getOrElse(Array.emptyByteArray)
         signedTx.tx match {
-          case TransactionWithAccessList(nonce, gasPrice, gasLimit, _, value, payload, accessList) =>
+          case TransactionWithAccessList(chainId, nonce, gasPrice, gasLimit, _, value, payload, accessList) =>
             RLPList(
-              chainId, // TODO improve how chainid is preserved in transactions (ETCM-1096)
+              chainId,
               nonce,
               gasPrice,
               gasLimit,
@@ -220,7 +218,7 @@ object BaseETH6XMessages {
 
       def toSignedTransaction: SignedTransaction = rlpEncodeable match {
         case RLPList(
-              _, // TODO improve how chainid is preserved in transactions (ETCM-1096)
+              chainId,
               nonce,
               gasPrice,
               gasLimit,
@@ -235,6 +233,7 @@ object BaseETH6XMessages {
           val receivingAddressOpt = if (receivingAddress.bytes.isEmpty) None else Some(Address(receivingAddress.bytes))
           SignedTransaction(
             TransactionWithAccessList(
+              chainId,
               nonce,
               gasPrice,
               gasLimit,

--- a/src/main/scala/io/iohk/ethereum/network/p2p/messages/ETC64.scala
+++ b/src/main/scala/io/iohk/ethereum/network/p2p/messages/ETC64.scala
@@ -105,6 +105,7 @@ object ETC64 {
 
     implicit class NewBlockDec(val bytes: Array[Byte]) extends AnyVal {
       import io.iohk.ethereum.network.p2p.messages.BaseETH6XMessages.SignedTransactions._
+      import io.iohk.ethereum.network.p2p.messages.BaseETH6XMessages.TypedTransaction._
 
       def toNewBlock: NewBlock = rawDecode(bytes) match {
         case RLPList(
@@ -115,7 +116,10 @@ object ETC64 {
           NewBlock(
             Block(
               blockHeader.toBlockHeader,
-              BlockBody(transactionList.items.map(_.toSignedTransaction), uncleNodesList.items.map(_.toBlockHeader))
+              BlockBody(
+                transactionList.items.toTypedRLPEncodables.map(_.toSignedTransaction),
+                uncleNodesList.items.map(_.toBlockHeader)
+              )
             ),
             ChainWeight(lastCheckpointNumber, totalDifficulty)
           )

--- a/src/main/scala/io/iohk/ethereum/utils/Picklers.scala
+++ b/src/main/scala/io/iohk/ethereum/utils/Picklers.scala
@@ -1,19 +1,22 @@
 package io.iohk.ethereum.utils
 
 import akka.util.ByteString
-
 import boopickle.DefaultBasic._
 import boopickle.Pickler
-
 import io.iohk.ethereum.crypto.ECDSASignature
-import io.iohk.ethereum.domain.Address
-import io.iohk.ethereum.domain.BlockBody
-import io.iohk.ethereum.domain.BlockHeader
+import io.iohk.ethereum.domain.{
+  AccessListItem,
+  Address,
+  BlockBody,
+  BlockHeader,
+  Checkpoint,
+  LegacyTransaction,
+  SignedTransaction,
+  Transaction,
+  TransactionWithAccessList
+}
 import io.iohk.ethereum.domain.BlockHeader.HeaderExtraFields
 import io.iohk.ethereum.domain.BlockHeader.HeaderExtraFields._
-import io.iohk.ethereum.domain.Checkpoint
-import io.iohk.ethereum.domain.LegacyTransaction
-import io.iohk.ethereum.domain.SignedTransaction
 
 object Picklers {
   implicit val byteStringPickler: Pickler[ByteString] =
@@ -30,9 +33,18 @@ object Picklers {
 
   implicit val addressPickler: Pickler[Address] =
     transformPickler[Address, ByteString](bytes => Address(bytes))(address => address.bytes)
-  implicit val transactionPickler: Pickler[LegacyTransaction] = generatePickler[LegacyTransaction]
+  implicit val accessListItemPickler: Pickler[AccessListItem] = generatePickler[AccessListItem]
+
+  implicit val legacyTransactionPickler: Pickler[LegacyTransaction] = generatePickler[LegacyTransaction]
+  implicit val transactionWithAccessListPickler: Pickler[TransactionWithAccessList] =
+    generatePickler[TransactionWithAccessList]
+
+  implicit val transactionPickler: Pickler[Transaction] = compositePickler[Transaction]
+    .addConcreteType[LegacyTransaction]
+    .addConcreteType[TransactionWithAccessList]
+
   implicit val signedTransactionPickler: Pickler[SignedTransaction] =
-    transformPickler[SignedTransaction, (LegacyTransaction, ECDSASignature)] { case (tx, signature) =>
+    transformPickler[SignedTransaction, (Transaction, ECDSASignature)] { case (tx, signature) =>
       new SignedTransaction(tx, signature)
     }(stx => (stx.tx, stx.signature))
 

--- a/src/main/scala/io/iohk/ethereum/utils/Picklers.scala
+++ b/src/main/scala/io/iohk/ethereum/utils/Picklers.scala
@@ -1,22 +1,22 @@
 package io.iohk.ethereum.utils
 
 import akka.util.ByteString
+
 import boopickle.DefaultBasic._
 import boopickle.Pickler
+
 import io.iohk.ethereum.crypto.ECDSASignature
-import io.iohk.ethereum.domain.{
-  AccessListItem,
-  Address,
-  BlockBody,
-  BlockHeader,
-  Checkpoint,
-  LegacyTransaction,
-  SignedTransaction,
-  Transaction,
-  TransactionWithAccessList
-}
+import io.iohk.ethereum.domain.AccessListItem
+import io.iohk.ethereum.domain.Address
+import io.iohk.ethereum.domain.BlockBody
+import io.iohk.ethereum.domain.BlockHeader
 import io.iohk.ethereum.domain.BlockHeader.HeaderExtraFields
 import io.iohk.ethereum.domain.BlockHeader.HeaderExtraFields._
+import io.iohk.ethereum.domain.Checkpoint
+import io.iohk.ethereum.domain.LegacyTransaction
+import io.iohk.ethereum.domain.SignedTransaction
+import io.iohk.ethereum.domain.Transaction
+import io.iohk.ethereum.domain.TransactionWithAccessList
 
 object Picklers {
   implicit val byteStringPickler: Pickler[ByteString] =

--- a/src/test/scala/io/iohk/ethereum/Fixtures.scala
+++ b/src/test/scala/io/iohk/ethereum/Fixtures.scala
@@ -61,8 +61,7 @@ object Fixtures {
             pointSign = 0x9d.toByte,
             signatureRandom =
               ByteString(Hex.decode("5b496e526a65eac3c4312e683361bfdb873741acd3714c3bf1bcd7f01dd57ccb")),
-            signature = ByteString(Hex.decode("3a30af5f529c7fc1d43cfed773275290475337c5e499f383afd012edcc8d7299")),
-            chainId = 0x3d.toByte
+            signature = ByteString(Hex.decode("3a30af5f529c7fc1d43cfed773275290475337c5e499f383afd012edcc8d7299"))
           ),
           SignedTransaction(
             tx = LegacyTransaction(
@@ -76,8 +75,7 @@ object Fixtures {
             pointSign = 0x9d.toByte,
             signatureRandom =
               ByteString(Hex.decode("377e542cd9cd0a4414752a18d0862a5d6ced24ee6dba26b583cd85bc435b0ccf")),
-            signature = ByteString(Hex.decode("579fee4fd96ecf9a92ec450be3c9a139a687aa3c72c7e43cfac8c1feaf65c4ac")),
-            chainId = 0x3d.toByte
+            signature = ByteString(Hex.decode("579fee4fd96ecf9a92ec450be3c9a139a687aa3c72c7e43cfac8c1feaf65c4ac"))
           ),
           SignedTransaction(
             tx = LegacyTransaction(
@@ -91,8 +89,7 @@ object Fixtures {
             pointSign = 0x9d.toByte,
             signatureRandom =
               ByteString(Hex.decode("a70267341ba0b33f7e6f122080aa767d52ba4879776b793c35efec31dc70778d")),
-            signature = ByteString(Hex.decode("3f66ed7f0197627cbedfe80fd8e525e8bc6c5519aae7955e7493591dcdf1d6d2")),
-            chainId = 0x3d.toByte
+            signature = ByteString(Hex.decode("3f66ed7f0197627cbedfe80fd8e525e8bc6c5519aae7955e7493591dcdf1d6d2"))
           ),
           SignedTransaction(
             tx = LegacyTransaction(
@@ -106,8 +103,7 @@ object Fixtures {
             pointSign = 0x9d.toByte,
             signatureRandom =
               ByteString(Hex.decode("beb8226bdb90216ca29967871a6663b56bdd7b86cf3788796b52fd1ea3606698")),
-            signature = ByteString(Hex.decode("2446994156bc1780cb5806e730b171b38307d5de5b9b0d9ad1f9de82e00316b5")),
-            chainId = 0x3d.toByte
+            signature = ByteString(Hex.decode("2446994156bc1780cb5806e730b171b38307d5de5b9b0d9ad1f9de82e00316b5"))
           )
         ),
         uncleNodesList = Seq[BlockHeader]()
@@ -183,8 +179,7 @@ object Fixtures {
             pointSign = 0x1b.toByte,
             signatureRandom =
               ByteString(Hex.decode("8d94a55c7ac7adbfa2285ef7f4b0c955ae1a02647452cd4ead03ee6f449675c6")),
-            signature = ByteString(Hex.decode("67149821b74208176d78fc4dffbe37c8b64eecfd47532406b9727c4ae8eb7c9a")),
-            chainId = 0x3d.toByte
+            signature = ByteString(Hex.decode("67149821b74208176d78fc4dffbe37c8b64eecfd47532406b9727c4ae8eb7c9a"))
           ),
           SignedTransaction(
             tx = LegacyTransaction(
@@ -198,8 +193,7 @@ object Fixtures {
             pointSign = 0x1c.toByte,
             signatureRandom =
               ByteString(Hex.decode("6d31e3d59bfea97a34103d8ce767a8fe7a79b8e2f30af1e918df53f9e78e69ab")),
-            signature = ByteString(Hex.decode("098e5b80e1cc436421aa54eb17e96b08fe80d28a2fbd46451b56f2bca7a321e7")),
-            chainId = 0x3d.toByte
+            signature = ByteString(Hex.decode("098e5b80e1cc436421aa54eb17e96b08fe80d28a2fbd46451b56f2bca7a321e7"))
           ),
           SignedTransaction(
             tx = LegacyTransaction(
@@ -213,8 +207,7 @@ object Fixtures {
             pointSign = 0x1b.toByte,
             signatureRandom =
               ByteString(Hex.decode("fdbbc462a8a60ac3d8b13ee236b45af9b7991cf4f0f556d3af46aa5aeca242ab")),
-            signature = ByteString(Hex.decode("5de5dc03fdcb6cf6d14609dbe6f5ba4300b8ff917c7d190325d9ea2144a7a2fb")),
-            chainId = 0x3d.toByte
+            signature = ByteString(Hex.decode("5de5dc03fdcb6cf6d14609dbe6f5ba4300b8ff917c7d190325d9ea2144a7a2fb"))
           ),
           SignedTransaction(
             tx = LegacyTransaction(
@@ -228,8 +221,7 @@ object Fixtures {
             pointSign = 0x1b.toByte,
             signatureRandom =
               ByteString(Hex.decode("bafb9f71cef873b9e0395b9ed89aac4f2a752e2a4b88ba3c9b6c1fea254eae73")),
-            signature = ByteString(Hex.decode("1cef688f6718932f7705d9c1f0dd5a8aad9ddb196b826775f6e5703fdb997706")),
-            chainId = 0x3d.toByte
+            signature = ByteString(Hex.decode("1cef688f6718932f7705d9c1f0dd5a8aad9ddb196b826775f6e5703fdb997706"))
           )
         ),
         uncleNodesList = Seq[BlockHeader](
@@ -277,8 +269,7 @@ object Fixtures {
             pointSign = 0x1b.toByte,
             signatureRandom =
               ByteString(Hex.decode("fdbbc462a8a60ac3d8b13ee236b45af9b7991cf4f0f556d3af46aa5aeca242ab")),
-            signature = ByteString(Hex.decode("5de5dc03fdcb6cf6d14609dbe6f5ba4300b8ff917c7d190325d9ea2144a7a2fb")),
-            chainId = 0x01.toByte
+            signature = ByteString(Hex.decode("5de5dc03fdcb6cf6d14609dbe6f5ba4300b8ff917c7d190325d9ea2144a7a2fb"))
           ),
           SignedTransaction(
             tx = LegacyTransaction(
@@ -292,8 +283,7 @@ object Fixtures {
             pointSign = 0x1b.toByte,
             signatureRandom =
               ByteString(Hex.decode("8d94a55c7ac7adbfa2285ef7f4b0c955ae1a02647452cd4ead03ee6f449675c6")),
-            signature = ByteString(Hex.decode("67149821b74208176d78fc4dffbe37c8b64eecfd47532406b9727c4ae8eb7c9a")),
-            chainId = 0x01.toByte
+            signature = ByteString(Hex.decode("67149821b74208176d78fc4dffbe37c8b64eecfd47532406b9727c4ae8eb7c9a"))
           ),
           SignedTransaction(
             tx = LegacyTransaction(
@@ -307,8 +297,7 @@ object Fixtures {
             pointSign = 0x1c.toByte,
             signatureRandom =
               ByteString(Hex.decode("6d31e3d59bfea97a34103d8ce767a8fe7a79b8e2f30af1e918df53f9e78e69ab")),
-            signature = ByteString(Hex.decode("098e5b80e1cc436421aa54eb17e96b08fe80d28a2fbd46451b56f2bca7a321e7")),
-            chainId = 0x01.toByte
+            signature = ByteString(Hex.decode("098e5b80e1cc436421aa54eb17e96b08fe80d28a2fbd46451b56f2bca7a321e7"))
           ),
           SignedTransaction(
             tx = LegacyTransaction(
@@ -322,8 +311,7 @@ object Fixtures {
             pointSign = 0x1b.toByte,
             signatureRandom =
               ByteString(Hex.decode("bafb9f71cef873b9e0395b9ed89aac4f2a752e2a4b88ba3c9b6c1fea254eae73")),
-            signature = ByteString(Hex.decode("1cef688f6718932f7705d9c1f0dd5a8aad9ddb196b826775f6e5703fdb997706")),
-            chainId = 0x01.toByte
+            signature = ByteString(Hex.decode("1cef688f6718932f7705d9c1f0dd5a8aad9ddb196b826775f6e5703fdb997706"))
           )
         ),
         uncleNodesList = Seq[BlockHeader]()

--- a/src/test/scala/io/iohk/ethereum/ObjectGenerators.scala
+++ b/src/test/scala/io/iohk/ethereum/ObjectGenerators.scala
@@ -107,6 +107,7 @@ trait ObjectGenerators {
   )
 
   def typedTransactionGen(): Gen[TransactionWithAccessList] = for {
+    chainId <- bigIntGen
     nonce <- bigIntGen
     gasPrice <- bigIntGen
     gasLimit <- bigIntGen
@@ -115,6 +116,7 @@ trait ObjectGenerators {
     payload <- byteStringOfLengthNGen(256)
     accessList <- Gen.listOf(accessListItemGen())
   } yield TransactionWithAccessList(
+    chainId,
     nonce,
     gasPrice,
     gasLimit,

--- a/src/test/scala/io/iohk/ethereum/ObjectGenerators.scala
+++ b/src/test/scala/io/iohk/ethereum/ObjectGenerators.scala
@@ -82,7 +82,10 @@ trait ObjectGenerators {
 
   def addressGen: Gen[Address] = byteArrayOfNItemsGen(20).map(Address(_))
 
-  def transactionGen(): Gen[LegacyTransaction] = for {
+  def transactionGen(): Gen[Transaction] =
+    Gen.oneOf(legacyTransactionGen(), typedTransactionGen())
+
+  def legacyTransactionGen(): Gen[LegacyTransaction] = for {
     nonce <- bigIntGen
     gasPrice <- bigIntGen
     gasLimit <- bigIntGen
@@ -96,6 +99,23 @@ trait ObjectGenerators {
     receivingAddress,
     value,
     payload
+  )
+
+  def typedTransactionGen(): Gen[TransactionWithAccessList] = for {
+    nonce <- bigIntGen
+    gasPrice <- bigIntGen
+    gasLimit <- bigIntGen
+    receivingAddress <- addressGen
+    value <- bigIntGen
+    payload <- byteStringOfLengthNGen(256)
+  } yield TransactionWithAccessList(
+    nonce,
+    gasPrice,
+    gasLimit,
+    receivingAddress,
+    value,
+    payload,
+    Nil
   )
 
   def receiptsGen(n: Int): Gen[Seq[Seq[Receipt]]] = Gen.listOfN(n, Gen.listOf(receiptGen()))

--- a/src/test/scala/io/iohk/ethereum/consensus/blocks/BlockGeneratorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/blocks/BlockGeneratorSpec.scala
@@ -631,6 +631,7 @@ class BlockGeneratorSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
     )
 
     val typedTransaction: TypedTransaction = TransactionWithAccessList(
+      chainId = 61, // ethereum classic mainnet
       nonce = 0,
       gasPrice = 1,
       gasLimit = txGasLimit,

--- a/src/test/scala/io/iohk/ethereum/consensus/blocks/BlockGeneratorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/blocks/BlockGeneratorSpec.scala
@@ -630,6 +630,16 @@ class BlockGeneratorSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
       payload = ByteString.empty
     )
 
+    val typedTransaction: TypedTransaction = TransactionWithAccessList(
+      nonce = 0,
+      gasPrice = 1,
+      gasLimit = txGasLimit,
+      receivingAddress = Address(testAddress),
+      value = txTransfer,
+      payload = ByteString.empty,
+      accessList = Nil
+    )
+
     //defined in test-genesis-treasury.json
     val treasuryAccount: Address = Address(0xeeeeee)
     val maliciousAccount: Address = Address(0x123)
@@ -639,8 +649,14 @@ class BlockGeneratorSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
     lazy val duplicatedSignedTransaction: SignedTransaction =
       SignedTransaction.sign(transaction.copy(gasLimit = 2), keyPair, Some(0x3d.toByte))
 
+    lazy val signedTypedTransaction: SignedTransaction =
+      SignedTransaction.sign(typedTransaction, keyPair, Some(0x3d.toByte))
+
     lazy val signedTransactionWithAddress: SignedTransactionWithSender =
       SignedTransactionWithSender(signedTransaction, Address(keyPair))
+
+    lazy val signedTypedTransactionWithAddress: SignedTransactionWithSender =
+      SignedTransactionWithSender(signedTypedTransaction, Address(keyPair))
 
     val baseBlockchainConfig: BlockchainConfig = BlockchainConfig(
       forkBlockNumbers = ForkBlockNumbers.Empty.copy(

--- a/src/test/scala/io/iohk/ethereum/consensus/pow/MinerSpecSetup.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/pow/MinerSpecSetup.scala
@@ -69,8 +69,7 @@ trait MinerSpecSetup extends MiningConfigBuilder with MockFactory with Blockchai
     ),
     pointSign = 0x9d.toByte,
     signatureRandom = ByteString(Hex.decode("beb8226bdb90216ca29967871a6663b56bdd7b86cf3788796b52fd1ea3606698")),
-    signature = ByteString(Hex.decode("2446994156bc1780cb5806e730b171b38307d5de5b9b0d9ad1f9de82e00316b5")),
-    chainId = 0x3d.toByte
+    signature = ByteString(Hex.decode("2446994156bc1780cb5806e730b171b38307d5de5b9b0d9ad1f9de82e00316b5"))
   )
 
   lazy val mining: PoWMining = buildPoWConsensus().withBlockGenerator(blockGenerator)

--- a/src/test/scala/io/iohk/ethereum/consensus/validators/std/StdBlockValidatorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/validators/std/StdBlockValidatorSpec.scala
@@ -116,8 +116,7 @@ class StdBlockValidatorSpec extends AnyFlatSpec with Matchers with SecureRandomB
         ),
         pointSign = 0x9d.toByte,
         signatureRandom = ByteString(Hex.decode("5b496e526a65eac3c4312e683361bfdb873741acd3714c3bf1bcd7f01dd57ccb")),
-        signature = ByteString(Hex.decode("3a30af5f529c7fc1d43cfed773275290475337c5e499f383afd012edcc8d7299")),
-        chainId = 0x3d.toByte
+        signature = ByteString(Hex.decode("3a30af5f529c7fc1d43cfed773275290475337c5e499f383afd012edcc8d7299"))
       ),
       SignedTransaction(
         tx = LegacyTransaction(
@@ -130,8 +129,7 @@ class StdBlockValidatorSpec extends AnyFlatSpec with Matchers with SecureRandomB
         ),
         pointSign = 0x9d.toByte,
         signatureRandom = ByteString(Hex.decode("377e542cd9cd0a4414752a18d0862a5d6ced24ee6dba26b583cd85bc435b0ccf")),
-        signature = ByteString(Hex.decode("579fee4fd96ecf9a92ec450be3c9a139a687aa3c72c7e43cfac8c1feaf65c4ac")),
-        chainId = 0x3d.toByte
+        signature = ByteString(Hex.decode("579fee4fd96ecf9a92ec450be3c9a139a687aa3c72c7e43cfac8c1feaf65c4ac"))
       ),
       SignedTransaction(
         tx = LegacyTransaction(
@@ -144,8 +142,7 @@ class StdBlockValidatorSpec extends AnyFlatSpec with Matchers with SecureRandomB
         ),
         pointSign = 0x9d.toByte,
         signatureRandom = ByteString(Hex.decode("a70267341ba0b33f7e6f122080aa767d52ba4879776b793c35efec31dc70778d")),
-        signature = ByteString(Hex.decode("3f66ed7f0197627cbedfe80fd8e525e8bc6c5519aae7955e7493591dcdf1d6d2")),
-        chainId = 0x3d.toByte
+        signature = ByteString(Hex.decode("3f66ed7f0197627cbedfe80fd8e525e8bc6c5519aae7955e7493591dcdf1d6d2"))
       ),
       SignedTransaction(
         tx = LegacyTransaction(
@@ -158,8 +155,7 @@ class StdBlockValidatorSpec extends AnyFlatSpec with Matchers with SecureRandomB
         ),
         pointSign = 0x9d.toByte,
         signatureRandom = ByteString(Hex.decode("beb8226bdb90216ca29967871a6663b56bdd7b86cf3788796b52fd1ea3606698")),
-        signature = ByteString(Hex.decode("2446994156bc1780cb5806e730b171b38307d5de5b9b0d9ad1f9de82e00316b5")),
-        chainId = 0x3d.toByte
+        signature = ByteString(Hex.decode("2446994156bc1780cb5806e730b171b38307d5de5b9b0d9ad1f9de82e00316b5"))
       )
     ),
     uncleNodesList = Seq[BlockHeader]()

--- a/src/test/scala/io/iohk/ethereum/consensus/validators/std/StdSignedLegacyTransactionValidatorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/validators/std/StdSignedLegacyTransactionValidatorSpec.scala
@@ -38,8 +38,7 @@ class StdSignedLegacyTransactionValidatorSpec extends AnyFlatSpec with Matchers 
     txBeforeHomestead,
     pointSign = 0x1b.toByte,
     signatureRandom = ByteString(Hex.decode("12bfc6e767e518c50f59006556ecc9911593094cfb6f6ef78c9959e3327137a3")),
-    signature = ByteString(Hex.decode("13696dc6b5b601d19960a4f764416d36b271fc292bb87e2c36aea25d52f49064")),
-    chainId = 0x3d.toByte
+    signature = ByteString(Hex.decode("13696dc6b5b601d19960a4f764416d36b271fc292bb87e2c36aea25d52f49064"))
   )
 
   //From block 0xdc7874d8ea90b63aa0ba122055e514db8bb75c0e7d51a448abd12a31ca3370cf with number 1200003 (tx index 0)
@@ -55,8 +54,7 @@ class StdSignedLegacyTransactionValidatorSpec extends AnyFlatSpec with Matchers 
     txAfterHomestead,
     pointSign = 0x1c.toByte,
     signatureRandom = ByteString(Hex.decode("f337e8ca3306c131eabb756aa3701ec7b00bef0d6cc21fbf6a6f291463d58baf")),
-    signature = ByteString(Hex.decode("72216654137b4b58a4ece0a6df87aa1a4faf18ec4091839dd1c722fa9604fd09")),
-    chainId = 0x3d.toByte
+    signature = ByteString(Hex.decode("72216654137b4b58a4ece0a6df87aa1a4faf18ec4091839dd1c722fa9604fd09"))
   )
 
   val senderBalance = 100

--- a/src/test/scala/io/iohk/ethereum/domain/TransactionSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/domain/TransactionSpec.scala
@@ -37,6 +37,10 @@ class TransactionSpec
   }
 
   "Transaction type 01" should "be correctly serialized to rlp" in {
+
+    // binary values have be taken directly from core-geth own tests
+    // see https://github.com/ethereum/go-ethereum/blob/a580f7d6c54812ef47df94c6ffc974c9dbc48245/core/types/transaction_test.go#L71
+
     val toAddr: Address = Address.apply("b94f5374fce5edbc8e2a8697c15331677e6ebf0b")
     val tx: TransactionWithAccessList = TransactionWithAccessList(
       3,

--- a/src/test/scala/io/iohk/ethereum/domain/TransactionSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/domain/TransactionSpec.scala
@@ -97,6 +97,7 @@ class TransactionSpec
       // hack to check for legacy transaction regression.
       // The 27 magic number is taken from the yellow paper and eip155, which stipulate that
       // transaction.v = signature.yParity (here ECDSA.v raw field) + 27
+      // This should be fixed in ETCM-1096
       signature = sig.copy(v = (sig.v + 27).toByte)
     )
 

--- a/src/test/scala/io/iohk/ethereum/domain/TransactionSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/domain/TransactionSpec.scala
@@ -1,0 +1,106 @@
+package io.iohk.ethereum.domain
+
+import akka.util.ByteString
+import io.iohk.ethereum.crypto.ECDSASignature
+import io.iohk.ethereum.network.p2p.messages.BaseETH6XMessages.SignedTransactions
+import io.iohk.ethereum.utils.Hex
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class TransactionSpec extends AnyFlatSpec with Matchers {
+  "Transaction type 01" should "be correctly serialized to rlp" in {
+    val toAddr: Address = Address.apply("b94f5374fce5edbc8e2a8697c15331677e6ebf0b")
+    /*re/types/legacy_tx.go
+func NewTransaction(nonce uint64, to common.Address, amount *big.Int, gasLimit uint64, gasPrice *big.Int, data []byte) *Transaction {
+mobile/types.go
+     */
+
+    println(SignedTransactions.chainId.toInt)
+
+    val tx: TransactionWithAccessList = TransactionWithAccessList(
+      3,
+      1,
+      25000,
+      toAddr,
+      10,
+      ByteString(Hex.decode("5544")),
+      Nil
+    )
+    println(tx)
+    val stx = SignedTransaction.apply(
+      tx = tx,
+      ECDSASignature
+        .fromBytes(
+          ByteString(
+            Hex.decode(
+              "c9519f4f2b30335884581971573fadf60c6204f59a911df35ee8a540456b266032f1e8e2c5dd761f9e4f88f41c8310aeaba26a8bfcdacfedfa12ec3862d3752101"
+            )
+          )
+        )
+        .get
+    )
+    println(stx)
+
+    import SignedTransactions.SignedTransactionEnc
+    val x: Array[Byte] = stx.toBytes
+    val y: Array[Byte] = Hex.decode("01") ++ x
+
+    val e =
+      "01f8630103018261a894b94f5374fce5edbc8e2a8697c15331677e6ebf0b0a825544c001a0c9519f4f2b30335884581971573fadf60c6204f59a911df35ee8a540456b2660a032f1e8e2c5dd761f9e4f88f41c8310aeaba26a8bfcdacfedfa12ec3862d37521"
+
+    import SignedTransactions.SignedTransactionDec
+    val expected = Hex.decode(e)
+    val des = expected.toSignedTransaction
+
+    println(des)
+    println(expected(0))
+    println(expected(1))
+
+    y shouldBe expected
+
+  }
+  it should "handle optional access list" in {}
+
+  "Legacy transaction" should "correctly serialize to original rlp" in {
+    val toAddr: Address = Address.apply("b94f5374fce5edbc8e2a8697c15331677e6ebf0b")
+
+    val tx: LegacyTransaction = LegacyTransaction(
+      3,
+      1,
+      2000,
+      toAddr,
+      10,
+      ByteString(Hex.decode("5544"))
+    )
+
+    val sig = ECDSASignature
+      .fromBytes(
+        ByteString(
+          Hex.decode(
+            "98ff921201554726367d2be8c804a7ff89ccf285ebc57dff8ae4c44b9c19ac4a8887321be575c8095f789dd4c743dfe42c1820f9231f98a962b210e3ac2452a301"
+          )
+        )
+      )
+      .get
+    println(sig)
+
+    val stx = SignedTransaction.apply(
+      tx = tx,
+      signature = sig
+    )
+
+    import SignedTransactions.SignedTransactionEnc
+    val x: Array[Byte] = stx.toBytes
+
+    import SignedTransactions.SignedTransactionDec
+    val e =
+      "f86103018207d094b94f5374fce5edbc8e2a8697c15331677e6ebf0b0a8255441ca098ff921201554726367d2be8c804a7ff89ccf285ebc57dff8ae4c44b9c19ac4aa08887321be575c8095f789dd4c743dfe42c1820f9231f98a962b210e3ac2452a3"
+
+    val expected = Hex.decode(e)
+    val des = expected.toSignedTransaction
+    println(stx)
+    println(des)
+    x shouldBe expected
+  }
+  it should "correctly serialize to EIP1598 rlp" in {}
+}

--- a/src/test/scala/io/iohk/ethereum/domain/TransactionSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/domain/TransactionSpec.scala
@@ -132,11 +132,4 @@ class TransactionSpec
     x shouldBe expected
 
   }
-  it should "correctly serialize to EIP1598 rlp" in {}
-
-  // plan:
-  // TODO ReceiptSpec
-  // TODO decode string to case class
-  // TODO adjust runVM in ledger
-  // TODO align how geth and besu treat typed transactions when sent via rpc before magneto HF
 }

--- a/src/test/scala/io/iohk/ethereum/domain/TransactionSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/domain/TransactionSpec.scala
@@ -10,6 +10,7 @@ import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import io.iohk.ethereum.ObjectGenerators
 import io.iohk.ethereum.crypto.ECDSASignature
 import io.iohk.ethereum.network.p2p.messages.BaseETH6XMessages.SignedTransactions
+import io.iohk.ethereum.rlp.RLPList
 import io.iohk.ethereum.security.SecureRandomBuilder
 import io.iohk.ethereum.utils.Config
 import io.iohk.ethereum.utils.Hex
@@ -27,13 +28,47 @@ class TransactionSpec
     forAll(signedTxGen(secureRandom, None)) { (originalSignedTransaction: SignedTransaction) =>
       // encode it
       import SignedTransactions.SignedTransactionEnc
-      val encodedSignedTransaction = originalSignedTransaction.toBytes
+      val encodedSignedTransaction: Array[Byte] = originalSignedTransaction.toBytes
 
       // decode it
       import SignedTransactions.SignedTransactionDec
       val decodedSignedTransaction = encodedSignedTransaction.toSignedTransaction
 
       decodedSignedTransaction shouldEqual originalSignedTransaction
+    }
+  }
+
+  "rlp encoding then decoding transactions sequence" should "give back the initial transactions sequence" in {
+
+    forAll(signedTxSeqGen(2, secureRandom, None)) { (originalSignedTransactionSeq: Seq[SignedTransaction]) =>
+      // encode it
+      import SignedTransactions.SignedTransactionsEnc
+
+      // SignedTransactionsEnc is the Sequence version of SignedTransactionEnc
+      // the SignedTransactionsEnc.toBytes calls
+      // -> SignedTransactionsEnc.toRLPEncodable which maps over
+      // -> SignedTransactionEnc.toRLPEncodable (single signed transaction encoder)
+      // without going through the SignedTransactionEnc.toByte, which is the actual part where the 01 prefix is inserted
+      val encodedSignedTransactionSeq: Array[Byte] = SignedTransactions(originalSignedTransactionSeq).toBytes
+
+      // decode it
+      import SignedTransactions.SignedTransactionsDec
+      // likewise, the SignedTransactionsDec.toSignedTransactions maps over
+      // -> SignedTransactionRlpEncodableDec.toSignedTransaction (single signed transaction)
+      // while ignoring the SignedTransactionDec(Array[Byte]), which is responsible to parse the prefix if available
+      val SignedTransactions(decodedSignedTransactionSeq) = encodedSignedTransactionSeq.toSignedTransactions
+
+      // The test is working because both encoding and decoding are skipping the prefix part,
+      // and the rlp encoded transaction is different enough to recognize a LegacyTransaction from a TX1
+
+      // I see two problems:
+      // - the encoding is not compatible with other clients
+      // - this is not working for receipt, where legacy and tx1 receipt payload are the same. As such we can't
+      // distinguish which one it is without the prefix
+
+      // The root cause seems to be that the prefix stuff is done on a byte[] level,
+      // whereas RLPList are working on RLPEncodable
+      decodedSignedTransactionSeq shouldEqual originalSignedTransactionSeq
     }
   }
 

--- a/src/test/scala/io/iohk/ethereum/domain/TransactionSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/domain/TransactionSpec.scala
@@ -1,22 +1,17 @@
 package io.iohk.ethereum.domain
 
 import akka.util.ByteString
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
 import io.iohk.ethereum.crypto.ECDSASignature
 import io.iohk.ethereum.network.p2p.messages.BaseETH6XMessages.SignedTransactions
 import io.iohk.ethereum.utils.Hex
-import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.matchers.should.Matchers
 
 class TransactionSpec extends AnyFlatSpec with Matchers {
   "Transaction type 01" should "be correctly serialized to rlp" in {
     val toAddr: Address = Address.apply("b94f5374fce5edbc8e2a8697c15331677e6ebf0b")
-    /*re/types/legacy_tx.go
-func NewTransaction(nonce uint64, to common.Address, amount *big.Int, gasLimit uint64, gasPrice *big.Int, data []byte) *Transaction {
-mobile/types.go
-     */
-
-    println(SignedTransactions.chainId.toInt)
-
     val tx: TransactionWithAccessList = TransactionWithAccessList(
       3,
       1,
@@ -26,7 +21,6 @@ mobile/types.go
       ByteString(Hex.decode("5544")),
       Nil
     )
-    println(tx)
     val stx = SignedTransaction.apply(
       tx = tx,
       ECDSASignature
@@ -39,31 +33,21 @@ mobile/types.go
         )
         .get
     )
-    println(stx)
-
     import SignedTransactions.SignedTransactionEnc
     val x: Array[Byte] = stx.toBytes
+    // TODO SignedTransactionEnc does not deal with bytes directly which prohibits prepending bytes directly
+    // needs to be handled somehow
     val y: Array[Byte] = Hex.decode("01") ++ x
-
     val e =
       "01f8630103018261a894b94f5374fce5edbc8e2a8697c15331677e6ebf0b0a825544c001a0c9519f4f2b30335884581971573fadf60c6204f59a911df35ee8a540456b2660a032f1e8e2c5dd761f9e4f88f41c8310aeaba26a8bfcdacfedfa12ec3862d37521"
-
-    import SignedTransactions.SignedTransactionDec
     val expected = Hex.decode(e)
-    val des = expected.toSignedTransaction
-
-    println(des)
-    println(expected(0))
-    println(expected(1))
-
     y shouldBe expected
-
   }
+
   it should "handle optional access list" in {}
 
   "Legacy transaction" should "correctly serialize to original rlp" in {
     val toAddr: Address = Address.apply("b94f5374fce5edbc8e2a8697c15331677e6ebf0b")
-
     val tx: LegacyTransaction = LegacyTransaction(
       3,
       1,
@@ -72,7 +56,6 @@ mobile/types.go
       10,
       ByteString(Hex.decode("5544"))
     )
-
     val sig = ECDSASignature
       .fromBytes(
         ByteString(
@@ -82,25 +65,22 @@ mobile/types.go
         )
       )
       .get
-    println(sig)
-
     val stx = SignedTransaction.apply(
       tx = tx,
       signature = sig
     )
-
     import SignedTransactions.SignedTransactionEnc
     val x: Array[Byte] = stx.toBytes
-
-    import SignedTransactions.SignedTransactionDec
     val e =
       "f86103018207d094b94f5374fce5edbc8e2a8697c15331677e6ebf0b0a8255441ca098ff921201554726367d2be8c804a7ff89ccf285ebc57dff8ae4c44b9c19ac4aa08887321be575c8095f789dd4c743dfe42c1820f9231f98a962b210e3ac2452a3"
-
     val expected = Hex.decode(e)
-    val des = expected.toSignedTransaction
-    println(stx)
-    println(des)
     x shouldBe expected
   }
   it should "correctly serialize to EIP1598 rlp" in {}
+
+  // plan:
+  // TODO ReceiptSpec
+  // TODO decode string to case class
+  // TODO adjust runVM in ledger
+  // TODO align how geth and besu treat typed transactions when sent via rpc before magneto HF
 }

--- a/src/test/scala/io/iohk/ethereum/domain/TransactionSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/domain/TransactionSpec.scala
@@ -11,6 +11,7 @@ import io.iohk.ethereum.ObjectGenerators
 import io.iohk.ethereum.crypto.ECDSASignature
 import io.iohk.ethereum.network.p2p.messages.BaseETH6XMessages.SignedTransactions
 import io.iohk.ethereum.security.SecureRandomBuilder
+import io.iohk.ethereum.utils.Config
 import io.iohk.ethereum.utils.Hex
 import io.iohk.ethereum.vm.utils.MockVmInput
 
@@ -43,6 +44,7 @@ class TransactionSpec
 
     val toAddr: Address = Address.apply("b94f5374fce5edbc8e2a8697c15331677e6ebf0b")
     val tx: TransactionWithAccessList = TransactionWithAccessList(
+      1, // ethereum mainnet, used by the core-geth test
       3,
       1,
       25000,

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/EthTxServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/EthTxServiceSpec.scala
@@ -423,8 +423,7 @@ class EthTxServiceSpec
       ),
       v,
       r,
-      s,
-      0x3d.toByte
+      s
     )
 
     val contractCreatingTransactionSender: Address = SignedTransaction.getSender(contractCreatingTransaction).get

--- a/src/test/scala/io/iohk/ethereum/ledger/BlockExecutionSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/BlockExecutionSpec.scala
@@ -254,7 +254,7 @@ class BlockExecutionSpec extends AnyWordSpec with Matchers with ScalaCheckProper
         txsExecResult.isRight shouldBe true
         val BlockResult(resultingWorldState, resultingGasUsed, resultingReceipts) = txsExecResult.toOption.get
 
-        val transaction: LegacyTransaction = validStxSignedByOrigin.tx
+        val transaction: Transaction = validStxSignedByOrigin.tx
         // Check valid world
         val minerPaymentForTxs = UInt256(transaction.gasLimit * transaction.gasPrice)
         val changes = Seq(

--- a/src/test/scala/io/iohk/ethereum/ledger/BlockValidationSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/BlockValidationSpec.scala
@@ -77,8 +77,7 @@ class BlockValidationSpec extends AnyWordSpec with Matchers with MockFactory {
       tx = tx,
       pointSign = 0x9d.toByte,
       signatureRandom = hash2ByteString(random),
-      signature = hash2ByteString(signature),
-      chainId = 0x3d.toByte
+      signature = hash2ByteString(signature)
     )
 
     val bloomFilter: ByteString = hash2ByteString("0" * 512)

--- a/src/test/scala/io/iohk/ethereum/ledger/StxLedgerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/StxLedgerSpec.scala
@@ -47,7 +47,7 @@ class StxLedgerSpec extends AnyFlatSpec with Matchers with Logger {
 
     // Execute transaction with gasLimit lesser by one that estimated minimum
     val errorExecResult: TxResult = mining.blockPreparator.executeTransaction(
-      stx.copy(tx = stx.tx.copy(gasLimit = estimationResult - 1)),
+      stx.copy(tx = Transaction.withGasLimit(estimationResult - 1)(stx.tx)),
       fromAddress,
       genesisHeader,
       worldWithAccount

--- a/src/test/scala/io/iohk/ethereum/network/p2p/messages/LegacyTransactionSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/network/p2p/messages/LegacyTransactionSpec.scala
@@ -37,24 +37,21 @@ class LegacyTransactionSpec extends AnyFlatSpec with Matchers {
     validTx,
     pointSign = 28.toByte,
     signatureRandom = ByteString(Hex.decode("cfe3ad31d6612f8d787c45f115cc5b43fb22bcc210b62ae71dc7cbf0a6bea8df")),
-    signature = ByteString(Hex.decode("57db8998114fae3c337e99dbd8573d4085691880f4576c6c1f6c5bbfe67d6cf0")),
-    chainId = blockchainConfig.chainId
+    signature = ByteString(Hex.decode("57db8998114fae3c337e99dbd8573d4085691880f4576c6c1f6c5bbfe67d6cf0"))
   )
 
   val invalidTransactionSignatureNewSchema: SignedTransaction = SignedTransaction(
     validTx,
     pointSign = -98.toByte,
     signatureRandom = ByteString(Hex.decode("cfe3ad31d6612f8d787c45f115cc5b43fb22bcc210b62ae71dc7cbf0a6bea8df")),
-    signature = ByteString(Hex.decode("57db8998114fae3c337e99dbd8573d4085691880f4576c6c1f6c5bbfe67d6cf0")),
-    chainId = blockchainConfig.chainId
+    signature = ByteString(Hex.decode("57db8998114fae3c337e99dbd8573d4085691880f4576c6c1f6c5bbfe67d6cf0"))
   )
 
   val invalidStx: SignedTransaction = SignedTransaction(
     validTx.copy(gasPrice = 0),
     pointSign = -98.toByte,
     signatureRandom = ByteString(Hex.decode("cfe3ad31d6612f8d787c45f115cc5b43fb22bcc210b62ae71dc7cbf0a6bea8df")),
-    signature = ByteString(Hex.decode("57db8998114fae3c337e99dbd8573d4085691880f4576c6c1f6c5bbfe67d6cf0")),
-    chainId = blockchainConfig.chainId
+    signature = ByteString(Hex.decode("57db8998114fae3c337e99dbd8573d4085691880f4576c6c1f6c5bbfe67d6cf0"))
   )
 
   val rawPublicKeyForNewSigningScheme: Array[Byte] =
@@ -77,16 +74,14 @@ class LegacyTransactionSpec extends AnyFlatSpec with Matchers {
     tx = validTransactionForNewSigningScheme,
     pointSign = -98.toByte,
     signatureRandom = ByteString(Hex.decode("1af423b3608f3b4b35e191c26f07175331de22ed8f60d1735f03210388246ade")),
-    signature = ByteString(Hex.decode("4d5b6b9e3955a0db8feec9c518d8e1aae0e1d91a143fbbca36671c3b89b89bc3")),
-    blockchainConfig.chainId
+    signature = ByteString(Hex.decode("4d5b6b9e3955a0db8feec9c518d8e1aae0e1d91a143fbbca36671c3b89b89bc3"))
   )
 
   val stxWithInvalidPointSign: SignedTransaction = SignedTransaction(
     validTx,
     pointSign = 26.toByte,
     signatureRandom = ByteString(Hex.decode("cfe3ad31d6612f8d787c45f115cc5b43fb22bcc210b62ae71dc7cbf0a6bea8df")),
-    signature = ByteString(Hex.decode("57db8998114fae3c337e99dbd8573d4085691880f4576c6c1f6c5bbfe67d6cf0")),
-    blockchainConfig.chainId
+    signature = ByteString(Hex.decode("57db8998114fae3c337e99dbd8573d4085691880f4576c6c1f6c5bbfe67d6cf0"))
   )
 
   it should "not recover sender public key for new sign encoding schema if there is no chain_id in signed data" in {
@@ -123,8 +118,7 @@ class LegacyTransactionSpec extends AnyFlatSpec with Matchers {
       signatureRandom =
         ByteString(BigInt("61965845294689009770156372156374760022787886965323743865986648153755601564112").toByteArray),
       signature =
-        ByteString(BigInt("31606574786494953692291101914709926755545765281581808821704454381804773090106").toByteArray),
-      chainId = blockchainConfig.chainId
+        ByteString(BigInt("31606574786494953692291101914709926755545765281581808821704454381804773090106").toByteArray)
     )
 
     SignedTransaction.getSender(stx).get shouldBe Address(


### PR DESCRIPTION
Make `SignedTransaction` wrap `Transaction` to allow `TypedTransactions`.

This PR is split from https://github.com/input-output-hk/mantis/pull/1061

Included in this branch are:
- ETCM-911: new Typed Transaction envelop
- ETCM-921: new Type 1 transaction (payload + rlp encoder/decoder)

Follow up tickets are expected:
- ETCM-1095: receipt implementation
- ETCM-1096: signature/validation process enhancement for EIP-2930