### PR TITLE
[ETCM-1096] eip2930 transaction signature

### DIFF
--- a/crypto/src/main/scala/io/iohk/ethereum/crypto/ECDSASignature.scala
+++ b/crypto/src/main/scala/io/iohk/ethereum/crypto/ECDSASignature.scala
@@ -28,8 +28,12 @@ object ECDSASignature {
   val CompressedOddIndicator: Byte = 0x03
 
   //only naming convention
+  // Pre EIP155 signature.v convention
   val negativePointSign: Byte = 27
   val positivePointSign: Byte = 28
+  // yParity
+  val negativeYParity: Byte = 0
+  val positiveYParity: Byte = 1
 
   val allowedPointSigns: Set[Byte] = Set(negativePointSign, positivePointSign)
 

--- a/src/main/scala/io/iohk/ethereum/consensus/blocks/BlockGeneratorSkeleton.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/blocks/BlockGeneratorSkeleton.scala
@@ -131,7 +131,7 @@ abstract class BlockGeneratorSkeleton(
   protected def prepareTransactions(
       transactions: Seq[SignedTransaction],
       blockGasLimit: BigInt
-  ): Seq[SignedTransaction] = {
+  )(implicit blockchainConfig: BlockchainConfig): Seq[SignedTransaction] = {
 
     val sortedTransactions: Seq[SignedTransaction] = transactions
       //should be safe to call get as we do not insert improper transactions to pool.

--- a/src/main/scala/io/iohk/ethereum/domain/SignedTransaction.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/SignedTransaction.scala
@@ -68,8 +68,8 @@ object SignedTransaction {
       chainId: Option[Byte]
   ): SignedTransaction = {
     val bytes = bytesToSign(tx, chainId)
-    val sig = ECDSASignature.sign(bytes, keyPair /*, chainId*/ )
-    SignedTransaction(tx, getEthereumSignature(sig, chainId))
+    val sig = ECDSASignature.sign(bytes, keyPair)
+    SignedTransaction(tx, getEthereumSignature(tx, sig, chainId))
   }
 
   private def bytesToSign(tx: Transaction, chainId: Option[Byte]): Array[Byte] =
@@ -80,7 +80,10 @@ object SignedTransaction {
         generalTransactionBytes(tx)
     }
 
-  /** Convert a RLP compatible ECDSA Signature to a raw crypto signature.
+  /** Transaction specific piece of code.
+    * This should be moved to the Signer architecture once available.
+    *
+    * Convert a RLP compatible ECDSA Signature to a raw crypto signature.
     * Depending on the transaction type and the block number, different rules are
     * used to enhance the v field with additional context for signing purpose and networking
     * communication.
@@ -88,11 +91,32 @@ object SignedTransaction {
     * Currently, both semantic data are represented by the same data structure.
     *
     * @see getEthereumSignature for the reciprocal conversion.
+    * @param signedTransaction the signed transaction from which to extract the raw signature
+    * @return a raw crypto signature, with only 27 or 28 as valid ECDSASignature.v value
+    */
+  private def getRawSignature(signedTransaction: SignedTransaction): ECDSASignature =
+    signedTransaction.tx match {
+      case _: LegacyTransaction =>
+        val chainIdOpt = extractChainId(signedTransaction)
+        getLegacyTransactionRawSignature(signedTransaction.signature, chainIdOpt)
+      case _: TransactionWithAccessList =>
+        getTWALRawSignature(signedTransaction.signature)
+      case _ => throw new IllegalArgumentException(s"Transaction type not supported for $signedTransaction")
+    }
+
+  /** Transaction specific piece of code.
+    * This should be moved to the Signer architecture once available.
+    *
+    * Convert a LegacyTransaction RLP compatible ECDSA Signature to a raw crypto signature
+    *
     * @param ethereumSignature the v-modified signature, received from the network
     * @param chainIdOpt        the chainId if available
     * @return a raw crypto signature, with only 27 or 28 as valid ECDSASignature.v value
     */
-  private def getRawSignature(ethereumSignature: ECDSASignature, chainIdOpt: Option[Byte]): ECDSASignature =
+  private def getLegacyTransactionRawSignature(
+      ethereumSignature: ECDSASignature,
+      chainIdOpt: Option[Byte]
+  ): ECDSASignature =
     chainIdOpt match {
       // ignore chainId for unprotected negative y-parity in pre-eip155 signature
       case Some(_) if ethereumSignature.v == ECDSASignature.negativePointSign =>
@@ -111,11 +135,33 @@ object SignedTransaction {
       // unexpected chainId
       case _ =>
         throw new IllegalStateException(
-          s"Unexpected pointSign. ChainId: ${chainIdOpt.getOrElse("None")}, ethereum.signature.v: ${ethereumSignature.v}"
+          s"Unexpected pointSign for LegacyTransaction, chainId: ${chainIdOpt
+            .getOrElse("None")}, ethereum.signature.v: ${ethereumSignature.v}"
         )
     }
 
-  /** Convert a RLP compatible ECDSA Signature to a raw crypto signature.
+  /** Transaction specific piece of code.
+    * This should be moved to the Signer architecture once available.
+    *
+    * Convert a TransactionWithAccessList RLP compatible ECDSA Signature to a raw crypto signature
+    *
+    * @param ethereumSignature the v-modified signature, received from the network
+    * @return a raw crypto signature, with only 27 or 28 as valid ECDSASignature.v value
+    */
+  private def getTWALRawSignature(ethereumSignature: ECDSASignature): ECDSASignature =
+    ethereumSignature.v match {
+      case 0 => ethereumSignature.copy(v = ECDSASignature.negativePointSign)
+      case 1 => ethereumSignature.copy(v = ECDSASignature.positivePointSign)
+      case _ =>
+        throw new IllegalStateException(
+          s"Unexpected pointSign for TransactionWithAccessList, ethereum.signature.v: ${ethereumSignature.v}"
+        )
+    }
+
+  /** Transaction specific piece of code.
+    * This should be moved to the Signer architecture once available.
+    *
+    * Convert a raw crypto signature into a RLP compatible ECDSA one.
     * Depending on the transaction type and the block number, different rules are
     * used to enhance the v field with additional context for signing purpose and networking
     * communication.
@@ -123,11 +169,30 @@ object SignedTransaction {
     * Currently, both semantic data are represented by the same data structure.
     *
     * @see getRawSignature for the reciprocal conversion.
-    * @param ethereumSignature the v-modified signature, received from the network
-    * @param chainIdOpt        the chainId if available
-    * @return a raw crypto signature, with only 27 or 28 as valid ECDSASignature.v value
+    * @param tx           the transaction to adapt the raw signature to
+    * @param rawSignature the raw signature generated by the crypto module
+    * @param chainIdOpt   the chainId if available
+    * @return a ECDSASignature with v value depending on the transaction type
     */
-  private def getEthereumSignature(rawSignature: ECDSASignature, chainIdOpt: Option[Byte]): ECDSASignature =
+  private def getEthereumSignature(tx: Transaction, rawSignature: ECDSASignature, chainIdOpt: Option[Byte]): ECDSASignature =
+    tx match {
+      case _: LegacyTransaction =>
+        getLegacyEthereumSignature(rawSignature, chainIdOpt)
+      case _: TransactionWithAccessList =>
+        getTWALEthereumSignature(rawSignature)
+      case _ => throw new IllegalArgumentException(s"Transaction type not supported for $tx")
+    }
+
+  /** Transaction specific piece of code.
+    * This should be moved to the Signer architecture once available.
+    *
+    * Convert a raw crypto signature into a RLP compatible ECDSA one.
+    *
+    * @param rawSignature the raw signature generated by the crypto module
+    * @param chainIdOpt        the chainId if available
+    * @return a legacy transaction specific ECDSASignature, with v chainId-protected if possible
+    */
+  private def getLegacyEthereumSignature(rawSignature: ECDSASignature, chainIdOpt: Option[Byte]): ECDSASignature =
     chainIdOpt match {
       case Some(chainId) if rawSignature.v == ECDSASignature.negativePointSign =>
         rawSignature.copy(v = (chainId * 2 + EIP155NegativePointSign).toByte)
@@ -141,19 +206,31 @@ object SignedTransaction {
         )
     }
 
+  /** Transaction specific piece of code.
+    * This should be moved to the Signer architecture once available.
+    *
+    * Convert a raw crypto signature into a RLP compatible ECDSA one.
+    *
+    * @param rawSignature the raw signature generated by the crypto module
+    * @return a transaction-with-access-list specific ECDSASignature
+    */
+  private def getTWALEthereumSignature(rawSignature: ECDSASignature): ECDSASignature =
+    rawSignature match {
+      case ECDSASignature(_, _, ECDSASignature.positivePointSign) => rawSignature.copy(v = ECDSASignature.positiveYParity)
+      case ECDSASignature(_, _, ECDSASignature.negativePointSign) => rawSignature.copy(v = ECDSASignature.negativeYParity)
+      case _ =>
+        throw new IllegalStateException(
+          s"Unexpected pointSign. raw.signature.v: ${rawSignature.v}, authorized values are ${ECDSASignature.allowedPointSigns
+            .mkString(", ")}"
+        )
+    }
+
   def getSender(tx: SignedTransaction): Option[Address] =
     Option(txSenders.getIfPresent(tx.hash)).orElse(calculateSender(tx))
 
   private def calculateSender(tx: SignedTransaction): Option[Address] = Try {
-    val ECDSASignature(_, _, v) = tx.signature
-    // chainId specific code that will be refactored with the Signer feature (ETCM-1096)
-    val chainIdOpt = extractChainId(tx)
-    val bytesToSign: Array[Byte] = chainIdOpt match {
-      case None          => generalTransactionBytes(tx.tx)
-      case Some(chainId) => chainSpecificTransactionBytes(tx.tx, chainId)
-    }
-
-    val recoveredPublicKey: Option[Array[Byte]] = getRawSignature(tx.signature, chainIdOpt).publicKey(bytesToSign)
+    val bytesToSign: Array[Byte] = getBytesToSign(tx)
+    val recoveredPublicKey: Option[Array[Byte]] = getRawSignature(tx).publicKey(bytesToSign)
 
     for {
       key <- recoveredPublicKey
@@ -179,11 +256,28 @@ object SignedTransaction {
   private def calculateAndCacheSender(stx: SignedTransaction) =
     calculateSender(stx).foreach(address => txSenders.put(stx.hash, address))
 
+  /** Transaction specific piece of code.
+    * This should be moved to the Signer architecture once available.
+    *
+    * Extract pre-eip 155 payload to sign for legacy transaction
+    *
+    * @param tx
+    * @return the transaction payload for Legacy transaction
+    */
   private def generalTransactionBytes(tx: Transaction): Array[Byte] = {
     val receivingAddressAsArray: Array[Byte] = tx.receivingAddress.map(_.toArray).getOrElse(Array.emptyByteArray)
     crypto.kec256(rlpEncode(RLPList(tx.nonce, tx.gasPrice, tx.gasLimit, receivingAddressAsArray, tx.value, tx.payload)))
   }
 
+  /** Transaction specific piece of code.
+    * This should be moved to the Signer architecture once available.
+    *
+    * Extract post-eip 155 payload to sign for legacy transaction
+    *
+    * @param tx
+    * @param chainId
+    * @return the transaction payload for Legacy transaction
+    */
   private def chainSpecificTransactionBytes(tx: Transaction, chainId: Byte): Array[Byte] = {
     val receivingAddressAsArray: Array[Byte] = tx.receivingAddress.map(_.toArray).getOrElse(Array.emptyByteArray)
     crypto.kec256(
@@ -203,6 +297,12 @@ object SignedTransaction {
     )
   }
 
+  /** Transaction specific piece of code.
+    * This should be moved to the Signer architecture once available.
+    *
+    * @param stx the signed transaction to get the chainId from
+    * @return Some(chainId) if available, None if not (unprotected signed transaction)
+    */
   private def extractChainId(stx: SignedTransaction): Option[Byte] = {
     val chainIdOpt: Option[BigInt] = stx.tx match {
       case _: LegacyTransaction
@@ -212,6 +312,62 @@ object SignedTransaction {
       case twal: TransactionWithAccessList => Some(twal.chainId)
     }
     chainIdOpt.map(_.toByte)
+  }
+
+  /** Transaction specific piece of code.
+    * This should be moved to the Signer architecture once available.
+    *
+    * @param transaction the signed transaction from which to extract the payload to sign
+    * @return the payload to sign
+    */
+  private def getBytesToSign(signedTransaction: SignedTransaction): Array[Byte] =
+    signedTransaction.tx match {
+      case _: LegacyTransaction            => getLegacyBytesToSign(signedTransaction)
+      case twal: TransactionWithAccessList => getTWALBytesToSign(twal)
+      case _                               => throw new IllegalArgumentException(s"unknown transaction type for $signedTransaction")
+    }
+
+  /** Transaction specific piece of code.
+    * This should be moved to the Signer architecture once available.
+    *
+    * Extract pre-eip / post-eip 155 payload to sign for legacy transaction
+    *
+    * @param signedTransaction
+    * @return the transaction payload for Legacy transaction
+    */
+  private def getLegacyBytesToSign(signedTransaction: SignedTransaction): Array[Byte] = {
+    val chainIdOpt = extractChainId(signedTransaction)
+    chainIdOpt match {
+      case None          => generalTransactionBytes(signedTransaction.tx)
+      case Some(chainId) => chainSpecificTransactionBytes(signedTransaction.tx, chainId)
+    }
+  }
+
+  /** Transaction specific piece of code.
+    * This should be moved to the Signer architecture once available.
+    *
+    * Extract payload to sign for Transaction with access list
+    *
+    * @param tx
+    * @return the transaction payload to sign for Transaction with access list
+    */
+  private def getTWALBytesToSign(tx: TransactionWithAccessList): Array[Byte] = {
+    import io.iohk.ethereum.network.p2p.messages.BaseETH6XMessages.accessListItemCodec
+    val receivingAddressAsArray: Array[Byte] = tx.receivingAddress.map(_.toArray).getOrElse(Array.emptyByteArray)
+    crypto.kec256(
+      rlpEncode(
+        RLPList(
+          tx.chainId,
+          tx.nonce,
+          tx.gasPrice,
+          tx.gasLimit,
+          receivingAddressAsArray,
+          tx.value,
+          tx.payload,
+          fromRlpList[AccessListItem](tx.accessList).toList
+        )
+      )
+    )
   }
 
   val byteArraySerializable: ByteArraySerializable[SignedTransaction] = new ByteArraySerializable[SignedTransaction] {

--- a/src/main/scala/io/iohk/ethereum/domain/SignedTransaction.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/SignedTransaction.scala
@@ -206,8 +206,9 @@ object SignedTransaction {
       case None => rawSignature
       case _ =>
         throw new IllegalStateException(
-          s"Unexpected pointSign. ChainId: ${chainIdOpt.getOrElse("None")}, raw.signature.v: ${rawSignature.v}, authorized values are ${ECDSASignature.allowedPointSigns
-            .mkString(", ")}"
+          s"Unexpected pointSign. ChainId: ${chainIdOpt.getOrElse("None")}, "
+            + s"raw.signature.v: ${rawSignature.v}, "
+            + s"authorized values are ${ECDSASignature.allowedPointSigns.mkString(", ")}"
         )
     }
 

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/EthBlocksService.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/EthBlocksService.scala
@@ -10,6 +10,8 @@ import io.iohk.ethereum.consensus.mining.Mining
 import io.iohk.ethereum.domain.Blockchain
 import io.iohk.ethereum.domain.BlockchainReader
 import io.iohk.ethereum.ledger.BlockQueue
+import io.iohk.ethereum.utils.BlockchainConfig
+import io.iohk.ethereum.utils.Config
 
 object EthBlocksService {
   case class BestBlockNumberRequest()
@@ -47,6 +49,8 @@ class EthBlocksService(
     val blockQueue: BlockQueue
 ) extends ResolveBlock {
   import EthBlocksService._
+
+  implicit val blockchainConfig: BlockchainConfig = Config.blockchains.blockchainConfig
 
   /** eth_blockNumber that returns the number of most recent block.
     *

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/EthTxService.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/EthTxService.scala
@@ -21,6 +21,8 @@ import io.iohk.ethereum.domain.SignedTransaction
 import io.iohk.ethereum.transactions.PendingTransactionsManager
 import io.iohk.ethereum.transactions.PendingTransactionsManager.PendingTransaction
 import io.iohk.ethereum.transactions.TransactionPicker
+import io.iohk.ethereum.utils.Config
+import io.iohk.ethereum.utils.BlockchainConfig
 
 object EthTxService {
   case class GetTransactionByHashRequest(txHash: ByteString) //rename to match request
@@ -50,6 +52,8 @@ class EthTxService(
 ) extends TransactionPicker
     with ResolveBlock {
   import EthTxService._
+
+  implicit val blockchainConfig: BlockchainConfig = Config.blockchains.blockchainConfig
 
   /** Implements the eth_getRawTransactionByHash - fetch raw transaction data of a transaction with the given hash.
     *

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/EthTxService.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/EthTxService.scala
@@ -21,8 +21,8 @@ import io.iohk.ethereum.domain.SignedTransaction
 import io.iohk.ethereum.transactions.PendingTransactionsManager
 import io.iohk.ethereum.transactions.PendingTransactionsManager.PendingTransaction
 import io.iohk.ethereum.transactions.TransactionPicker
-import io.iohk.ethereum.utils.Config
 import io.iohk.ethereum.utils.BlockchainConfig
+import io.iohk.ethereum.utils.Config
 
 object EthTxService {
   case class GetTransactionByHashRequest(txHash: ByteString) //rename to match request

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/MantisService.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/MantisService.scala
@@ -11,12 +11,17 @@ import io.iohk.ethereum.jsonrpc.MantisService.GetAccountTransactionsResponse
 import io.iohk.ethereum.jsonrpc.server.controllers.JsonRpcBaseController.JsonRpcConfig
 import io.iohk.ethereum.transactions.TransactionHistoryService
 import io.iohk.ethereum.transactions.TransactionHistoryService.ExtendedTransactionData
+import io.iohk.ethereum.utils.Config
+import io.iohk.ethereum.utils.BlockchainConfig
 
 object MantisService {
   case class GetAccountTransactionsRequest(address: Address, blocksRange: NumericRange[BigInt])
   case class GetAccountTransactionsResponse(transactions: List[ExtendedTransactionData])
 }
 class MantisService(transactionHistoryService: TransactionHistoryService, jsonRpcConfig: JsonRpcConfig) {
+
+  implicit val blockchainConfig: BlockchainConfig = Config.blockchains.blockchainConfig
+
   def getAccountTransactions(
       request: GetAccountTransactionsRequest
   ): ServiceResponse[GetAccountTransactionsResponse] =

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/MantisService.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/MantisService.scala
@@ -11,8 +11,8 @@ import io.iohk.ethereum.jsonrpc.MantisService.GetAccountTransactionsResponse
 import io.iohk.ethereum.jsonrpc.server.controllers.JsonRpcBaseController.JsonRpcConfig
 import io.iohk.ethereum.transactions.TransactionHistoryService
 import io.iohk.ethereum.transactions.TransactionHistoryService.ExtendedTransactionData
-import io.iohk.ethereum.utils.Config
 import io.iohk.ethereum.utils.BlockchainConfig
+import io.iohk.ethereum.utils.Config
 
 object MantisService {
   case class GetAccountTransactionsRequest(address: Address, blocksRange: NumericRange[BigInt])

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/QAService.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/QAService.scala
@@ -74,7 +74,7 @@ class QAService(
     val keys = privateKeys.map { key =>
       crypto.keyPairFromPrvKey(key.toArray)
     }
-    val signatures = keys.map(ECDSASignature.sign(blockHash.toArray, _, None))
+    val signatures = keys.map(ECDSASignature.sign(blockHash.toArray, _))
     Checkpoint(signatures)
   }
 

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/TransactionResponse.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/TransactionResponse.scala
@@ -4,6 +4,8 @@ import akka.util.ByteString
 
 import io.iohk.ethereum.domain.BlockHeader
 import io.iohk.ethereum.domain.SignedTransaction
+import io.iohk.ethereum.utils.BlockchainConfig
+import io.iohk.ethereum.utils.Config
 
 trait BaseTransactionResponse {
   def hash: ByteString
@@ -40,6 +42,8 @@ final case class TransactionData(
 )
 
 object TransactionResponse {
+
+  implicit val blockchainConfig: BlockchainConfig = Config.blockchains.blockchainConfig
 
   def apply(tx: TransactionData): TransactionResponse =
     TransactionResponse(tx.stx, tx.blockHeader, tx.transactionIndex)

--- a/src/main/scala/io/iohk/ethereum/network/p2p/messages/BaseETH6XMessages.scala
+++ b/src/main/scala/io/iohk/ethereum/network/p2p/messages/BaseETH6XMessages.scala
@@ -58,7 +58,7 @@ object BaseETH6XMessages {
   implicit val accessListItemCodec: RLPCodec[AccessListItem] =
     RLPCodec.instance[AccessListItem](
       { case AccessListItem(address, storageKeys) =>
-        RLPList(address, toRlpList(storageKeys))
+        RLPList(address, toRlpList(storageKeys.map(UInt256(_).bytes.toArray)))
       },
       {
         case r: RLPList if r.items.isEmpty => AccessListItem(null, List.empty)

--- a/src/main/scala/io/iohk/ethereum/testmode/TestEthBlockServiceWrapper.scala
+++ b/src/main/scala/io/iohk/ethereum/testmode/TestEthBlockServiceWrapper.scala
@@ -18,7 +18,9 @@ import io.iohk.ethereum.jsonrpc.JsonRpcError
 import io.iohk.ethereum.jsonrpc.ServiceResponse
 import io.iohk.ethereum.jsonrpc.TransactionData
 import io.iohk.ethereum.ledger.BlockQueue
+import io.iohk.ethereum.utils.BlockchainConfig
 import io.iohk.ethereum.utils.ByteStringUtils._
+import io.iohk.ethereum.utils.Config
 import io.iohk.ethereum.utils.Logger
 
 class TestEthBlockServiceWrapper(
@@ -155,6 +157,8 @@ final case class EthTransactionResponse(
 ) extends BaseTransactionResponse
 
 object EthTransactionResponse {
+
+  implicit val blockchainConfig: BlockchainConfig = Config.blockchains.blockchainConfig
 
   def apply(tx: TransactionData): EthTransactionResponse =
     EthTransactionResponse(tx.stx, tx.blockHeader, tx.transactionIndex)

--- a/src/main/scala/io/iohk/ethereum/transactions/PendingTransactionsManager.scala
+++ b/src/main/scala/io/iohk/ethereum/transactions/PendingTransactionsManager.scala
@@ -29,7 +29,9 @@ import io.iohk.ethereum.network.PeerManagerActor.Peers
 import io.iohk.ethereum.network.p2p.messages.BaseETH6XMessages.SignedTransactions
 import io.iohk.ethereum.transactions.SignedTransactionsFilterActor.ProperSignedTransactions
 import io.iohk.ethereum.utils.ByteStringUtils.ByteStringOps
+import io.iohk.ethereum.utils.Config
 import io.iohk.ethereum.utils.TxPoolConfig
+import io.iohk.ethereum.utils.BlockchainConfig
 
 object PendingTransactionsManager {
   def props(
@@ -102,6 +104,8 @@ class PendingTransactionsManager(
   peerEventBus ! Subscribe(SubscriptionClassifier.PeerHandshaked)
 
   val transactionFilter: ActorRef = context.actorOf(SignedTransactionsFilterActor.props(context.self, peerEventBus))
+
+  implicit val blockchainConfig: BlockchainConfig = Config.blockchains.blockchainConfig
 
   // scalastyle:off method.length
   override def receive: Receive = {

--- a/src/main/scala/io/iohk/ethereum/transactions/PendingTransactionsManager.scala
+++ b/src/main/scala/io/iohk/ethereum/transactions/PendingTransactionsManager.scala
@@ -28,10 +28,10 @@ import io.iohk.ethereum.network.PeerManagerActor
 import io.iohk.ethereum.network.PeerManagerActor.Peers
 import io.iohk.ethereum.network.p2p.messages.BaseETH6XMessages.SignedTransactions
 import io.iohk.ethereum.transactions.SignedTransactionsFilterActor.ProperSignedTransactions
+import io.iohk.ethereum.utils.BlockchainConfig
 import io.iohk.ethereum.utils.ByteStringUtils.ByteStringOps
 import io.iohk.ethereum.utils.Config
 import io.iohk.ethereum.utils.TxPoolConfig
-import io.iohk.ethereum.utils.BlockchainConfig
 
 object PendingTransactionsManager {
   def props(

--- a/src/main/scala/io/iohk/ethereum/transactions/SignedTransactionsFilterActor.scala
+++ b/src/main/scala/io/iohk/ethereum/transactions/SignedTransactionsFilterActor.scala
@@ -15,8 +15,8 @@ import io.iohk.ethereum.network.PeerId
 import io.iohk.ethereum.network.p2p.messages.BaseETH6XMessages.SignedTransactions
 import io.iohk.ethereum.network.p2p.messages.Codes
 import io.iohk.ethereum.transactions.SignedTransactionsFilterActor.ProperSignedTransactions
-import io.iohk.ethereum.utils.Config
 import io.iohk.ethereum.utils.BlockchainConfig
+import io.iohk.ethereum.utils.Config
 
 class SignedTransactionsFilterActor(pendingTransactionsManager: ActorRef, peerEventBus: ActorRef)
     extends Actor

--- a/src/main/scala/io/iohk/ethereum/transactions/SignedTransactionsFilterActor.scala
+++ b/src/main/scala/io/iohk/ethereum/transactions/SignedTransactionsFilterActor.scala
@@ -15,10 +15,14 @@ import io.iohk.ethereum.network.PeerId
 import io.iohk.ethereum.network.p2p.messages.BaseETH6XMessages.SignedTransactions
 import io.iohk.ethereum.network.p2p.messages.Codes
 import io.iohk.ethereum.transactions.SignedTransactionsFilterActor.ProperSignedTransactions
+import io.iohk.ethereum.utils.Config
+import io.iohk.ethereum.utils.BlockchainConfig
 
 class SignedTransactionsFilterActor(pendingTransactionsManager: ActorRef, peerEventBus: ActorRef)
     extends Actor
     with RequiresMessageQueue[BoundedMessageQueueSemantics] {
+
+  implicit val blockchainConfig: BlockchainConfig = Config.blockchains.blockchainConfig
 
   peerEventBus ! Subscribe(MessageClassifier(Set(Codes.SignedTransactionsCode), PeerSelector.AllPeers))
 

--- a/src/test/scala/io/iohk/ethereum/domain/SignedLegacyTransactionSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/domain/SignedLegacyTransactionSpec.scala
@@ -4,11 +4,11 @@ import org.scalatest.flatspec.AnyFlatSpec
 
 import io.iohk.ethereum.vm.Generators
 
-class SignedLegacyTransactionSpec
-    extends AnyFlatSpec
-    with SignedTransactionBehavior {
+class SignedLegacyTransactionSpec extends AnyFlatSpec with SignedTransactionBehavior {
 
   private def allowedPointSigns(chainId: Byte) = Set((chainId * 2 + 35).toByte, (chainId * 2 + 36).toByte)
 
-  "Signed LegacyTransaction" should behave like SignedTransactionBehavior(Generators.legacyTransactionGen(), allowedPointSigns)
+  ("Signed LegacyTransaction" should behave).like(
+    SignedTransactionBehavior(Generators.legacyTransactionGen(), allowedPointSigns)
+  )
 }

--- a/src/test/scala/io/iohk/ethereum/domain/SignedLegacyTransactionSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/domain/SignedLegacyTransactionSpec.scala
@@ -8,6 +8,7 @@ import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import io.iohk.ethereum.crypto
 import io.iohk.ethereum.domain.SignedTransaction.getSender
 import io.iohk.ethereum.network.p2p.messages.BaseETH6XMessages.SignedTransactions
+import io.iohk.ethereum.utils.Config
 import io.iohk.ethereum.utils.Hex
 import io.iohk.ethereum.vm.Generators
 
@@ -20,6 +21,8 @@ class SignedLegacyTransactionSpec extends AnyFlatSpec with SignedTransactionBeha
   )
 
   "Legacy transaction sender" should "be properly recoverable from rlp encoded values" in {
+
+    implicit val blockchainConfig = Config.blockchains.blockchainConfig.copy(chainId = 1)
 
     // values are taken from https://github.com/ethereum/go-ethereum/blob/90987db7334c1d10eb866ca550efedb66dea8a20/core/types/transaction_signing_test.go#L79-L94
     val testValues = Table(

--- a/src/test/scala/io/iohk/ethereum/domain/SignedLegacyTransactionSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/domain/SignedLegacyTransactionSpec.scala
@@ -9,6 +9,6 @@ class SignedLegacyTransactionSpec extends AnyFlatSpec with SignedTransactionBeha
   private def allowedPointSigns(chainId: Byte) = Set((chainId * 2 + 35).toByte, (chainId * 2 + 36).toByte)
 
   ("Signed LegacyTransaction" should behave).like(
-    SignedTransactionBehavior(Generators.legacyTransactionGen(), allowedPointSigns)
+    SignedTransactionBehavior(Generators.legacyTransactionGen, allowedPointSigns)
   )
 }

--- a/src/test/scala/io/iohk/ethereum/domain/SignedLegacyTransactionSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/domain/SignedLegacyTransactionSpec.scala
@@ -1,37 +1,14 @@
 package io.iohk.ethereum.domain
 
-import org.bouncycastle.crypto.params.ECPublicKeyParameters
-import org.scalacheck.Arbitrary
 import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.matchers.should.Matchers
-import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
-import io.iohk.ethereum.crypto
-import io.iohk.ethereum.crypto.generateKeyPair
-import io.iohk.ethereum.domain.SignedTransaction.FirstByteOfAddress
-import io.iohk.ethereum.security.SecureRandomBuilder
 import io.iohk.ethereum.vm.Generators
 
 class SignedLegacyTransactionSpec
     extends AnyFlatSpec
-    with Matchers
-    with ScalaCheckPropertyChecks
-    with SecureRandomBuilder {
-  "SignedTransaction" should "correctly set pointSign for chainId with chain specific signing schema" in {
-    forAll(Generators.transactionGen, Arbitrary.arbitrary[Unit].map(_ => generateKeyPair(secureRandom))) { (tx, key) =>
-      val chainId: Byte = 0x3d
-      val allowedPointSigns = Set((chainId * 2 + 35).toByte, (chainId * 2 + 36).toByte)
-      //byte 0 of encoded ECC point indicates that it is uncompressed point, it is part of bouncycastle encoding
-      val address = Address(
-        crypto
-          .kec256(key.getPublic.asInstanceOf[ECPublicKeyParameters].getQ.getEncoded(false).tail)
-          .drop(FirstByteOfAddress)
-      )
-      val signedTransaction = SignedTransaction.sign(tx, key, Some(chainId))
-      val result = SignedTransactionWithSender(signedTransaction, Address(key))
+    with SignedTransactionBehavior {
 
-      allowedPointSigns should contain(result.tx.signature.v)
-      address shouldEqual result.senderAddress
-    }
-  }
+  private def allowedPointSigns(chainId: Byte) = Set((chainId * 2 + 35).toByte, (chainId * 2 + 36).toByte)
+
+  "Signed LegacyTransaction" should behave like SignedTransactionBehavior(Generators.legacyTransactionGen(), allowedPointSigns)
 }

--- a/src/test/scala/io/iohk/ethereum/domain/SignedLegacyTransactionSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/domain/SignedLegacyTransactionSpec.scala
@@ -1,14 +1,118 @@
 package io.iohk.ethereum.domain
 
-import org.scalatest.flatspec.AnyFlatSpec
+import akka.util.ByteString
 
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+
+import io.iohk.ethereum.crypto
+import io.iohk.ethereum.domain.SignedTransaction.getSender
+import io.iohk.ethereum.network.p2p.messages.BaseETH6XMessages.SignedTransactions
+import io.iohk.ethereum.utils.Hex
 import io.iohk.ethereum.vm.Generators
 
-class SignedLegacyTransactionSpec extends AnyFlatSpec with SignedTransactionBehavior {
+class SignedLegacyTransactionSpec extends AnyFlatSpec with SignedTransactionBehavior with ScalaCheckPropertyChecks {
 
   private def allowedPointSigns(chainId: Byte) = Set((chainId * 2 + 35).toByte, (chainId * 2 + 36).toByte)
 
   ("Signed LegacyTransaction" should behave).like(
     SignedTransactionBehavior(Generators.legacyTransactionGen, allowedPointSigns)
   )
+
+  "Legacy transaction sender" should "be properly recoverable from rlp encoded values" in {
+
+    // values are taken from https://github.com/ethereum/go-ethereum/blob/90987db7334c1d10eb866ca550efedb66dea8a20/core/types/transaction_signing_test.go#L79-L94
+    val testValues = Table(
+      ("binaryRLP", "expectedSender"),
+      (
+        "f864808504a817c800825208943535353535353535353535353535353535353535808025a0044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116da0044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d",
+        "0xf0f6f18bca1b28cd68e4357452947e021241e9ce"
+      ),
+      (
+        "f864018504a817c80182a410943535353535353535353535353535353535353535018025a0489efdaa54c0f20c7adf612882df0950f5a951637e0307cdcb4c672f298b8bcaa0489efdaa54c0f20c7adf612882df0950f5a951637e0307cdcb4c672f298b8bc6",
+        "0x23ef145a395ea3fa3deb533b8a9e1b4c6c25d112"
+      ),
+      (
+        "f864028504a817c80282f618943535353535353535353535353535353535353535088025a02d7c5bef027816a800da1736444fb58a807ef4c9603b7848673f7e3a68eb14a5a02d7c5bef027816a800da1736444fb58a807ef4c9603b7848673f7e3a68eb14a5",
+        "0x2e485e0c23b4c3c542628a5f672eeab0ad4888be"
+      ),
+      (
+        "f865038504a817c803830148209435353535353535353535353535353535353535351b8025a02a80e1ef1d7842f27f2e6be0972bb708b9a135c38860dbe73c27c3486c34f4e0a02a80e1ef1d7842f27f2e6be0972bb708b9a135c38860dbe73c27c3486c34f4de",
+        "0x82a88539669a3fd524d669e858935de5e5410cf0"
+      ),
+      (
+        "f865048504a817c80483019a28943535353535353535353535353535353535353535408025a013600b294191fc92924bb3ce4b969c1e7e2bab8f4c93c3fc6d0a51733df3c063a013600b294191fc92924bb3ce4b969c1e7e2bab8f4c93c3fc6d0a51733df3c060",
+        "0xf9358f2538fd5ccfeb848b64a96b743fcc930554"
+      ),
+      (
+        "f865058504a817c8058301ec309435353535353535353535353535353535353535357d8025a04eebf77a833b30520287ddd9478ff51abbdffa30aa90a8d655dba0e8a79ce0c1a04eebf77a833b30520287ddd9478ff51abbdffa30aa90a8d655dba0e8a79ce0c1",
+        "0xa8f7aba377317440bc5b26198a363ad22af1f3a4"
+      ),
+      (
+        "f866068504a817c80683023e3894353535353535353535353535353535353535353581d88025a06455bf8ea6e7463a1046a0b52804526e119b4bf5136279614e0b1e8e296a4e2fa06455bf8ea6e7463a1046a0b52804526e119b4bf5136279614e0b1e8e296a4e2d",
+        "0xf1f571dc362a0e5b2696b8e775f8491d3e50de35"
+      ),
+      (
+        "f867078504a817c807830290409435353535353535353535353535353535353535358201578025a052f1a9b320cab38e5da8a8f97989383aab0a49165fc91c737310e4f7e9821021a052f1a9b320cab38e5da8a8f97989383aab0a49165fc91c737310e4f7e9821021",
+        "0xd37922162ab7cea97c97a87551ed02c9a38b7332"
+      ),
+      (
+        "f867088504a817c8088302e2489435353535353535353535353535353535353535358202008025a064b1702d9298fee62dfeccc57d322a463ad55ca201256d01f62b45b2e1c21c12a064b1702d9298fee62dfeccc57d322a463ad55ca201256d01f62b45b2e1c21c10",
+        "0x9bddad43f934d313c2b79ca28a432dd2b7281029"
+      ),
+      (
+        "f867098504a817c809830334509435353535353535353535353535353535353535358202d98025a052f8f61201b2b11a78d6e866abc9c3db2ae8631fa656bfe5cb53668255367afba052f8f61201b2b11a78d6e866abc9c3db2ae8631fa656bfe5cb53668255367afb",
+        "0x3c24d7329e92f84f08556ceb6df1cdb0104ca49f"
+      )
+    )
+
+    forAll(testValues) { (binaryRLP: String, expectedSender: String) =>
+      import SignedTransactions.SignedTransactionDec
+      val decodedSignedTransaction = Hex.decode(binaryRLP).toSignedTransaction
+
+      val expectedSenderAddress = Address(expectedSender)
+      val computedSenderAddressOpt = getSender(decodedSignedTransaction)
+      computedSenderAddressOpt shouldEqual (Some(expectedSenderAddress))
+    }
+  }
+
+  "Legacy transaction signature" should "respect EIP155 example" in {
+    // values have been taken directly from the EIP-155 document
+    // https://eips.ethereum.org/EIPS/eip-155
+    val legacyTransaction = LegacyTransaction(
+      nonce = 9,
+      gasPrice = 20 * BigInt(10).pow(9),
+      gasLimit = 21000,
+      receivingAddress = Address("0x3535353535353535353535353535353535353535"),
+      value = BigInt(10).pow(18),
+      payload = ByteString.empty
+    )
+
+    val expectedSigningData =
+      "ec098504a817c800825208943535353535353535353535353535353535353535880de0b6b3a764000080018080"
+    val expectedSigningHash = "daf5a779ae972f972197303d7b574746c7ef83eadac0f2791ad23db92e4c8e53"
+    val privateKey = "4646464646464646464646464646464646464646464646464646464646464646"
+    val expectedSignatureV = 37
+    val expectedSignatureR = BigInt("18515461264373351373200002665853028612451056578545711640558177340181847433846")
+    val expectedSignatureS = BigInt("46948507304638947509940763649030358759909902576025900602547168820602576006531")
+
+    val expectedSignedTransaction =
+      "f86c098504a817c800825208943535353535353535353535353535353535353535880de0b6b3a76400008025a028ef61340bd939bc2195fe537567866003e1a15d3c71ff63e1590620aa636276a067cbe9d8997f761aecb703304b3800ccf555c9f3dc64214b297fb1966a3b6d83"
+
+    val signingData = SignedTransaction.bytesToSign(legacyTransaction, Some(1))
+
+    Hex.toHexString(signingData) shouldEqual expectedSigningHash
+
+    val senderKeyPair = crypto.keyPairFromPrvKey(Hex.decode(privateKey))
+    val signedTransaction = SignedTransaction.sign(legacyTransaction, senderKeyPair, Some(1))
+
+    signedTransaction.signature.v shouldEqual expectedSignatureV
+    signedTransaction.signature.r shouldEqual expectedSignatureR
+    signedTransaction.signature.s shouldEqual expectedSignatureS
+
+    import SignedTransactions.SignedTransactionEnc
+    val encodedSignedTransaction: Array[Byte] = signedTransaction.toBytes
+
+    Hex.toHexString(encodedSignedTransaction) shouldEqual expectedSignedTransaction
+  }
 }

--- a/src/test/scala/io/iohk/ethereum/domain/SignedTransactionBehavior.scala
+++ b/src/test/scala/io/iohk/ethereum/domain/SignedTransactionBehavior.scala
@@ -1,24 +1,24 @@
 package io.iohk.ethereum.domain
 
-import io.iohk.ethereum.crypto
-import io.iohk.ethereum.crypto.generateKeyPair
-import io.iohk.ethereum.domain.SignedTransaction.FirstByteOfAddress
-import io.iohk.ethereum.security.SecureRandomBuilder
 import org.bouncycastle.crypto.params.ECPublicKeyParameters
-import org.scalacheck.{Arbitrary, Gen}
+import org.scalacheck.Arbitrary
+import org.scalacheck.Gen
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
-trait SignedTransactionBehavior
-extends Matchers
-with ScalaCheckPropertyChecks
-with SecureRandomBuilder
-{
+import io.iohk.ethereum.crypto
+import io.iohk.ethereum.crypto.generateKeyPair
+import io.iohk.ethereum.domain.SignedTransaction.FirstByteOfAddress
+import io.iohk.ethereum.security.SecureRandomBuilder
+
+trait SignedTransactionBehavior extends Matchers with ScalaCheckPropertyChecks with SecureRandomBuilder {
   this: AnyFlatSpec =>
 
-  def SignedTransactionBehavior(signedTransactionGenerator: Gen[Transaction], allowedPointSigns: Byte => Set[Byte]): Unit = {
-
+  def SignedTransactionBehavior(
+      signedTransactionGenerator: Gen[Transaction],
+      allowedPointSigns: Byte => Set[Byte]
+  ): Unit =
     it should "correctly set pointSign for chainId with chain specific signing schema" in {
       forAll(signedTransactionGenerator, Arbitrary.arbitrary[Unit].map(_ => generateKeyPair(secureRandom))) {
         (tx, key) =>
@@ -36,5 +36,4 @@ with SecureRandomBuilder
           address shouldEqual result.senderAddress
       }
     }
-  }
 }

--- a/src/test/scala/io/iohk/ethereum/domain/SignedTransactionBehavior.scala
+++ b/src/test/scala/io/iohk/ethereum/domain/SignedTransactionBehavior.scala
@@ -1,0 +1,40 @@
+package io.iohk.ethereum.domain
+
+import io.iohk.ethereum.crypto
+import io.iohk.ethereum.crypto.generateKeyPair
+import io.iohk.ethereum.domain.SignedTransaction.FirstByteOfAddress
+import io.iohk.ethereum.security.SecureRandomBuilder
+import org.bouncycastle.crypto.params.ECPublicKeyParameters
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+
+trait SignedTransactionBehavior
+extends Matchers
+with ScalaCheckPropertyChecks
+with SecureRandomBuilder
+{
+  this: AnyFlatSpec =>
+
+  def SignedTransactionBehavior(signedTransactionGenerator: Gen[Transaction], allowedPointSigns: Byte => Set[Byte]): Unit = {
+
+    it should "correctly set pointSign for chainId with chain specific signing schema" in {
+      forAll(signedTransactionGenerator, Arbitrary.arbitrary[Unit].map(_ => generateKeyPair(secureRandom))) {
+        (tx, key) =>
+          val chainId: Byte = 0x3d
+          //byte 0 of encoded ECC point indicates that it is uncompressed point, it is part of bouncycastle encoding
+          val address = Address(
+            crypto
+              .kec256(key.getPublic.asInstanceOf[ECPublicKeyParameters].getQ.getEncoded(false).tail)
+              .drop(FirstByteOfAddress)
+          )
+          val signedTransaction = SignedTransaction.sign(tx, key, Some(chainId))
+          val result = SignedTransactionWithSender(signedTransaction, Address(key))
+
+          allowedPointSigns(chainId) should contain(result.tx.signature.v)
+          address shouldEqual result.senderAddress
+      }
+    }
+  }
+}

--- a/src/test/scala/io/iohk/ethereum/domain/SignedTransactionWithAccessListSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/domain/SignedTransactionWithAccessListSpec.scala
@@ -9,6 +9,6 @@ class SignedTransactionWithAccessListSpec extends AnyFlatSpec with SignedTransac
   private def allowedPointSigns(chainId: Byte) = Set(0.toByte, 1.toByte)
 
   ("Signed TransactionWithAccessList" should behave).like(
-    SignedTransactionBehavior(Generators.typedTransactionGen(), allowedPointSigns)
+    SignedTransactionBehavior(Generators.typedTransactionGen, allowedPointSigns)
   )
 }

--- a/src/test/scala/io/iohk/ethereum/domain/SignedTransactionWithAccessListSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/domain/SignedTransactionWithAccessListSpec.scala
@@ -1,0 +1,13 @@
+package io.iohk.ethereum.domain
+
+import io.iohk.ethereum.vm.Generators
+import org.scalatest.flatspec.AnyFlatSpec
+
+class SignedTransactionWithAccessListSpec
+  extends AnyFlatSpec
+    with SignedTransactionBehavior {
+
+  private def allowedPointSigns(chainId: Byte) = Set(0.toByte, 1.toByte)
+
+  "Signed TransactionWithAccessList" should behave like SignedTransactionBehavior(Generators.typedTransactionGen(), allowedPointSigns)
+}

--- a/src/test/scala/io/iohk/ethereum/domain/SignedTransactionWithAccessListSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/domain/SignedTransactionWithAccessListSpec.scala
@@ -1,13 +1,14 @@
 package io.iohk.ethereum.domain
 
-import io.iohk.ethereum.vm.Generators
 import org.scalatest.flatspec.AnyFlatSpec
 
-class SignedTransactionWithAccessListSpec
-  extends AnyFlatSpec
-    with SignedTransactionBehavior {
+import io.iohk.ethereum.vm.Generators
+
+class SignedTransactionWithAccessListSpec extends AnyFlatSpec with SignedTransactionBehavior {
 
   private def allowedPointSigns(chainId: Byte) = Set(0.toByte, 1.toByte)
 
-  "Signed TransactionWithAccessList" should behave like SignedTransactionBehavior(Generators.typedTransactionGen(), allowedPointSigns)
+  ("Signed TransactionWithAccessList" should behave).like(
+    SignedTransactionBehavior(Generators.typedTransactionGen(), allowedPointSigns)
+  )
 }

--- a/src/test/scala/io/iohk/ethereum/domain/TransactionSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/domain/TransactionSpec.scala
@@ -14,6 +14,7 @@ import io.iohk.ethereum.crypto.pubKeyFromKeyPair
 import io.iohk.ethereum.domain.SignedTransaction.getSender
 import io.iohk.ethereum.network.p2p.messages.BaseETH6XMessages.SignedTransactions
 import io.iohk.ethereum.security.SecureRandomBuilder
+import io.iohk.ethereum.utils.Config
 import io.iohk.ethereum.utils.Hex
 
 class TransactionSpec
@@ -41,6 +42,8 @@ class TransactionSpec
   "signing transaction, encoding and decoding it" should "allow to retrieve the proper sender" in {
 
     forAll(transactionGen) { (originalTransaction: Transaction) =>
+      implicit val blockchainConfig = Config.blockchains.blockchainConfig
+
       val senderKeys = crypto.generateKeyPair(secureRandom)
 
       val originalSenderAddress = {
@@ -52,7 +55,8 @@ class TransactionSpec
         Address(slice)
       }
 
-      val originalSignedTransaction = SignedTransaction.sign(originalTransaction, senderKeys, Some(1))
+      val originalSignedTransaction =
+        SignedTransaction.sign(originalTransaction, senderKeys, Some(blockchainConfig.chainId))
       // check for proper signature content
       getSender(originalSignedTransaction) shouldEqual (Some(originalSenderAddress))
 

--- a/src/test/scala/io/iohk/ethereum/domain/TransactionSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/domain/TransactionSpec.scala
@@ -3,18 +3,18 @@ package io.iohk.ethereum.domain
 import akka.util.ByteString
 
 import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
 import io.iohk.ethereum.ObjectGenerators
+import io.iohk.ethereum.crypto
 import io.iohk.ethereum.crypto.ECDSASignature
+import io.iohk.ethereum.crypto.kec256
+import io.iohk.ethereum.crypto.pubKeyFromKeyPair
+import io.iohk.ethereum.domain.SignedTransaction.getSender
 import io.iohk.ethereum.network.p2p.messages.BaseETH6XMessages.SignedTransactions
-import io.iohk.ethereum.rlp.RLPList
 import io.iohk.ethereum.security.SecureRandomBuilder
-import io.iohk.ethereum.utils.Config
 import io.iohk.ethereum.utils.Hex
-import io.iohk.ethereum.vm.utils.MockVmInput
 
 class TransactionSpec
     extends AnyFlatSpec
@@ -35,6 +35,38 @@ class TransactionSpec
       val decodedSignedTransaction = encodedSignedTransaction.toSignedTransaction
 
       decodedSignedTransaction shouldEqual originalSignedTransaction
+    }
+  }
+
+  "signing transaction, encoding and decoding it" should "allow to retrieve the proper sender" in {
+
+    forAll(transactionGen) { (originalTransaction: Transaction) =>
+      val senderKeys = crypto.generateKeyPair(secureRandom)
+
+      val originalSenderAddress = {
+        // You get a public address for your account by taking the last 20 bytes of the Keccak-256 hash of the public key and adding 0x to the beginning.
+        ECDSASignature
+        val pubKey = pubKeyFromKeyPair(senderKeys)
+        val hashedPublickKey = kec256(pubKey)
+        val slice = hashedPublickKey.slice(hashedPublickKey.length - 20, hashedPublickKey.length)
+        Address(slice)
+      }
+
+      val originalSignedTransaction = SignedTransaction.sign(originalTransaction, senderKeys, Some(1))
+      // check for proper signature content
+      getSender(originalSignedTransaction) shouldEqual (Some(originalSenderAddress))
+
+      // encode it
+      import SignedTransactions.SignedTransactionEnc
+      val encodedSignedTransaction: Array[Byte] = originalSignedTransaction.toBytes
+
+      // decode it
+      import SignedTransactions.SignedTransactionDec
+      val decodedSignedTransaction = encodedSignedTransaction.toSignedTransaction
+
+      // resolve original sender
+      getSender(originalSignedTransaction)
+      getSender(decodedSignedTransaction) shouldEqual getSender(originalSignedTransaction)
     }
   }
 

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/MantisServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/MantisServiceSpec.scala
@@ -31,6 +31,7 @@ import io.iohk.ethereum.nodebuilder.TxPoolConfigBuilder
 import io.iohk.ethereum.transactions.TransactionHistoryService
 import io.iohk.ethereum.transactions.TransactionHistoryService.ExtendedTransactionData
 import io.iohk.ethereum.transactions.TransactionHistoryService.MinedTransactionData
+import io.iohk.ethereum.utils.BlockchainConfig
 
 class MantisServiceSpec
     extends TestKit(ActorSystem("MantisServiceSpec"))
@@ -83,7 +84,9 @@ class MantisServiceSpec
             pendingTransactionsManager,
             txPoolConfig.getTransactionFromPoolTimeout
           ) {
-            override def getAccountTransactions(account: Address, fromBlocks: NumericRange[BigInt]) =
+            override def getAccountTransactions(account: Address, fromBlocks: NumericRange[BigInt])(implicit
+                blockchainConfig: BlockchainConfig
+            ) =
               Task.pure(expectedResponse)
           }
       }

--- a/src/test/scala/io/iohk/ethereum/network/p2p/messages/LegacyTransactionSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/network/p2p/messages/LegacyTransactionSpec.scala
@@ -12,10 +12,11 @@ import io.iohk.ethereum.domain.Address
 import io.iohk.ethereum.domain.LegacyTransaction
 import io.iohk.ethereum.domain.SignedTransaction
 import io.iohk.ethereum.utils.Config
+import io.iohk.ethereum.utils.BlockchainConfig
 
 class LegacyTransactionSpec extends AnyFlatSpec with Matchers {
 
-  val blockchainConfig = Config.blockchains.blockchainConfig
+  implicit val blockchainConfig: BlockchainConfig = Config.blockchains.blockchainConfig
 
   val rawPublicKey: Array[Byte] =
     Hex.decode(

--- a/src/test/scala/io/iohk/ethereum/network/p2p/messages/LegacyTransactionSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/network/p2p/messages/LegacyTransactionSpec.scala
@@ -11,8 +11,8 @@ import io.iohk.ethereum.crypto
 import io.iohk.ethereum.domain.Address
 import io.iohk.ethereum.domain.LegacyTransaction
 import io.iohk.ethereum.domain.SignedTransaction
-import io.iohk.ethereum.utils.Config
 import io.iohk.ethereum.utils.BlockchainConfig
+import io.iohk.ethereum.utils.Config
 
 class LegacyTransactionSpec extends AnyFlatSpec with Matchers {
 

--- a/src/test/scala/io/iohk/ethereum/transactions/LegacyTransactionHistoryServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/transactions/LegacyTransactionHistoryServiceSpec.scala
@@ -140,7 +140,7 @@ class LegacyTransactionHistoryServiceSpec
           _,
           header => {
             val checkpoint =
-              Checkpoint(List(ECDSASignature.sign(crypto.kec256(ByteString("foo")).toArray, checkpointKey, None)))
+              Checkpoint(List(ECDSASignature.sign(crypto.kec256(ByteString("foo")).toArray, checkpointKey)))
             header.copy(extraFields = HefPostEcip1097(Some(checkpoint)))
           }
         )

--- a/src/test/scala/io/iohk/ethereum/transactions/testing/PendingTransactionsManagerAutoPilot.scala
+++ b/src/test/scala/io/iohk/ethereum/transactions/testing/PendingTransactionsManagerAutoPilot.scala
@@ -7,9 +7,14 @@ import io.iohk.ethereum.domain.SignedTransaction
 import io.iohk.ethereum.domain.SignedTransactionWithSender
 import io.iohk.ethereum.transactions.PendingTransactionsManager._
 import io.iohk.ethereum.transactions.SignedTransactionsFilterActor.ProperSignedTransactions
+import io.iohk.ethereum.utils.Config
+import io.iohk.ethereum.utils.BlockchainConfig
 
 case class PendingTransactionsManagerAutoPilot(pendingTransactions: Set[PendingTransaction] = Set.empty)
     extends AutoPilot {
+
+  implicit val blockchainConfig: BlockchainConfig = Config.blockchains.blockchainConfig
+
   def run(sender: ActorRef, msg: Any): AutoPilot =
     msg match {
       case AddUncheckedTransactions(transactions) =>

--- a/src/test/scala/io/iohk/ethereum/transactions/testing/PendingTransactionsManagerAutoPilot.scala
+++ b/src/test/scala/io/iohk/ethereum/transactions/testing/PendingTransactionsManagerAutoPilot.scala
@@ -7,8 +7,8 @@ import io.iohk.ethereum.domain.SignedTransaction
 import io.iohk.ethereum.domain.SignedTransactionWithSender
 import io.iohk.ethereum.transactions.PendingTransactionsManager._
 import io.iohk.ethereum.transactions.SignedTransactionsFilterActor.ProperSignedTransactions
-import io.iohk.ethereum.utils.Config
 import io.iohk.ethereum.utils.BlockchainConfig
+import io.iohk.ethereum.utils.Config
 
 case class PendingTransactionsManagerAutoPilot(pendingTransactions: Set[PendingTransaction] = Set.empty)
     extends AutoPilot {


### PR DESCRIPTION
# Description

Transaction with optional access list (added by EIP 2930) requires a specific rule for signing / validation.
There is currently no framework to handle different rulesets for such a purpose.
 
This PR is split from https://github.com/input-output-hk/mantis/pull/1061

# Proposed Solution

Implement the specific ruleset for new transaction type 1

This may need a signature process refactoring. (Signature refactoring has been parked into the branch https://github.com/input-output-hk/mantis/tree/feature/eip2930%2Fsigner_hierarchy)

