### PR TITLE
[ETCM-1069] consensus adapter

### DIFF
--- a/src/it/scala/io/iohk/ethereum/ledger/BlockImporterItSpec.scala
+++ b/src/it/scala/io/iohk/ethereum/ledger/BlockImporterItSpec.scala
@@ -3,16 +3,20 @@ package io.iohk.ethereum.ledger
 import akka.actor.ActorRef
 import akka.testkit.TestProbe
 import akka.util.ByteString
+
 import cats.data.NonEmptyList
+
 import monix.execution.Scheduler
 import monix.execution.schedulers.SchedulerService
 
 import scala.concurrent.duration._
+
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.Eventually
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
+
 import io.iohk.ethereum.Fixtures
 import io.iohk.ethereum.Mocks
 import io.iohk.ethereum.NormalPatience

--- a/src/it/scala/io/iohk/ethereum/ledger/BlockImporterItSpec.scala
+++ b/src/it/scala/io/iohk/ethereum/ledger/BlockImporterItSpec.scala
@@ -3,20 +3,16 @@ package io.iohk.ethereum.ledger
 import akka.actor.ActorRef
 import akka.testkit.TestProbe
 import akka.util.ByteString
-
 import cats.data.NonEmptyList
-
 import monix.execution.Scheduler
 import monix.execution.schedulers.SchedulerService
 
 import scala.concurrent.duration._
-
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.Eventually
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
-
 import io.iohk.ethereum.Fixtures
 import io.iohk.ethereum.Mocks
 import io.iohk.ethereum.NormalPatience
@@ -26,7 +22,6 @@ import io.iohk.ethereum.blockchain.sync.regular.BlockFetcher
 import io.iohk.ethereum.blockchain.sync.regular.BlockImporter
 import io.iohk.ethereum.blockchain.sync.regular.BlockImporter.NewCheckpoint
 import io.iohk.ethereum.checkpointing.CheckpointingTestHelpers
-import io.iohk.ethereum.consensus.Consensus
 import io.iohk.ethereum.consensus.ConsensusAdapter
 import io.iohk.ethereum.consensus.blocks.CheckpointBlockGenerator
 import io.iohk.ethereum.consensus.pow.validators.OmmersValidator

--- a/src/it/scala/io/iohk/ethereum/sync/util/RegularSyncItSpecUtils.scala
+++ b/src/it/scala/io/iohk/ethereum/sync/util/RegularSyncItSpecUtils.scala
@@ -111,7 +111,6 @@ object RegularSyncItSpecUtils {
         bl,
         blockchainReader,
         blockchainWriter,
-        blockQueue,
         blockExecution
       )
     lazy val consensusAdapter = new ConsensusAdapter(

--- a/src/it/scala/io/iohk/ethereum/sync/util/RegularSyncItSpecUtils.scala
+++ b/src/it/scala/io/iohk/ethereum/sync/util/RegularSyncItSpecUtils.scala
@@ -4,11 +4,14 @@ import akka.actor.ActorRef
 import akka.actor.typed
 import akka.actor.typed.scaladsl.adapter._
 import akka.util.ByteString
+
 import cats.effect.Resource
+
 import monix.eval.Task
 import monix.execution.Scheduler
 
 import scala.concurrent.duration._
+
 import io.iohk.ethereum.Mocks.MockValidatorsAlwaysSucceed
 import io.iohk.ethereum.blockchain.sync.PeersClient
 import io.iohk.ethereum.blockchain.sync.SyncProtocol
@@ -30,6 +33,7 @@ import io.iohk.ethereum.consensus.blocks.CheckpointBlockGenerator
 import io.iohk.ethereum.consensus.mining.FullMiningConfig
 import io.iohk.ethereum.consensus.mining.MiningConfig
 import io.iohk.ethereum.consensus.mining.Protocol.NoAdditionalPoWData
+import io.iohk.ethereum.consensus.pow
 import io.iohk.ethereum.consensus.pow.EthashConfig
 import io.iohk.ethereum.consensus.pow.PoWMining
 import io.iohk.ethereum.consensus.pow.validators.ValidatorsExecutor

--- a/src/it/scala/io/iohk/ethereum/sync/util/RegularSyncItSpecUtils.scala
+++ b/src/it/scala/io/iohk/ethereum/sync/util/RegularSyncItSpecUtils.scala
@@ -4,14 +4,11 @@ import akka.actor.ActorRef
 import akka.actor.typed
 import akka.actor.typed.scaladsl.adapter._
 import akka.util.ByteString
-
 import cats.effect.Resource
-
 import monix.eval.Task
 import monix.execution.Scheduler
 
 import scala.concurrent.duration._
-
 import io.iohk.ethereum.Mocks.MockValidatorsAlwaysSucceed
 import io.iohk.ethereum.blockchain.sync.PeersClient
 import io.iohk.ethereum.blockchain.sync.SyncProtocol
@@ -33,7 +30,6 @@ import io.iohk.ethereum.consensus.blocks.CheckpointBlockGenerator
 import io.iohk.ethereum.consensus.mining.FullMiningConfig
 import io.iohk.ethereum.consensus.mining.MiningConfig
 import io.iohk.ethereum.consensus.mining.Protocol.NoAdditionalPoWData
-import io.iohk.ethereum.consensus.pow
 import io.iohk.ethereum.consensus.pow.EthashConfig
 import io.iohk.ethereum.consensus.pow.PoWMining
 import io.iohk.ethereum.consensus.pow.validators.ValidatorsExecutor

--- a/src/it/scala/io/iohk/ethereum/sync/util/RegularSyncItSpecUtils.scala
+++ b/src/it/scala/io/iohk/ethereum/sync/util/RegularSyncItSpecUtils.scala
@@ -116,7 +116,6 @@ object RegularSyncItSpecUtils {
     lazy val consensusAdapter = new ConsensusAdapter(
       consensus,
       blockchainReader,
-      bl,
       blockQueue,
       blockValidation,
       Scheduler.global

--- a/src/it/scala/io/iohk/ethereum/sync/util/RegularSyncItSpecUtils.scala
+++ b/src/it/scala/io/iohk/ethereum/sync/util/RegularSyncItSpecUtils.scala
@@ -117,6 +117,7 @@ object RegularSyncItSpecUtils {
     lazy val consensusAdapter = new ConsensusAdapter(
       consensus,
       blockchainReader,
+      bl,
       blockQueue,
       blockValidation,
       Scheduler.global

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/SyncController.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/SyncController.scala
@@ -6,10 +6,8 @@ import akka.actor.ActorRef
 import akka.actor.PoisonPill
 import akka.actor.Props
 import akka.actor.Scheduler
-
 import io.iohk.ethereum.blockchain.sync.fast.FastSync
 import io.iohk.ethereum.blockchain.sync.regular.RegularSync
-import io.iohk.ethereum.consensus.Consensus
 import io.iohk.ethereum.consensus.ConsensusAdapter
 import io.iohk.ethereum.consensus.validators.Validators
 import io.iohk.ethereum.db.storage.AppStateStorage

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/SyncController.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/SyncController.scala
@@ -6,6 +6,7 @@ import akka.actor.ActorRef
 import akka.actor.PoisonPill
 import akka.actor.Props
 import akka.actor.Scheduler
+
 import io.iohk.ethereum.blockchain.sync.fast.FastSync
 import io.iohk.ethereum.blockchain.sync.regular.RegularSync
 import io.iohk.ethereum.consensus.ConsensusAdapter

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/regular/BlockImporter.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/regular/BlockImporter.scala
@@ -7,12 +7,15 @@ import akka.actor.ActorRef
 import akka.actor.NotInfluenceReceiveTimeout
 import akka.actor.Props
 import akka.actor.ReceiveTimeout
+
 import cats.data.NonEmptyList
 import cats.implicits._
+
 import monix.eval.Task
 import monix.execution.Scheduler
 
 import scala.concurrent.duration._
+
 import io.iohk.ethereum.blockchain.sync.Blacklist.BlacklistReason
 import io.iohk.ethereum.blockchain.sync.regular.BlockBroadcast.BlockToBroadcast
 import io.iohk.ethereum.blockchain.sync.regular.BlockBroadcasterActor.BroadcastBlocks

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/regular/BlockImporter.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/regular/BlockImporter.scala
@@ -7,20 +7,16 @@ import akka.actor.ActorRef
 import akka.actor.NotInfluenceReceiveTimeout
 import akka.actor.Props
 import akka.actor.ReceiveTimeout
-
 import cats.data.NonEmptyList
 import cats.implicits._
-
 import monix.eval.Task
 import monix.execution.Scheduler
 
 import scala.concurrent.duration._
-
 import io.iohk.ethereum.blockchain.sync.Blacklist.BlacklistReason
 import io.iohk.ethereum.blockchain.sync.regular.BlockBroadcast.BlockToBroadcast
 import io.iohk.ethereum.blockchain.sync.regular.BlockBroadcasterActor.BroadcastBlocks
 import io.iohk.ethereum.blockchain.sync.regular.RegularSync.ProgressProtocol
-import io.iohk.ethereum.consensus.Consensus
 import io.iohk.ethereum.consensus.ConsensusAdapter
 import io.iohk.ethereum.crypto.kec256
 import io.iohk.ethereum.db.storage.StateStorage

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/regular/RegularSync.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/regular/RegularSync.scala
@@ -10,6 +10,7 @@ import akka.actor.Scheduler
 import akka.actor.SupervisorStrategy
 import akka.actor.typed.scaladsl.adapter._
 import akka.actor.typed.{ActorRef => TypedActorRef}
+
 import io.iohk.ethereum.blockchain.sync.Blacklist
 import io.iohk.ethereum.blockchain.sync.SyncProtocol
 import io.iohk.ethereum.blockchain.sync.SyncProtocol.Status

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/regular/RegularSync.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/regular/RegularSync.scala
@@ -10,7 +10,6 @@ import akka.actor.Scheduler
 import akka.actor.SupervisorStrategy
 import akka.actor.typed.scaladsl.adapter._
 import akka.actor.typed.{ActorRef => TypedActorRef}
-
 import io.iohk.ethereum.blockchain.sync.Blacklist
 import io.iohk.ethereum.blockchain.sync.SyncProtocol
 import io.iohk.ethereum.blockchain.sync.SyncProtocol.Status
@@ -19,7 +18,6 @@ import io.iohk.ethereum.blockchain.sync.regular.BlockFetcher.InternalLastBlockIm
 import io.iohk.ethereum.blockchain.sync.regular.RegularSync.NewCheckpoint
 import io.iohk.ethereum.blockchain.sync.regular.RegularSync.ProgressProtocol
 import io.iohk.ethereum.blockchain.sync.regular.RegularSync.ProgressState
-import io.iohk.ethereum.consensus.Consensus
 import io.iohk.ethereum.consensus.ConsensusAdapter
 import io.iohk.ethereum.consensus.validators.BlockValidator
 import io.iohk.ethereum.db.storage.StateStorage

--- a/src/main/scala/io/iohk/ethereum/consensus/Consensus.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/Consensus.scala
@@ -96,7 +96,8 @@ object Consensus {
 
   case object KeptCurrentBestBranch extends ConsensusResult
 
-  case class BranchExecutionFailure(failingBlockHash: ByteString, error: String) extends ConsensusResult
+  case class BranchExecutionFailure(blockToEnqueue: List[Block], failingBlockHash: ByteString, error: String)
+      extends ConsensusResult
 
   case class ConsensusError(blockToEnqueue: List[Block], err: String) extends ConsensusResult
   case class ConsensusErrorDueToMissingNode(blockToEnqueue: List[Block], reason: MissingNodeException)

--- a/src/main/scala/io/iohk/ethereum/consensus/Consensus.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/Consensus.scala
@@ -76,6 +76,15 @@ trait Consensus {
 }
 
 object Consensus {
+  /* This return type for consensus is probably overcomplicated for now because some information is needed
+   * to keep the compatibility with the current code (particularly for the block queue handling).
+   * In particular:
+   *  - `blockToEnqueue` fields won't be needed if the block are already stored in memory
+   *  - The distinction between ExtendedCurrentBestBranch and SelectedNewBestBranch won't really be useful
+   *  because there will be no need to put back the old branch into the block queue in case of reorganisation
+   *  - `ConsensusErrorDueToMissingNode` would mean that the application is in an inconsistent state
+   */
+
   sealed trait ConsensusResult
 
   case class ExtendedCurrentBestBranch(blockImportData: List[BlockData]) extends ConsensusResult
@@ -89,6 +98,7 @@ object Consensus {
 
   case class BranchExecutionFailure(failingBlockHash: ByteString, error: String) extends ConsensusResult
 
-  case class ConsensusError(err: String) extends ConsensusResult
-  case class ConsensusErrorDueToMissingNode(reason: MissingNodeException) extends ConsensusResult
+  case class ConsensusError(blockToEnqueue: List[Block], err: String) extends ConsensusResult
+  case class ConsensusErrorDueToMissingNode(blockToEnqueue: List[Block], reason: MissingNodeException)
+      extends ConsensusResult
 }

--- a/src/main/scala/io/iohk/ethereum/consensus/Consensus.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/Consensus.scala
@@ -1,5 +1,7 @@
 package io.iohk.ethereum.consensus
 
+import akka.util.ByteString
+
 import cats.data.NonEmptyList
 
 import monix.eval.Task
@@ -77,11 +79,15 @@ object Consensus {
   sealed trait ConsensusResult
 
   case class ExtendedCurrentBestBranch(blockImportData: List[BlockData]) extends ConsensusResult
+  case class ExtendedCurrentBestBranchPartially(blockImportData: List[BlockData], failureBranch: BranchExecutionFailure)
+      extends ConsensusResult
 
   case class SelectedNewBestBranch(oldBranch: List[Block], newBranch: List[Block], weights: List[ChainWeight])
       extends ConsensusResult
 
   case object KeptCurrentBestBranch extends ConsensusResult
+
+  case class BranchExecutionFailure(failingBlockHash: ByteString, error: String) extends ConsensusResult
 
   case class ConsensusError(err: String) extends ConsensusResult
   case class ConsensusErrorDueToMissingNode(reason: MissingNodeException) extends ConsensusResult

--- a/src/main/scala/io/iohk/ethereum/consensus/ConsensusAdapter.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/ConsensusAdapter.scala
@@ -1,22 +1,21 @@
 package io.iohk.ethereum.consensus
 
-import monix.eval.Task
-import monix.execution.Scheduler
-
 import io.iohk.ethereum.blockchain.sync.regular.BlockImportFailed
-import io.iohk.ethereum.blockchain.sync.regular.BlockImportResult
 import io.iohk.ethereum.blockchain.sync.regular.DuplicateBlock
-import io.iohk.ethereum.domain.Block
 import io.iohk.ethereum.domain.BlockHeader
 import io.iohk.ethereum.domain.BlockchainReader
 import io.iohk.ethereum.ledger.BlockExecutionError.ValidationBeforeExecError
 import io.iohk.ethereum.ledger.BlockExecutionSuccess
 import io.iohk.ethereum.ledger.BlockQueue
 import io.iohk.ethereum.ledger.BlockValidation
-import io.iohk.ethereum.utils.BlockchainConfig
 import io.iohk.ethereum.utils.FunctorOps._
 import io.iohk.ethereum.utils.Hex
 import io.iohk.ethereum.utils.Logger
+import io.iohk.ethereum.blockchain.sync.regular.BlockImportResult
+import io.iohk.ethereum.domain.Block
+import io.iohk.ethereum.utils.BlockchainConfig
+import monix.eval.Task
+import monix.execution.Scheduler
 
 /** This is a temporary class to isolate the real Consensus and extract responsibilities which should not
   * be part of the consensus in the final design, but are currently needed.

--- a/src/main/scala/io/iohk/ethereum/consensus/ConsensusAdapter.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/ConsensusAdapter.scala
@@ -86,9 +86,11 @@ class ConsensusAdapter(
                       case BranchExecutionFailure(failingBlockHash, error) =>
                         blockQueue.removeSubtree(failingBlockHash)
                         BlockImportFailed(error)
-                      case ConsensusError(error) =>
+                      case ConsensusError(blocksToEnqueue, error) =>
+                        blocksToEnqueue.foreach(blockQueue.enqueueBlock(_))
                         BlockImportFailed(error)
-                      case ConsensusErrorDueToMissingNode(reason) =>
+                      case ConsensusErrorDueToMissingNode(blocksToEnqueue, reason) =>
+                        blocksToEnqueue.foreach(blockQueue.enqueueBlock(_))
                         BlockImportFailedDueToMissingNode(reason)
                     }
               }

--- a/src/main/scala/io/iohk/ethereum/consensus/ConsensusAdapter.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/ConsensusAdapter.scala
@@ -61,8 +61,7 @@ class ConsensusAdapter(
             Hex.toHexString(block.hash.toArray),
             error.reason.toString
           )
-        case Right(_) =>
-          log.debug("Block with hash {} validated successfully", Hex.toHexString(block.hash.toArray))
+        case Right(_) => log.debug("Block with hash {} validated successfully", Hex.toHexString(block.hash.toArray))
       }
       .executeOn(validationScheduler)
 

--- a/src/main/scala/io/iohk/ethereum/consensus/ConsensusAdapter.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/ConsensusAdapter.scala
@@ -98,7 +98,6 @@ class ConsensusAdapter(
           }
         }
       case None =>
-        // TODO ETCM-1069 remove duplication with ConsensusImpl
         log.error("Couldn't find the current best block")
         Task.now(BlockImportFailed("Couldn't find the current best block"))
     }

--- a/src/main/scala/io/iohk/ethereum/consensus/ConsensusAdapter.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/ConsensusAdapter.scala
@@ -75,15 +75,17 @@ class ConsensusAdapter(
                         BlockImportedToTop(blockImportData)
                       case ExtendedCurrentBestBranchPartially(
                             blockImportData,
-                            BranchExecutionFailure(failingBlockHash, error)
+                            BranchExecutionFailure(blocksToEnqueue, failingBlockHash, error)
                           ) =>
+                        blocksToEnqueue.foreach(blockQueue.enqueueBlock(_))
                         blockQueue.removeSubtree(failingBlockHash)
-                        log.warn("extended best branch partially because of error: {}")
+                        log.warn("extended best branch partially because of error: {}", error)
                         BlockImportedToTop(blockImportData)
                       case KeptCurrentBestBranch =>
                         newBranch.toList.foreach(blockQueue.enqueueBlock(_))
                         BlockEnqueued
-                      case BranchExecutionFailure(failingBlockHash, error) =>
+                      case BranchExecutionFailure(blocksToEnqueue, failingBlockHash, error) =>
+                        blocksToEnqueue.foreach(blockQueue.enqueueBlock(_))
                         blockQueue.removeSubtree(failingBlockHash)
                         BlockImportFailed(error)
                       case ConsensusError(blocksToEnqueue, error) =>

--- a/src/main/scala/io/iohk/ethereum/consensus/ConsensusAdapter.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/ConsensusAdapter.scala
@@ -1,21 +1,22 @@
 package io.iohk.ethereum.consensus
 
+import monix.eval.Task
+import monix.execution.Scheduler
+
 import io.iohk.ethereum.blockchain.sync.regular.BlockImportFailed
+import io.iohk.ethereum.blockchain.sync.regular.BlockImportResult
 import io.iohk.ethereum.blockchain.sync.regular.DuplicateBlock
+import io.iohk.ethereum.domain.Block
 import io.iohk.ethereum.domain.BlockHeader
 import io.iohk.ethereum.domain.BlockchainReader
 import io.iohk.ethereum.ledger.BlockExecutionError.ValidationBeforeExecError
 import io.iohk.ethereum.ledger.BlockExecutionSuccess
 import io.iohk.ethereum.ledger.BlockQueue
 import io.iohk.ethereum.ledger.BlockValidation
+import io.iohk.ethereum.utils.BlockchainConfig
 import io.iohk.ethereum.utils.FunctorOps._
 import io.iohk.ethereum.utils.Hex
 import io.iohk.ethereum.utils.Logger
-import io.iohk.ethereum.blockchain.sync.regular.BlockImportResult
-import io.iohk.ethereum.domain.Block
-import io.iohk.ethereum.utils.BlockchainConfig
-import monix.eval.Task
-import monix.execution.Scheduler
 
 /** This is a temporary class to isolate the real Consensus and extract responsibilities which should not
   * be part of the consensus in the final design, but are currently needed.
@@ -60,7 +61,8 @@ class ConsensusAdapter(
             Hex.toHexString(block.hash.toArray),
             error.reason.toString
           )
-        case Right(_) => log.debug("Block with hash {} validated successfully", Hex.toHexString(block.hash.toArray))
+        case Right(_) =>
+          log.debug("Block with hash {} validated successfully", Hex.toHexString(block.hash.toArray))
       }
       .executeOn(validationScheduler)
 

--- a/src/main/scala/io/iohk/ethereum/consensus/ConsensusAdapter.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/ConsensusAdapter.scala
@@ -21,7 +21,6 @@ import io.iohk.ethereum.consensus.Consensus.KeptCurrentBestBranch
 import io.iohk.ethereum.consensus.Consensus.SelectedNewBestBranch
 import io.iohk.ethereum.domain.Block
 import io.iohk.ethereum.domain.BlockHeader
-import io.iohk.ethereum.domain.Blockchain
 import io.iohk.ethereum.domain.BlockchainReader
 import io.iohk.ethereum.ledger.BlockExecutionError.ValidationBeforeExecError
 import io.iohk.ethereum.ledger.BlockExecutionSuccess
@@ -38,7 +37,6 @@ import io.iohk.ethereum.utils.Logger
 class ConsensusAdapter(
     consensus: Consensus,
     blockchainReader: BlockchainReader,
-    blockchain: Blockchain,
     blockQueue: BlockQueue,
     blockValidation: BlockValidation,
     validationScheduler: Scheduler

--- a/src/main/scala/io/iohk/ethereum/consensus/ConsensusAdapter.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/ConsensusAdapter.scala
@@ -12,7 +12,6 @@ import io.iohk.ethereum.blockchain.sync.regular.BlockImportResult
 import io.iohk.ethereum.blockchain.sync.regular.BlockImportedToTop
 import io.iohk.ethereum.blockchain.sync.regular.ChainReorganised
 import io.iohk.ethereum.blockchain.sync.regular.DuplicateBlock
-import io.iohk.ethereum.blockchain.sync.regular.UnknownParent
 import io.iohk.ethereum.consensus.Consensus.BranchExecutionFailure
 import io.iohk.ethereum.consensus.Consensus.ConsensusError
 import io.iohk.ethereum.consensus.Consensus.ConsensusErrorDueToMissingNode

--- a/src/main/scala/io/iohk/ethereum/consensus/ConsensusImpl.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/ConsensusImpl.scala
@@ -109,13 +109,10 @@ class ConsensusImpl(
         // TODO ETCM-1069 do something with importedBlocks
         ConsensusErrorDueToMissingNode(reason.asInstanceOf[MissingNodeException])
       case (Nil, Some(error)) =>
-        blockQueue.removeSubtree(branch.head.header.hash)
-        ConsensusError(error.toString)
-      case (importedBlocks, Some(_)) =>
-        branch.toList.drop(importedBlocks.length).headOption.foreach { failedBlock =>
-          blockQueue.removeSubtree(failedBlock.header.hash)
-        }
-        ExtendedCurrentBestBranch(importedBlocks)
+        BranchExecutionFailure(branch.head.header.hash, error.toString)
+      case (importedBlocks, Some(error)) =>
+        val failingBlock = branch.toList.drop(importedBlocks.length).headOption.get
+        ExtendedCurrentBestBranchPartially(importedBlocks, BranchExecutionFailure(failingBlock.hash, error.toString))
     }
 
   private def reorganise(newBranch: NonEmptyList[Block], parentWeight: ChainWeight, parentHash: ByteString)(implicit

--- a/src/main/scala/io/iohk/ethereum/consensus/ConsensusImpl.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/ConsensusImpl.scala
@@ -31,7 +31,7 @@ class ConsensusImpl(
 
   /** Try to set the given branch as the new best branch if it is better than the current best
     * branch.
-    * @param branch                  the new branch as a sorted list of blocks. It's parent must
+    * @param branch                  the new branch as a sorted list of blocks. Its parent must
     *                                be in the current best branch
     * @param blockExecutionScheduler threadPool on which the execution should be run
     * @param blockchainConfig        blockchain configuration
@@ -203,7 +203,6 @@ class ConsensusImpl(
 
   /** Reverts chain reorganisation in the event that one of the blocks from new branch fails to execute
     *
-    * @param newBranch      new blocks
     * @param oldBranch      old blocks along with corresponding receipts and totalDifficulties
     * @param executedBlocks sub-sequence of new branch that was executed correctly
     */

--- a/src/main/scala/io/iohk/ethereum/consensus/ConsensusImpl.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/ConsensusImpl.scala
@@ -2,6 +2,7 @@ package io.iohk.ethereum.consensus
 
 import akka.util.ByteString
 
+import cats.data.NonEmptyList
 import cats.implicits._
 
 import monix.eval.Task
@@ -18,8 +19,8 @@ import io.iohk.ethereum.blockchain.sync.regular.BlockImportResult
 import io.iohk.ethereum.blockchain.sync.regular.BlockImportedToTop
 import io.iohk.ethereum.blockchain.sync.regular.ChainReorganised
 import io.iohk.ethereum.blockchain.sync.regular.DuplicateBlock
+import io.iohk.ethereum.consensus.Consensus._
 import io.iohk.ethereum.domain.Block
-import io.iohk.ethereum.domain.BlockHeader
 import io.iohk.ethereum.domain.BlockchainImpl
 import io.iohk.ethereum.domain.BlockchainReader
 import io.iohk.ethereum.domain.BlockchainWriter
@@ -28,16 +29,11 @@ import io.iohk.ethereum.ledger.BlockData
 import io.iohk.ethereum.ledger.BlockExecution
 import io.iohk.ethereum.ledger.BlockExecutionError
 import io.iohk.ethereum.ledger.BlockExecutionError.MPTError
-import io.iohk.ethereum.ledger.BlockExecutionError.ValidationBeforeExecError
-import io.iohk.ethereum.ledger.BlockExecutionSuccess
 import io.iohk.ethereum.ledger.BlockMetrics
 import io.iohk.ethereum.ledger.BlockQueue
-import io.iohk.ethereum.ledger.BlockQueue.Leaf
-import io.iohk.ethereum.ledger.BlockValidation
 import io.iohk.ethereum.mpt.MerklePatriciaTrie.MissingNodeException
 import io.iohk.ethereum.utils.BlockchainConfig
 import io.iohk.ethereum.utils.ByteStringUtils
-import io.iohk.ethereum.utils.FunctorOps._
 import io.iohk.ethereum.utils.Logger
 
 class ConsensusImpl(
@@ -49,189 +45,129 @@ class ConsensusImpl(
 ) extends Consensus
     with Logger {
 
-  /** Tries to import the block as the new best block in the chain or enqueue it for later processing.
-    *
-    * @param block                   block to be imported
+  /** Try to set the given branch as the new best branch if it is better than the current best
+    * branch.
+    * @param branch                  the new branch as a sorted list of blocks. It's parent must
+    *                                be in the current best branch
     * @param blockExecutionScheduler threadPool on which the execution should be run
     * @param blockchainConfig        blockchain configuration
     * @return One of:
-    *   - [[BlockImportedToTop]] - if the block was added as the new best block
-    *   - [[BlockEnqueued]]      - block is stored in the [[io.iohk.ethereum.ledger.BlockQueue]]
-    *   - [[ChainReorganised]]   - a better new branch was found causing chain reorganisation
-    *   - [[DuplicateBlock]]     - block already exists either in the main chain or in the queue
-    *   - [[BlockImportFailed]]  - block failed to execute (when importing to top or reorganising the chain)
+    *   - [[ExtendedCurrentBestBranch]] - if the branch was added on top of the current branch
+    *   - [[SelectedNewBestBranch]]     - if the chain was reorganized.
+    *   - [[KeptCurrentBestBranch]]     - if the branch was not considered as better than the current branch
+    *   - [[ConsensusError]]            - block failed to execute (when importing to top or reorganising the chain)
+    *   - [[ConsensusErrorDueToMissingNode]]  - block failed to execute (when importing to top or reorganising the chain)
     */
   override def evaluateBranch(
-      branch: Seq[Block]
-  )(implicit blockExecutionScheduler: Scheduler, blockchainConfig: BlockchainConfig): Task[BlockImportResult] = {
-    val block = branch.head
+      branch: NonEmptyList[Block]
+  )(implicit blockExecutionScheduler: Scheduler, blockchainConfig: BlockchainConfig): Task[ConsensusResult] =
     blockchainReader.getBestBlock() match {
       case Some(bestBlock) =>
         blockchainReader.getChainWeightByHash(bestBlock.header.hash) match {
-          case Some(weight) => handleBlockImport(block, bestBlock, weight)
+          case Some(weight) => handleBranchImport(branch, bestBlock, weight)
           case None         => returnNoTotalDifficulty(bestBlock)
         }
       case None => returnNoBestBlock()
     }
-  }
 
-  private def handleBlockImport(block: Block, bestBlock: Block, weight: ChainWeight)(implicit
+  private def handleBranchImport(
+      branch: NonEmptyList[Block],
+      currentBestBlock: Block,
+      currentBestBlockWeight: ChainWeight
+  )(implicit
       blockExecutionScheduler: Scheduler,
       blockchainConfig: BlockchainConfig
-  ): Task[BlockImportResult] = {
-    val importResult = if (isPossibleNewBestBlock(block.header, bestBlock.header)) {
-      importToTop(block, bestBlock, weight)
-    } else {
-      reorganiseOrEnqueue(block, bestBlock, weight)
-    }
-    importResult.foreach(measureBlockMetrics)
-    importResult
+  ): Task[ConsensusResult] = {
+    val parentHash = branch.head.header.parentHash
+    val parentWeight = blockchainReader
+      .getChainWeightByHash(parentHash)
+      .getOrElse(throw new Error("Inconsistent database"))
+
+    val consensusResult: Task[ConsensusResult] =
+      if (newBranchWeight(branch, parentWeight) > currentBestBlockWeight) {
+        if (currentBestBlock.isParentOf(branch.head)) {
+          Task.evalOnce(importToTop(branch, currentBestBlockWeight)).executeOn(blockExecutionScheduler)
+        } else {
+          Task.evalOnce(reorganise(branch, parentWeight, parentHash)).executeOn(blockExecutionScheduler)
+        }
+      } else {
+        Task.now(KeptCurrentBestBranch)
+      }
+
+    consensusResult.foreach(measureBlockMetrics)
+    consensusResult
   }
 
-  private def returnNoTotalDifficulty(bestBlock: Block): Task[BlockImportFailed] = {
+  private def importToTop(branch: NonEmptyList[Block], currentBestBlockWeight: ChainWeight)(implicit
+      blockExecutionScheduler: Scheduler,
+      blockchainConfig: BlockchainConfig
+  ): ConsensusResult =
+    blockExecution.executeAndValidateBlocks(branch.toList, currentBestBlockWeight) match {
+      case (importedBlocks, None) =>
+        ExtendedCurrentBestBranch(importedBlocks)
+      case (importedBlocks, Some(MPTError(reason))) if reason.isInstanceOf[MissingNodeException] =>
+        // TODO ETCM-1069 do something with importedBlocks
+        ConsensusErrorDueToMissingNode(reason.asInstanceOf[MissingNodeException])
+      case (Nil, Some(error)) =>
+        blockQueue.removeSubtree(branch.head.header.hash)
+        ConsensusError(error.toString)
+      case (importedBlocks, Some(_)) =>
+        branch.toList.drop(importedBlocks.length).headOption.foreach { failedBlock =>
+          blockQueue.removeSubtree(failedBlock.header.hash)
+        }
+        ExtendedCurrentBestBranch(importedBlocks)
+    }
+
+  private def reorganise(newBranch: NonEmptyList[Block], parentWeight: ChainWeight, parentHash: ByteString)(implicit
+      blockchainConfig: BlockchainConfig
+  ): ConsensusResult = {
+
+    val bestNumber = blockchainReader.getBestBlockNumber()
+    log.debug(
+      "Removing blocks starting from number {} and parent {}",
+      bestNumber,
+      ByteStringUtils.hash2string(parentHash)
+    )
+    val oldBlocksData = removeBlocksUntil(parentHash, bestNumber)
+    oldBlocksData.foreach(block => blockQueue.enqueueBlock(block.block))
+
+    handleBlockExecResult(newBranch.toList, parentWeight, oldBlocksData).fold(
+      {
+        case MPTError(reason: MissingNodeException) => ConsensusErrorDueToMissingNode(reason)
+        case err                                    => ConsensusError(s"Error while trying to reorganise chain: $err")
+      },
+      SelectedNewBestBranch.tupled
+    )
+  }
+
+  private def newBranchWeight(newBranch: NonEmptyList[Block], parentWeight: ChainWeight) =
+    newBranch.foldLeft(parentWeight)((w, b) => w.increase(b.header))
+
+  private def returnNoTotalDifficulty(bestBlock: Block): Task[ConsensusError] = {
     log.error(
       "Getting total difficulty for current best block with hash: {} failed",
       bestBlock.header.hashAsHexString
     )
     Task.now(
-      BlockImportFailed(
+      ConsensusError(
         s"Couldn't get total difficulty for current best block with hash: ${bestBlock.header.hashAsHexString}"
       )
     )
   }
 
-  private def returnNoBestBlock(): Task[BlockImportFailed] = {
+  private def returnNoBestBlock(): Task[ConsensusError] = {
     log.error("Getting current best block failed")
-    Task.now(BlockImportFailed("Couldn't find the current best block"))
+    Task.now(ConsensusError("Couldn't find the current best block"))
   }
 
-  private def isPossibleNewBestBlock(newBlock: BlockHeader, currentBestBlock: BlockHeader): Boolean =
-    newBlock.number == currentBestBlock.number + 1 && newBlock.parentHash == currentBestBlock.hash
-
-  private def measureBlockMetrics(importResult: BlockImportResult): Unit =
+  private def measureBlockMetrics(importResult: ConsensusResult): Unit =
     importResult match {
-      case BlockImportedToTop(blockImportData) =>
+      case ExtendedCurrentBestBranch(blockImportData) =>
         blockImportData.foreach(blockData => BlockMetrics.measure(blockData.block, blockchainReader.getBlockByHash))
-      case ChainReorganised(_, newBranch, _) =>
+      case SelectedNewBestBranch(_, newBranch, _) =>
         newBranch.foreach(block => BlockMetrics.measure(block, blockchainReader.getBlockByHash))
       case _ => ()
     }
-
-  private def importToTop(
-      block: Block,
-      currentBestBlock: Block,
-      currentWeight: ChainWeight
-  )(implicit blockExecutionScheduler: Scheduler, blockchainConfig: BlockchainConfig): Task[BlockImportResult] =
-    Task
-      .evalOnce(importBlockToTop(block, currentBestBlock.header.number, currentWeight))
-      .executeOn(blockExecutionScheduler)
-
-  /** *
-    * Open for discussion: this is code that was in BlockImport. Even thought is tested (before) that only one block
-    * is being added to the blockchain, this code assumes that the import may be of more than one block (a branch)
-    * and because it is assuming that it may be dealing with a branch the code to handle errors assumes several scenarios.
-    * Is there is reason for this over-complication?
-    */
-  private def importBlockToTop(block: Block, bestBlockNumber: BigInt, currentWeight: ChainWeight)(implicit
-      blockchainConfig: BlockchainConfig
-  ): BlockImportResult = {
-    val executionResult = for {
-      topBlock <- blockQueue.enqueueBlock(block, bestBlockNumber)
-      topBlocks = blockQueue.getBranch(topBlock.hash, dequeue = true)
-      (executed, errors) = blockExecution.executeAndValidateBlocks(topBlocks, currentWeight)
-    } yield (executed, errors, topBlocks)
-
-    executionResult match {
-      case Some((importedBlocks, maybeError, topBlocks)) =>
-        val result = maybeError match {
-          case None => BlockImportedToTop(importedBlocks)
-
-          case Some(MPTError(reason)) if reason.isInstanceOf[MissingNodeException] =>
-            BlockImportFailedDueToMissingNode(reason.asInstanceOf[MissingNodeException])
-
-          case Some(error) if importedBlocks.isEmpty =>
-            blockQueue.removeSubtree(block.header.hash)
-            BlockImportFailed(error.toString)
-
-          case Some(_) =>
-            topBlocks.drop(importedBlocks.length).headOption.foreach { failedBlock =>
-              blockQueue.removeSubtree(failedBlock.header.hash)
-            }
-            BlockImportedToTop(importedBlocks)
-        }
-
-        importedBlocks.foreach { blockData =>
-          val header = blockData.block.header
-          log.debug(
-            "Imported new block ({}: {}) to the top of chain \n",
-            header.number,
-            Hex.toHexString(header.hash.toArray)
-          )
-        }
-
-        result
-
-      case None =>
-        BlockImportFailed(s"Newly enqueued block with hash: ${block.header.hash} is not part of a known branch")
-    }
-  }
-
-  private def reorganiseOrEnqueue(
-      block: Block,
-      currentBestBlock: Block,
-      currentWeight: ChainWeight
-  )(implicit blockchainConfig: BlockchainConfig): Task[BlockImportResult] =
-    Task.evalOnce(blockQueue.enqueueBlock(block, currentBestBlock.header.number) match {
-      case Some(Leaf(leafHash, leafWeight)) if leafWeight > currentWeight =>
-        reorganiseChainFromQueue(leafHash)
-
-      case _ =>
-        BlockEnqueued
-    })
-
-  /** Once a better branch was found this attempts to reorganise the chain
-    *
-    * @param queuedLeaf a block hash that determines a new branch stored in the queue (newest block from the branch)
-    *
-    * @return [[BlockExecutionError]] if one of the blocks in the new branch failed to execute, otherwise:
-    *        (oldBranch, newBranch) as lists of blocks
-    */
-  private def reorganiseChainFromQueue(
-      queuedLeaf: ByteString
-  )(implicit blockchainConfig: BlockchainConfig): BlockImportResult = {
-    log.info("Reorganising chain from leaf {}", ByteStringUtils.hash2string(queuedLeaf))
-    val newBranch = blockQueue.getBranch(queuedLeaf, dequeue = true)
-    val bestNumber = blockchainReader.getBestBlockNumber()
-
-    val reorgResult = for {
-      parent <- newBranch.headOption
-      parentHash = parent.header.parentHash
-      parentWeight <- blockchainReader.getChainWeightByHash(parentHash)
-    } yield {
-      log.debug(
-        "Removing blocks starting from number {} and parent {}",
-        bestNumber,
-        ByteStringUtils.hash2string(parentHash)
-      )
-      val oldBlocksData = removeBlocksUntil(parentHash, bestNumber)
-      oldBlocksData.foreach(block => blockQueue.enqueueBlock(block.block))
-      handleBlockExecResult(newBranch, parentWeight, oldBlocksData)
-    }
-
-    reorgResult match {
-      case Some(execResult) =>
-        execResult.fold(
-          {
-            case MPTError(reason: MissingNodeException) => BlockImportFailedDueToMissingNode(reason)
-            case err                                    => BlockImportFailed(s"Error while trying to reorganise chain: $err")
-          },
-          ChainReorganised.tupled
-        )
-
-      case None =>
-        BlockImportFailed("Error while trying to reorganise chain with parent of new branch")
-    }
-  }
 
   private def handleBlockExecResult(
       newBranch: List[Block],

--- a/src/main/scala/io/iohk/ethereum/ledger/BlockExecution.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/BlockExecution.scala
@@ -176,7 +176,7 @@ class BlockExecution(
               newBlockData.block,
               newBlockData.receipts,
               newBlockData.weight,
-              saveAsBestBlock = true
+              saveAsBestBlock = false
             )
             go(newBlockData :: executedBlocksDecOrder, remainingBlocksIncOrder.tail, newWeight)
           case Left(executionError) =>

--- a/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
@@ -2,10 +2,13 @@ package io.iohk.ethereum.nodebuilder
 
 import java.time.Clock
 import java.util.concurrent.atomic.AtomicReference
+
 import akka.actor.ActorRef
 import akka.actor.ActorSystem
 import akka.util.ByteString
+
 import cats.implicits._
+
 import monix.eval.Task
 import monix.execution.Scheduler
 
@@ -14,13 +17,17 @@ import scala.concurrent.duration._
 import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
+
 import org.bouncycastle.crypto.AsymmetricCipherKeyPair
+
 import io.iohk.ethereum.blockchain.data.GenesisDataLoader
 import io.iohk.ethereum.blockchain.sync.Blacklist
 import io.iohk.ethereum.blockchain.sync.BlockchainHostActor
 import io.iohk.ethereum.blockchain.sync.CacheBasedBlacklist
 import io.iohk.ethereum.blockchain.sync.SyncController
-import io.iohk.ethereum.consensus.{Consensus, ConsensusAdapter, ConsensusImpl}
+import io.iohk.ethereum.consensus.Consensus
+import io.iohk.ethereum.consensus.ConsensusAdapter
+import io.iohk.ethereum.consensus.ConsensusImpl
 import io.iohk.ethereum.consensus.blocks.CheckpointBlockGenerator
 import io.iohk.ethereum.consensus.mining.MiningBuilder
 import io.iohk.ethereum.consensus.mining.MiningConfigBuilder

--- a/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
@@ -2,13 +2,10 @@ package io.iohk.ethereum.nodebuilder
 
 import java.time.Clock
 import java.util.concurrent.atomic.AtomicReference
-
 import akka.actor.ActorRef
 import akka.actor.ActorSystem
 import akka.util.ByteString
-
 import cats.implicits._
-
 import monix.eval.Task
 import monix.execution.Scheduler
 
@@ -17,17 +14,13 @@ import scala.concurrent.duration._
 import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
-
 import org.bouncycastle.crypto.AsymmetricCipherKeyPair
-
 import io.iohk.ethereum.blockchain.data.GenesisDataLoader
 import io.iohk.ethereum.blockchain.sync.Blacklist
 import io.iohk.ethereum.blockchain.sync.BlockchainHostActor
 import io.iohk.ethereum.blockchain.sync.CacheBasedBlacklist
 import io.iohk.ethereum.blockchain.sync.SyncController
-import io.iohk.ethereum.consensus.Consensus
-import io.iohk.ethereum.consensus.ConsensusAdapter
-import io.iohk.ethereum.consensus.ConsensusImpl
+import io.iohk.ethereum.consensus.{Consensus, ConsensusAdapter, ConsensusImpl}
 import io.iohk.ethereum.consensus.blocks.CheckpointBlockGenerator
 import io.iohk.ethereum.consensus.mining.MiningBuilder
 import io.iohk.ethereum.consensus.mining.MiningConfigBuilder
@@ -217,6 +210,9 @@ trait ConsensusBuilder {
       blockValidation,
       Scheduler(system.dispatchers.lookup("validation-context"))
     )
+
+  lazy val consensusAdapter: ConsensusAdapter =
+    new ConsensusAdapter(consensus)
 }
 
 trait ForkResolverBuilder {

--- a/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
@@ -217,15 +217,6 @@ trait ConsensusBuilder {
       blockValidation,
       Scheduler(system.dispatchers.lookup("validation-context"))
     )
-
-  lazy val consensusAdapter: ConsensusAdapter =
-    new ConsensusAdapter(
-      consensus,
-      blockchainReader,
-      blockQueue,
-      blockValidation,
-      Scheduler(system.dispatchers.lookup("validation-context"))
-    )
 }
 
 trait ForkResolverBuilder {

--- a/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
@@ -212,7 +212,13 @@ trait ConsensusBuilder {
     )
 
   lazy val consensusAdapter: ConsensusAdapter =
-    new ConsensusAdapter(consensus)
+    new ConsensusAdapter(
+      consensus,
+      blockchainReader,
+      blockQueue,
+      blockValidation,
+      Scheduler(system.dispatchers.lookup("validation-context"))
+    )
 }
 
 trait ForkResolverBuilder {

--- a/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
@@ -205,7 +205,6 @@ trait ConsensusBuilder {
       blockchain,
       blockchainReader,
       blockchainWriter,
-      blockQueue,
       blockExecution
     )
 

--- a/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
@@ -213,6 +213,7 @@ trait ConsensusBuilder {
     new ConsensusAdapter(
       consensus,
       blockchainReader,
+      blockchain,
       blockQueue,
       blockValidation,
       Scheduler(system.dispatchers.lookup("validation-context"))

--- a/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
@@ -212,7 +212,6 @@ trait ConsensusBuilder {
     new ConsensusAdapter(
       consensus,
       blockchainReader,
-      blockchain,
       blockQueue,
       blockValidation,
       Scheduler(system.dispatchers.lookup("validation-context"))

--- a/src/main/scala/io/iohk/ethereum/testmode/TestModeComponentsProvider.scala
+++ b/src/main/scala/io/iohk/ethereum/testmode/TestModeComponentsProvider.scala
@@ -53,7 +53,6 @@ class TestModeComponentsProvider(
         blockExecution
       ),
       blockchainReader,
-      blockchain,
       node.blockQueue,
       blockValidation,
       validationExecutionContext

--- a/src/main/scala/io/iohk/ethereum/testmode/TestModeComponentsProvider.scala
+++ b/src/main/scala/io/iohk/ethereum/testmode/TestModeComponentsProvider.scala
@@ -1,12 +1,9 @@
 package io.iohk.ethereum.testmode
 
 import akka.util.ByteString
-
 import monix.execution.Scheduler
 
-import io.iohk.ethereum.consensus.Consensus
-import io.iohk.ethereum.consensus.ConsensusAdapter
-import io.iohk.ethereum.consensus.ConsensusImpl
+import io.iohk.ethereum.consensus.{ConsensusAdapter, ConsensusImpl}
 import io.iohk.ethereum.consensus.mining.MiningConfig
 import io.iohk.ethereum.crypto
 import io.iohk.ethereum.db.storage.EvmCodeStorage

--- a/src/main/scala/io/iohk/ethereum/testmode/TestModeComponentsProvider.scala
+++ b/src/main/scala/io/iohk/ethereum/testmode/TestModeComponentsProvider.scala
@@ -54,6 +54,7 @@ class TestModeComponentsProvider(
         blockExecution
       ),
       blockchainReader,
+      blockchain,
       node.blockQueue,
       blockValidation,
       validationExecutionContext

--- a/src/main/scala/io/iohk/ethereum/testmode/TestModeComponentsProvider.scala
+++ b/src/main/scala/io/iohk/ethereum/testmode/TestModeComponentsProvider.scala
@@ -1,9 +1,11 @@
 package io.iohk.ethereum.testmode
 
 import akka.util.ByteString
+
 import monix.execution.Scheduler
 
-import io.iohk.ethereum.consensus.{ConsensusAdapter, ConsensusImpl}
+import io.iohk.ethereum.consensus.ConsensusAdapter
+import io.iohk.ethereum.consensus.ConsensusImpl
 import io.iohk.ethereum.consensus.mining.MiningConfig
 import io.iohk.ethereum.crypto
 import io.iohk.ethereum.db.storage.EvmCodeStorage

--- a/src/main/scala/io/iohk/ethereum/testmode/TestModeComponentsProvider.scala
+++ b/src/main/scala/io/iohk/ethereum/testmode/TestModeComponentsProvider.scala
@@ -50,7 +50,6 @@ class TestModeComponentsProvider(
         blockchain,
         blockchainReader,
         blockchainWriter,
-        node.blockQueue,
         blockExecution
       ),
       blockchainReader,

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/ScenarioSetup.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/ScenarioSetup.scala
@@ -1,13 +1,16 @@
 package io.iohk.ethereum.blockchain.sync
 
 import java.util.concurrent.Executors
+
 import monix.execution.Scheduler
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.ExecutionContextExecutor
+
 import io.iohk.ethereum.Mocks
 import io.iohk.ethereum.Mocks.MockVM
-import io.iohk.ethereum.consensus.{ConsensusAdapter, ConsensusImpl}
+import io.iohk.ethereum.consensus.ConsensusAdapter
+import io.iohk.ethereum.consensus.ConsensusImpl
 import io.iohk.ethereum.consensus.mining.Mining
 import io.iohk.ethereum.consensus.mining.Protocol
 import io.iohk.ethereum.consensus.mining.StdTestMiningBuilder

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/ScenarioSetup.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/ScenarioSetup.scala
@@ -100,7 +100,6 @@ trait ScenarioSetup extends StdTestMiningBuilder with StxLedgerBuilder {
         blockExecutionOpt.getOrElse(mkBlockExecution(validators))
       ),
       blockchainReader,
-      blockchain,
       blockQueue,
       blockValidation,
       Scheduler(system.dispatchers.lookup("validation-context"))

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/ScenarioSetup.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/ScenarioSetup.scala
@@ -97,7 +97,6 @@ trait ScenarioSetup extends StdTestMiningBuilder with StxLedgerBuilder {
         blockchain,
         blockchainReader,
         blockchainWriter,
-        blockQueue,
         blockExecutionOpt.getOrElse(mkBlockExecution(validators))
       ),
       blockchainReader,

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/ScenarioSetup.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/ScenarioSetup.scala
@@ -101,6 +101,7 @@ trait ScenarioSetup extends StdTestMiningBuilder with StxLedgerBuilder {
         blockExecutionOpt.getOrElse(mkBlockExecution(validators))
       ),
       blockchainReader,
+      blockchain,
       blockQueue,
       blockValidation,
       Scheduler(system.dispatchers.lookup("validation-context"))

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/ScenarioSetup.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/ScenarioSetup.scala
@@ -1,17 +1,13 @@
 package io.iohk.ethereum.blockchain.sync
 
 import java.util.concurrent.Executors
-
 import monix.execution.Scheduler
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.ExecutionContextExecutor
-
 import io.iohk.ethereum.Mocks
 import io.iohk.ethereum.Mocks.MockVM
-import io.iohk.ethereum.consensus.Consensus
-import io.iohk.ethereum.consensus.ConsensusAdapter
-import io.iohk.ethereum.consensus.ConsensusImpl
+import io.iohk.ethereum.consensus.{ConsensusAdapter, ConsensusImpl}
 import io.iohk.ethereum.consensus.mining.Mining
 import io.iohk.ethereum.consensus.mining.Protocol
 import io.iohk.ethereum.consensus.mining.StdTestMiningBuilder

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/StateSyncSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/StateSyncSpec.scala
@@ -244,7 +244,7 @@ class StateSyncSpec
       ByteString.fromArrayUnsafe(genRandomArray())
 
     lazy val syncStateSchedulerActor: ActorRef = {
-      val (blockchainReader, blockchain) = buildBlockChain()
+      val (blockchainReader, _) = buildBlockChain()
       system.actorOf(
         SyncStateSchedulerActor.props(
           SyncStateScheduler(

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/SyncControllerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/SyncControllerSpec.scala
@@ -641,7 +641,7 @@ class SyncControllerSpec
               this
             }
 
-          case SendMessage(msg: GetNodeDataEnc, peer) if !onlyPivot =>
+          case SendMessage(_: GetNodeDataEnc, peer) if !onlyPivot =>
             stateDownloadStarted = true
             if (!failedNodeRequest) {
               sender ! MessageFromPeer(NodeData(Seq(defaultStateMptLeafWithAccount)), peer)

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/regular/RegularSyncFixtures.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/regular/RegularSyncFixtures.scala
@@ -32,10 +32,7 @@ import org.scalatest.matchers.should.Matchers
 
 import io.iohk.ethereum.BlockHelpers
 import io.iohk.ethereum.blockchain.sync._
-import io.iohk.ethereum.consensus.Consensus
-import io.iohk.ethereum.consensus.Consensus.ConsensusResult
 import io.iohk.ethereum.consensus.ConsensusAdapter
-import io.iohk.ethereum.consensus.ConsensusImpl
 import io.iohk.ethereum.consensus.blocks.CheckpointBlockGenerator
 import io.iohk.ethereum.db.storage.StateStorage
 import io.iohk.ethereum.domain.BlockHeaderImplicits._
@@ -312,7 +309,7 @@ trait RegularSyncFixtures { self: Matchers with AsyncMockFactory =>
 
     def fakeEvaluateBlock(
         block: Block
-    )(implicit blockExecutionScheduler: Scheduler, blockchainConfig: BlockchainConfig): Task[BlockImportResult] = {
+    ): Task[BlockImportResult] = {
       val result: BlockImportResult = if (didTryToImportBlock(block)) {
         DuplicateBlock
       } else {

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/regular/RegularSyncFixtures.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/regular/RegularSyncFixtures.scala
@@ -33,6 +33,7 @@ import org.scalatest.matchers.should.Matchers
 import io.iohk.ethereum.BlockHelpers
 import io.iohk.ethereum.blockchain.sync._
 import io.iohk.ethereum.consensus.Consensus
+import io.iohk.ethereum.consensus.Consensus.ConsensusResult
 import io.iohk.ethereum.consensus.ConsensusAdapter
 import io.iohk.ethereum.consensus.ConsensusImpl
 import io.iohk.ethereum.consensus.blocks.CheckpointBlockGenerator
@@ -108,7 +109,17 @@ trait RegularSyncFixtures { self: Matchers with AsyncMockFactory =>
     val testBlocks: List[Block] = BlockHelpers.generateChain(20, BlockHelpers.genesis)
     val testBlocksChunked: List[List[Block]] = testBlocks.grouped(syncConfig.blockHeadersPerRequest).toList
 
-    override lazy val consensus: Consensus = new TestConsensus()
+    override lazy val consensusAdapter: ConsensusAdapter = {
+      val adapter = stub[ConsensusAdapter]
+      (adapter
+        .evaluateBranchBlock(_: Block)(_: Scheduler, _: BlockchainConfig))
+        .when(*, *, *)
+        .onCall { case (block: Block, _, _) =>
+          importedBlocksSet.add(block)
+          results(block.header.hash).flatTap(_ => Task.fromFuture(importedBlocksSubject.onNext(block)))
+        }
+      adapter
+    }
 
     blockchainWriter.save(
       block = BlockHelpers.genesis,
@@ -200,23 +211,6 @@ trait RegularSyncFixtures { self: Matchers with AsyncMockFactory =>
 
     def setImportResult(block: Block, result: Task[BlockImportResult]): Unit =
       results(block.header.hash) = result
-
-    class TestConsensus
-        extends ConsensusImpl(
-          stub[BlockchainImpl],
-          stub[BlockchainReader],
-          stub[BlockchainWriter],
-          stub[BlockQueue],
-          stub[BlockExecution]
-        ) {
-      override def evaluateBranch(
-          branch: Seq[Block]
-      )(implicit blockExecutionScheduler: Scheduler, blockchainConfig: BlockchainConfig): Task[BlockImportResult] = {
-        // TODO have a real implementation ETCM-1069
-        importedBlocksSet.add(branch.head)
-        results(branch.head.hash).flatTap(_ => Task.fromFuture(importedBlocksSubject.onNext(branch.head)))
-      }
-    }
 
     class PeersClientAutoPilot(blocks: List[Block] = testBlocks) extends AutoPilot {
 

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/regular/RegularSyncFixtures.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/regular/RegularSyncFixtures.scala
@@ -1,6 +1,7 @@
 package io.iohk.ethereum.blockchain.sync.regular
 
 import java.net.InetSocketAddress
+
 import akka.actor.ActorRef
 import akka.actor.ActorSystem
 import akka.actor.PoisonPill
@@ -10,9 +11,11 @@ import akka.testkit.TestKitBase
 import akka.testkit.TestProbe
 import akka.util.ByteString
 import akka.util.Timeout
+
 import cats.Eq
 import cats.data.NonEmptyList
 import cats.implicits._
+
 import monix.eval.Task
 import monix.execution.Scheduler
 import monix.reactive.Observable
@@ -23,11 +26,15 @@ import scala.concurrent.duration.DurationInt
 import scala.concurrent.duration.FiniteDuration
 import scala.math.BigInt
 import scala.reflect.ClassTag
+
 import org.scalamock.scalatest.AsyncMockFactory
 import org.scalatest.matchers.should.Matchers
+
 import io.iohk.ethereum.BlockHelpers
 import io.iohk.ethereum.blockchain.sync._
-import io.iohk.ethereum.consensus.{Consensus, ConsensusAdapter, ConsensusImpl}
+import io.iohk.ethereum.consensus.Consensus
+import io.iohk.ethereum.consensus.ConsensusAdapter
+import io.iohk.ethereum.consensus.ConsensusImpl
 import io.iohk.ethereum.consensus.blocks.CheckpointBlockGenerator
 import io.iohk.ethereum.db.storage.StateStorage
 import io.iohk.ethereum.domain.BlockHeaderImplicits._

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/regular/RegularSyncFixtures.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/regular/RegularSyncFixtures.scala
@@ -1,7 +1,6 @@
 package io.iohk.ethereum.blockchain.sync.regular
 
 import java.net.InetSocketAddress
-
 import akka.actor.ActorRef
 import akka.actor.ActorSystem
 import akka.actor.PoisonPill
@@ -11,11 +10,9 @@ import akka.testkit.TestKitBase
 import akka.testkit.TestProbe
 import akka.util.ByteString
 import akka.util.Timeout
-
 import cats.Eq
 import cats.data.NonEmptyList
 import cats.implicits._
-
 import monix.eval.Task
 import monix.execution.Scheduler
 import monix.reactive.Observable
@@ -26,15 +23,11 @@ import scala.concurrent.duration.DurationInt
 import scala.concurrent.duration.FiniteDuration
 import scala.math.BigInt
 import scala.reflect.ClassTag
-
 import org.scalamock.scalatest.AsyncMockFactory
 import org.scalatest.matchers.should.Matchers
-
 import io.iohk.ethereum.BlockHelpers
 import io.iohk.ethereum.blockchain.sync._
-import io.iohk.ethereum.consensus.Consensus
-import io.iohk.ethereum.consensus.ConsensusAdapter
-import io.iohk.ethereum.consensus.ConsensusImpl
+import io.iohk.ethereum.consensus.{Consensus, ConsensusAdapter, ConsensusImpl}
 import io.iohk.ethereum.consensus.blocks.CheckpointBlockGenerator
 import io.iohk.ethereum.db.storage.StateStorage
 import io.iohk.ethereum.domain.BlockHeaderImplicits._

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/regular/RegularSyncSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/regular/RegularSyncSpec.scala
@@ -298,7 +298,7 @@ class RegularSyncSpec
           (consensusAdapter
             .evaluateBranchBlock(_: Block)(_: Scheduler, _: BlockchainConfig))
             .when(*, *, *)
-            .onCall((block, scheduler, conf) => fakeEvaluateBlock(block))
+            .onCall((block, _, _) => fakeEvaluateBlock(block))
           override lazy val branchResolution: BranchResolution = new FakeBranchResolution()
           override lazy val syncConfig = defaultSyncConfig.copy(
             blockHeadersPerRequest = 5,
@@ -358,7 +358,7 @@ class RegularSyncSpec
         (consensusAdapter
           .evaluateBranchBlock(_: Block)(_: Scheduler, _: BlockchainConfig))
           .when(*, *, *)
-          .onCall((block, scheduler, conf) => fakeEvaluateBlock(block))
+          .onCall((block, _, _) => fakeEvaluateBlock(block))
         override lazy val branchResolution: BranchResolution = new FakeBranchResolution()
         override lazy val syncConfig = defaultSyncConfig.copy(
           syncRetryInterval = 1.second,

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/regular/RegularSyncSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/regular/RegularSyncSpec.scala
@@ -8,10 +8,8 @@ import akka.testkit.TestActor.AutoPilot
 import akka.testkit.TestKit
 import akka.testkit.TestProbe
 import akka.util.ByteString
-
 import cats.effect.Resource
 import cats.syntax.traverse._
-
 import monix.eval.Task
 import monix.execution.Scheduler
 
@@ -20,13 +18,11 @@ import scala.concurrent.Future
 import scala.concurrent.Promise
 import scala.concurrent.duration._
 import scala.math.BigInt
-
 import org.scalamock.scalatest.AsyncMockFactory
 import org.scalatest.Assertion
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.diagrams.Diagrams
 import org.scalatest.matchers.should.Matchers
-
 import io.iohk.ethereum.BlockHelpers
 import io.iohk.ethereum.ObjectGenerators
 import io.iohk.ethereum.ResourceFixtures
@@ -38,9 +34,7 @@ import io.iohk.ethereum.blockchain.sync.SyncProtocol.Status
 import io.iohk.ethereum.blockchain.sync.SyncProtocol.Status.Progress
 import io.iohk.ethereum.blockchain.sync.regular.BlockFetcher.Start
 import io.iohk.ethereum.blockchain.sync.regular.RegularSync.NewCheckpoint
-import io.iohk.ethereum.consensus.Consensus
-import io.iohk.ethereum.consensus.ConsensusAdapter
-import io.iohk.ethereum.consensus.ConsensusImpl
+import io.iohk.ethereum.consensus.{Consensus, ConsensusAdapter}
 import io.iohk.ethereum.crypto.kec256
 import io.iohk.ethereum.domain.BlockHeaderImplicits._
 import io.iohk.ethereum.domain._

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/regular/RegularSyncSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/regular/RegularSyncSpec.scala
@@ -8,8 +8,10 @@ import akka.testkit.TestActor.AutoPilot
 import akka.testkit.TestKit
 import akka.testkit.TestProbe
 import akka.util.ByteString
+
 import cats.effect.Resource
 import cats.syntax.traverse._
+
 import monix.eval.Task
 import monix.execution.Scheduler
 
@@ -18,11 +20,13 @@ import scala.concurrent.Future
 import scala.concurrent.Promise
 import scala.concurrent.duration._
 import scala.math.BigInt
+
 import org.scalamock.scalatest.AsyncMockFactory
 import org.scalatest.Assertion
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.diagrams.Diagrams
 import org.scalatest.matchers.should.Matchers
+
 import io.iohk.ethereum.BlockHelpers
 import io.iohk.ethereum.ObjectGenerators
 import io.iohk.ethereum.ResourceFixtures
@@ -34,7 +38,9 @@ import io.iohk.ethereum.blockchain.sync.SyncProtocol.Status
 import io.iohk.ethereum.blockchain.sync.SyncProtocol.Status.Progress
 import io.iohk.ethereum.blockchain.sync.regular.BlockFetcher.Start
 import io.iohk.ethereum.blockchain.sync.regular.RegularSync.NewCheckpoint
-import io.iohk.ethereum.consensus.{Consensus, ConsensusAdapter}
+import io.iohk.ethereum.consensus.Consensus
+import io.iohk.ethereum.consensus.ConsensusAdapter
+import io.iohk.ethereum.consensus.ConsensusImpl
 import io.iohk.ethereum.crypto.kec256
 import io.iohk.ethereum.domain.BlockHeaderImplicits._
 import io.iohk.ethereum.domain._

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/regular/RegularSyncSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/regular/RegularSyncSpec.scala
@@ -38,9 +38,7 @@ import io.iohk.ethereum.blockchain.sync.SyncProtocol.Status
 import io.iohk.ethereum.blockchain.sync.SyncProtocol.Status.Progress
 import io.iohk.ethereum.blockchain.sync.regular.BlockFetcher.Start
 import io.iohk.ethereum.blockchain.sync.regular.RegularSync.NewCheckpoint
-import io.iohk.ethereum.consensus.Consensus
 import io.iohk.ethereum.consensus.ConsensusAdapter
-import io.iohk.ethereum.consensus.ConsensusImpl
 import io.iohk.ethereum.crypto.kec256
 import io.iohk.ethereum.domain.BlockHeaderImplicits._
 import io.iohk.ethereum.domain._
@@ -300,7 +298,7 @@ class RegularSyncSpec
           (consensusAdapter
             .evaluateBranchBlock(_: Block)(_: Scheduler, _: BlockchainConfig))
             .when(*, *, *)
-            .onCall((block, scheduler, conf) => fakeEvaluateBlock(block)(scheduler, conf))
+            .onCall((block, scheduler, conf) => fakeEvaluateBlock(block))
           override lazy val branchResolution: BranchResolution = new FakeBranchResolution()
           override lazy val syncConfig = defaultSyncConfig.copy(
             blockHeadersPerRequest = 5,
@@ -360,7 +358,7 @@ class RegularSyncSpec
         (consensusAdapter
           .evaluateBranchBlock(_: Block)(_: Scheduler, _: BlockchainConfig))
           .when(*, *, *)
-          .onCall((block, scheduler, conf) => fakeEvaluateBlock(block)(scheduler, conf))
+          .onCall((block, scheduler, conf) => fakeEvaluateBlock(block))
         override lazy val branchResolution: BranchResolution = new FakeBranchResolution()
         override lazy val syncConfig = defaultSyncConfig.copy(
           syncRetryInterval = 1.second,

--- a/src/test/scala/io/iohk/ethereum/consensus/ConsensusAdapterSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/ConsensusAdapterSpec.scala
@@ -67,7 +67,9 @@ class ConsensusAdapterSpec extends AnyFlatSpec with Matchers with ScalaFutures {
     val blockData = BlockData(block, Seq.empty[Receipt], newWeight)
 
     // Just to bypass metrics needs
-    (blockchainReader.getBlockByHash _).expects(*).returning(None)
+    (blockchainReader.getBlockByHash _).expects(*).anyNumberOfTimes().returning(None)
+    (blockchainWriter.save _).expects(*, *, *, *).returning()
+    (blockchain.saveBestKnownBlocks _).expects(*, *, *).returning()
 
     (blockQueue.enqueueBlock _).expects(block, bestNum).returning(Some(Leaf(hash, newWeight)))
     (blockQueue.getBranch _).expects(hash, true).returning(List(block))

--- a/src/test/scala/io/iohk/ethereum/consensus/ConsensusAdapterSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/ConsensusAdapterSpec.scala
@@ -34,12 +34,12 @@ import io.iohk.ethereum.mpt.LeafNode
 import io.iohk.ethereum.mpt.MerklePatriciaTrie
 import io.iohk.ethereum.utils.BlockchainConfig
 
-class ConsensusSpec extends AnyFlatSpec with Matchers with ScalaFutures {
+class ConsensusAdapterSpec extends AnyFlatSpec with Matchers with ScalaFutures {
 
   implicit override val patienceConfig: PatienceConfig =
     PatienceConfig(timeout = scaled(2 seconds), interval = scaled(1 second))
 
-  "Consensus" should "ignore duplicated block" in new ImportBlockTestSetup {
+  "ConsensusAdapter" should "ignore duplicated block" in new ImportBlockTestSetup {
     val block1: Block = getBlock()
     val block2: Block = getBlock()
 

--- a/src/test/scala/io/iohk/ethereum/consensus/ConsensusAdapterSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/ConsensusAdapterSpec.scala
@@ -69,7 +69,7 @@ class ConsensusAdapterSpec extends AnyFlatSpec with Matchers with ScalaFutures {
     // Just to bypass metrics needs
     (blockchainReader.getBlockByHash _).expects(*).anyNumberOfTimes().returning(None)
     (blockchainWriter.save _).expects(*, *, *, *).returning()
-    (blockchain.saveBestKnownBlocks _).expects(*, *, *).returning()
+    (blockchainWriter.saveBestKnownBlocks _).expects(*, *, *).returning()
 
     (blockQueue.enqueueBlock _).expects(block, bestNum).returning(Some(Leaf(hash, newWeight)))
     (blockQueue.getBranch _).expects(hash, true).returning(List(block))

--- a/src/test/scala/io/iohk/ethereum/consensus/ConsensusAdapterSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/ConsensusAdapterSpec.scala
@@ -68,8 +68,8 @@ class ConsensusAdapterSpec extends AnyFlatSpec with Matchers with ScalaFutures {
 
     // Just to bypass metrics needs
     (blockchainReader.getBlockByHash _).expects(*).anyNumberOfTimes().returning(None)
-    (blockchainWriter.save _).expects(*, *, *, *).returning()
-    (blockchainWriter.saveBestKnownBlocks _).expects(*, *, *).returning()
+    (blockchainWriter.save _).expects(*, *, *, *).returning(())
+    (blockchainWriter.saveBestKnownBlocks _).expects(*, *, *).returning(())
 
     (blockQueue.enqueueBlock _).expects(block, bestNum).returning(Some(Leaf(hash, newWeight)))
     (blockQueue.getBranch _).expects(hash, true).returning(List(block))

--- a/src/test/scala/io/iohk/ethereum/consensus/ConsensusImplSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/ConsensusImplSpec.scala
@@ -1,19 +1,26 @@
 package io.iohk.ethereum.consensus
 
+import java.util.concurrent.ScheduledExecutorService
+
 import cats.data.NonEmptyList
-import io.iohk.ethereum.BlockHelpers
-import io.iohk.ethereum.blockchain.sync.EphemBlockchainTestSetup
-import io.iohk.ethereum.consensus.Consensus.{ExtendedCurrentBestBranch, KeptCurrentBestBranch, SelectedNewBestBranch}
-import io.iohk.ethereum.domain.{Block, ChainWeight}
-import io.iohk.ethereum.ledger.{BlockData, BlockExecution}
-import io.iohk.ethereum.utils.BlockchainConfig
+
 import monix.execution.Scheduler
+
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-import java.util.concurrent.ScheduledExecutorService
+import io.iohk.ethereum.BlockHelpers
+import io.iohk.ethereum.blockchain.sync.EphemBlockchainTestSetup
+import io.iohk.ethereum.consensus.Consensus.ExtendedCurrentBestBranch
+import io.iohk.ethereum.consensus.Consensus.KeptCurrentBestBranch
+import io.iohk.ethereum.consensus.Consensus.SelectedNewBestBranch
+import io.iohk.ethereum.domain.Block
+import io.iohk.ethereum.domain.ChainWeight
+import io.iohk.ethereum.ledger.BlockData
+import io.iohk.ethereum.ledger.BlockExecution
+import io.iohk.ethereum.utils.BlockchainConfig
 
 class ConsensusImplSpec extends AnyFlatSpec with Matchers with ScalaFutures {
   import ConsensusImplSpec._
@@ -49,7 +56,7 @@ class ConsensusImplSpec extends AnyFlatSpec with Matchers with ScalaFutures {
 }
 
 object ConsensusImplSpec {
-  val initialChain = BlockHelpers.genesis +: BlockHelpers.generateChain(4, BlockHelpers.genesis)
+  val initialChain: List[Block] = BlockHelpers.genesis +: BlockHelpers.generateChain(4, BlockHelpers.genesis)
   val initialBestBlock = initialChain.last
 
   abstract class ConsensusSetup {

--- a/src/test/scala/io/iohk/ethereum/consensus/ConsensusImplSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/ConsensusImplSpec.scala
@@ -1,0 +1,77 @@
+package io.iohk.ethereum.consensus
+
+import cats.data.NonEmptyList
+import io.iohk.ethereum.BlockHelpers
+import io.iohk.ethereum.blockchain.sync.EphemBlockchainTestSetup
+import io.iohk.ethereum.consensus.Consensus.{ExtendedCurrentBestBranch, KeptCurrentBestBranch, SelectedNewBestBranch}
+import io.iohk.ethereum.domain.{Block, ChainWeight}
+import io.iohk.ethereum.ledger.{BlockData, BlockExecution}
+import io.iohk.ethereum.utils.BlockchainConfig
+import monix.execution.Scheduler
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.util.concurrent.ScheduledExecutorService
+
+class ConsensusImplSpec extends AnyFlatSpec with Matchers with ScalaFutures {
+  import ConsensusImplSpec._
+  "Consensus" should "extend the current best chain" in new ConsensusSetup {
+    val chainExtension = BlockHelpers.generateChain(3, initialBestBlock)
+
+    whenReady(consensus.evaluateBranch(NonEmptyList.fromListUnsafe(chainExtension)).runToFuture) {
+      _ shouldBe a[ExtendedCurrentBestBranch]
+    }
+
+    blockchainReader.getBestBlockNumber() shouldBe chainExtension.last.number
+  }
+
+  it should "keep the current best chain if the passed one is not better" in new ConsensusSetup {
+    val chainWithLowWeight =
+      BlockHelpers.generateChain(3, initialChain(2), b => b.copy(header = b.header.copy(difficulty = 1)))
+
+    whenReady(consensus.evaluateBranch(NonEmptyList.fromListUnsafe(chainWithLowWeight)).runToFuture) {
+      _ shouldBe KeptCurrentBestBranch
+    }
+    blockchainReader.getBestBlock() shouldBe Some(initialBestBlock)
+  }
+
+  it should "reorganise the chain if the new chain is better" in new ConsensusSetup {
+    val newBetterBranch =
+      BlockHelpers.generateChain(3, initialChain(2), b => b.copy(header = b.header.copy(difficulty = 10000000)))
+
+    whenReady(consensus.evaluateBranch(NonEmptyList.fromListUnsafe(newBetterBranch)).runToFuture) {
+      _ shouldBe a[SelectedNewBestBranch]
+    }
+    blockchainReader.getBestBlockNumber() shouldBe newBetterBranch.last.number
+  }
+}
+
+object ConsensusImplSpec {
+  val initialChain = BlockHelpers.genesis +: BlockHelpers.generateChain(4, BlockHelpers.genesis)
+  val initialBestBlock = initialChain.last
+
+  abstract class ConsensusSetup {
+    private val testSetup = new EphemBlockchainTestSetup with MockFactory {
+      override lazy val blockExecution: BlockExecution = stub[BlockExecution]
+      (blockExecution
+        .executeAndValidateBlocks(_: List[Block], _: ChainWeight)(_: BlockchainConfig))
+        .when(*, *, *)
+        .anyNumberOfTimes()
+        .onCall((blocks, _, _) => (blocks.map(b => BlockData(b, Nil, ChainWeight.zero)), None))
+    }
+
+    initialChain.foldLeft(ChainWeight.zero) { (previousWeight, block) =>
+      val weight = previousWeight.increase(block.header)
+      testSetup.blockchainWriter.save(block, Nil, weight, saveAsBestBlock = true)
+      weight
+    }
+
+    val consensus = testSetup.consensus
+    val blockchainReader = testSetup.blockchainReader
+    implicit val scheduler: Scheduler = Scheduler.global
+    implicit val blockchainConfig: BlockchainConfig = testSetup.blockchainConfig
+
+  }
+}

--- a/src/test/scala/io/iohk/ethereum/consensus/ConsensusImplSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/ConsensusImplSpec.scala
@@ -1,7 +1,5 @@
 package io.iohk.ethereum.consensus
 
-import java.util.concurrent.ScheduledExecutorService
-
 import cats.data.NonEmptyList
 
 import monix.execution.Scheduler

--- a/src/test/scala/io/iohk/ethereum/ledger/LedgerTestSetup.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/LedgerTestSetup.scala
@@ -411,6 +411,7 @@ trait TestSetupWithVmAndValidators extends EphemBlockchainTestSetup {
     new ConsensusAdapter(
       consensus,
       blockchainReader,
+      blockchain,
       blockQueue,
       blockValidation,
       Scheduler(system.dispatchers.lookup("validation-context"))
@@ -427,8 +428,7 @@ trait MockBlockchain extends MockFactory { self: TestSetupWithVmAndValidators =>
   override lazy val blockchain: BlockchainImpl = mock[BlockchainImpl]
   //- cake overrides
 
-  class MockBlockQueue extends BlockQueue(null, 10, 10)
-  override lazy val blockQueue: BlockQueue = mock[MockBlockQueue]
+  override lazy val blockQueue: BlockQueue = mock[BlockQueue]
 
   def setBlockExists(block: Block, inChain: Boolean, inQueue: Boolean): CallHandler1[ByteString, Boolean] = {
     (blockchainReader.getBlockByHash _)
@@ -450,7 +450,7 @@ trait MockBlockchain extends MockFactory { self: TestSetupWithVmAndValidators =>
     setChainWeightByHash(block.hash, weight)
 
   def setChainWeightByHash(hash: ByteString, weight: ChainWeight): CallHandler1[ByteString, Option[ChainWeight]] =
-    (blockchainReader.getChainWeightByHash _).expects(hash).returning(Some(weight))
+    (blockchainReader.getChainWeightByHash _).expects(hash).anyNumberOfTimes().returning(Some(weight))
 
   def expectBlockSaved(
       block: Block,

--- a/src/test/scala/io/iohk/ethereum/ledger/LedgerTestSetup.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/LedgerTestSetup.scala
@@ -2,8 +2,11 @@ package io.iohk.ethereum.ledger
 
 import akka.util.ByteString
 import akka.util.ByteString.{empty => bEmpty}
+
 import cats.data.NonEmptyList
+
 import monix.execution.Scheduler
+
 import org.bouncycastle.crypto.AsymmetricCipherKeyPair
 import org.bouncycastle.crypto.params.ECPublicKeyParameters
 import org.bouncycastle.util.encoders.Hex
@@ -12,11 +15,13 @@ import org.scalamock.handlers.CallHandler1
 import org.scalamock.handlers.CallHandler2
 import org.scalamock.handlers.CallHandler4
 import org.scalamock.scalatest.MockFactory
+
 import io.iohk.ethereum.Fixtures
 import io.iohk.ethereum.Mocks
 import io.iohk.ethereum.ObjectGenerators
 import io.iohk.ethereum.blockchain.sync.EphemBlockchainTestSetup
-import io.iohk.ethereum.consensus.{ConsensusAdapter, ConsensusImpl}
+import io.iohk.ethereum.consensus.ConsensusAdapter
+import io.iohk.ethereum.consensus.ConsensusImpl
 import io.iohk.ethereum.consensus.blocks.CheckpointBlockGenerator
 import io.iohk.ethereum.consensus.mining.GetBlockHeaderByHash
 import io.iohk.ethereum.consensus.mining.TestMining

--- a/src/test/scala/io/iohk/ethereum/ledger/LedgerTestSetup.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/LedgerTestSetup.scala
@@ -410,7 +410,6 @@ trait TestSetupWithVmAndValidators extends EphemBlockchainTestSetup {
       blockValidation,
       Scheduler(system.dispatchers.lookup("validation-context"))
     )
-    new ConsensusAdapter(consensus)
   }
 }
 

--- a/src/test/scala/io/iohk/ethereum/ledger/LedgerTestSetup.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/LedgerTestSetup.scala
@@ -410,7 +410,6 @@ trait TestSetupWithVmAndValidators extends EphemBlockchainTestSetup {
     new ConsensusAdapter(
       consensus,
       blockchainReader,
-      blockchain,
       blockQueue,
       blockValidation,
       Scheduler(system.dispatchers.lookup("validation-context"))

--- a/src/test/scala/io/iohk/ethereum/ledger/LedgerTestSetup.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/LedgerTestSetup.scala
@@ -2,11 +2,8 @@ package io.iohk.ethereum.ledger
 
 import akka.util.ByteString
 import akka.util.ByteString.{empty => bEmpty}
-
 import cats.data.NonEmptyList
-
 import monix.execution.Scheduler
-
 import org.bouncycastle.crypto.AsymmetricCipherKeyPair
 import org.bouncycastle.crypto.params.ECPublicKeyParameters
 import org.bouncycastle.util.encoders.Hex
@@ -15,14 +12,11 @@ import org.scalamock.handlers.CallHandler1
 import org.scalamock.handlers.CallHandler2
 import org.scalamock.handlers.CallHandler4
 import org.scalamock.scalatest.MockFactory
-
 import io.iohk.ethereum.Fixtures
 import io.iohk.ethereum.Mocks
 import io.iohk.ethereum.ObjectGenerators
 import io.iohk.ethereum.blockchain.sync.EphemBlockchainTestSetup
-import io.iohk.ethereum.consensus.Consensus
-import io.iohk.ethereum.consensus.ConsensusAdapter
-import io.iohk.ethereum.consensus.ConsensusImpl
+import io.iohk.ethereum.consensus.{ConsensusAdapter, ConsensusImpl}
 import io.iohk.ethereum.consensus.blocks.CheckpointBlockGenerator
 import io.iohk.ethereum.consensus.mining.GetBlockHeaderByHash
 import io.iohk.ethereum.consensus.mining.TestMining
@@ -416,6 +410,7 @@ trait TestSetupWithVmAndValidators extends EphemBlockchainTestSetup {
       blockValidation,
       Scheduler(system.dispatchers.lookup("validation-context"))
     )
+    new ConsensusAdapter(consensus)
   }
 }
 

--- a/src/test/scala/io/iohk/ethereum/ledger/LedgerTestSetup.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/LedgerTestSetup.scala
@@ -382,7 +382,6 @@ trait TestSetupWithVmAndValidators extends EphemBlockchainTestSetup {
       blockchain,
       blockchainReader,
       blockchainWriter,
-      blockQueue,
       new BlockExecution(
         blockchain,
         blockchainReader,


### PR DESCRIPTION
# Description

Depends on #1091

Change the ConsensusImpl so that  it does not depend on the block queue anymore. The ConsensusAdapter ensures compatibility with the existing code. 

It also define a `ConsensusResult` sum type which is the return type we get when we call the consensus. But it could be simpler when we get rid of the Adapter because I had to add more fined grained information about what happened during the consensus to allow the adapter to be able to faithfully reproduce the same behaviour as before.

# Testing
Branch was tested against ETC and deployed in Staging successfully.
ERC20 tests run successfully in Staging: https://buildkite.com/input-output-hk/mantis-automation/builds/9936#_