### PR TITLE
[ETCM-1092] Move getLatestCheckpointBlockNumber to BlockchainReader

### DIFF
--- a/src/it/scala/io/iohk/ethereum/ledger/BlockImporterItSpec.scala
+++ b/src/it/scala/io/iohk/ethereum/ledger/BlockImporterItSpec.scala
@@ -128,7 +128,7 @@ class BlockImporterItSpec
     blockImporter ! BlockFetcher.PickedBlocks(NonEmptyList.fromListUnsafe(newBranch))
 
     eventually(blockchainReader.getBestBlock().get shouldEqual oldBlock5WithCheckpoint)
-    eventually(blockchain.getLatestCheckpointBlockNumber() shouldEqual oldBlock5WithCheckpoint.header.number)
+    eventually(blockchainReader.getLatestCheckpointBlockNumber() shouldEqual oldBlock5WithCheckpoint.header.number)
   }
 
   it should "switch to a branch with a newer checkpoint" in new StartedImportFixture() {
@@ -142,7 +142,7 @@ class BlockImporterItSpec
     blockImporter ! BlockFetcher.PickedBlocks(NonEmptyList.fromListUnsafe(newBranch))
 
     eventually(blockchainReader.getBestBlock().get shouldEqual newBlock4WithCheckpoint)
-    eventually(blockchain.getLatestCheckpointBlockNumber() shouldEqual newBlock4WithCheckpoint.header.number)
+    eventually(blockchainReader.getLatestCheckpointBlockNumber() shouldEqual newBlock4WithCheckpoint.header.number)
   }
 
   it should "return a correct checkpointed block after receiving a request for generating a new checkpoint" in new StartedImportFixture() {
@@ -161,7 +161,7 @@ class BlockImporterItSpec
     blockImporter ! NewCheckpoint(checkpointBlock)
 
     eventually(blockchainReader.getBestBlock().get shouldEqual checkpointBlock)
-    eventually(blockchain.getLatestCheckpointBlockNumber() shouldEqual newBlock5.header.number + 1)
+    eventually(blockchainReader.getLatestCheckpointBlockNumber() shouldEqual newBlock5.header.number + 1)
   }
 
   it should "ask BlockFetcher to resolve missing node" in new TestFixture() {

--- a/src/it/scala/io/iohk/ethereum/sync/RegularSyncItSpec.scala
+++ b/src/it/scala/io/iohk/ethereum/sync/RegularSyncItSpec.scala
@@ -87,7 +87,10 @@ class RegularSyncItSpec extends FreeSpecBase with Matchers with BeforeAndAfterAl
       _ <- peer1.waitForRegularSyncLoadLastBlock(blockNumber + 1)
     } yield {
       assert(peer1.blockchainReader.getBestBlock().get.hash == peer2.blockchainReader.getBestBlock().get.hash)
-      assert(peer1.bl.getLatestCheckpointBlockNumber() == peer2.bl.getLatestCheckpointBlockNumber())
+      assert(
+        peer1.blockchainReader.getLatestCheckpointBlockNumber() == peer2.blockchainReader
+          .getLatestCheckpointBlockNumber()
+      )
     }
   }
 
@@ -111,7 +114,10 @@ class RegularSyncItSpec extends FreeSpecBase with Matchers with BeforeAndAfterAl
       _ <- peer2.waitForRegularSyncLoadLastBlock(blockNumber + 5)
     } yield {
       assert(peer1.blockchainReader.getBestBlock().get.hash == peer2.blockchainReader.getBestBlock().get.hash)
-      assert(peer1.bl.getLatestCheckpointBlockNumber() == peer2.bl.getLatestCheckpointBlockNumber())
+      assert(
+        peer1.blockchainReader.getLatestCheckpointBlockNumber() == peer2.blockchainReader
+          .getLatestCheckpointBlockNumber()
+      )
     }
   }
 
@@ -135,7 +141,10 @@ class RegularSyncItSpec extends FreeSpecBase with Matchers with BeforeAndAfterAl
       val peer1BestBlockNumber = peer1.blockchainReader.getBestBlock().get.number
       val peer2BestBlockNumber = peer2.blockchainReader.getBestBlock().get.number
       assert(peer1BestBlockNumber == peer2BestBlockNumber && peer1BestBlockNumber == length)
-      assert(peer1.bl.getLatestCheckpointBlockNumber() == peer2.bl.getLatestCheckpointBlockNumber())
+      assert(
+        peer1.blockchainReader.getLatestCheckpointBlockNumber() == peer2.blockchainReader
+          .getLatestCheckpointBlockNumber()
+      )
     }
   }
 

--- a/src/it/scala/io/iohk/ethereum/txExecTest/util/DumpChainApp.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/util/DumpChainApp.scala
@@ -202,8 +202,6 @@ class BlockchainMock(genesisHash: ByteString) extends Blockchain {
 
   def getBestBlock(): Option[Block] = ???
 
-  override def getLatestCheckpointBlockNumber(): BigInt = ???
-
   override def getBackingMptStorage(blockNumber: BigInt): MptStorage = ???
 
   override def getReadOnlyMptStorage(): MptStorage = ???

--- a/src/main/scala/io/iohk/ethereum/domain/Blockchain.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/Blockchain.scala
@@ -55,8 +55,6 @@ trait Blockchain {
     */
   def getReadOnlyMptStorage(): MptStorage
 
-  def getLatestCheckpointBlockNumber(): BigInt
-
   def removeBlock(hash: ByteString): Unit
 
   def saveBestKnownBlocks(
@@ -79,8 +77,6 @@ class BlockchainImpl(
     blockchainReader: BlockchainReader
 ) extends Blockchain
     with Logger {
-
-  override def getLatestCheckpointBlockNumber(): BigInt = appStateStorage.getLatestCheckpointBlockNumber()
 
   override def getAccountStorageAt(
       rootHash: ByteString,
@@ -168,7 +164,7 @@ class BlockchainImpl(
     log.debug(s"Trying to remove block ${block.idTag}")
 
     val txList = block.body.transactionList
-    val latestCheckpointNumber = getLatestCheckpointBlockNumber()
+    val latestCheckpointNumber = blockchainReader.getLatestCheckpointBlockNumber()
 
     val blockNumberMappingUpdates =
       if (blockchainReader.getHashByBlockNumber(blockchainReader.getBestBranch(), block.number).contains(blockHash))

--- a/src/main/scala/io/iohk/ethereum/domain/BlockchainReader.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/BlockchainReader.scala
@@ -85,6 +85,8 @@ class BlockchainReader(
 
   def getBestBlockNumber(): BigInt = appStateStorage.getBestBlockNumber()
 
+  def getLatestCheckpointBlockNumber(): BigInt = appStateStorage.getLatestCheckpointBlockNumber()
+
   //returns the best known block if it's available in the storage
   def getBestBlock(): Option[Block] = {
     val bestKnownBlockinfo = appStateStorage.getBestBlockInfo()

--- a/src/main/scala/io/iohk/ethereum/ledger/BlockQueue.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/BlockQueue.scala
@@ -6,7 +6,6 @@ import scala.annotation.tailrec
 import scala.jdk.CollectionConverters._
 
 import io.iohk.ethereum.domain.Block
-import io.iohk.ethereum.domain.Blockchain
 import io.iohk.ethereum.domain.BlockchainReader
 import io.iohk.ethereum.domain.ChainWeight
 import io.iohk.ethereum.ledger.BlockQueue.Leaf

--- a/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
@@ -393,7 +393,6 @@ object TransactionHistoryServiceBuilder {
     self: BlockchainBuilder with PendingTransactionsManagerBuilder with TxPoolConfigBuilder =>
     lazy val transactionHistoryService =
       new TransactionHistoryService(
-        blockchain,
         blockchainReader,
         pendingTransactionsManager,
         txPoolConfig.getTransactionFromPoolTimeout

--- a/src/main/scala/io/iohk/ethereum/transactions/TransactionHistoryService.scala
+++ b/src/main/scala/io/iohk/ethereum/transactions/TransactionHistoryService.scala
@@ -21,7 +21,6 @@ import io.iohk.ethereum.transactions.TransactionHistoryService.PendingTxChecker
 import io.iohk.ethereum.utils.Logger
 
 class TransactionHistoryService(
-    blockchain: Blockchain,
     blockchainReader: BlockchainReader,
     pendingTransactionsManager: ActorRef,
     getTransactionFromPoolTimeout: FiniteDuration
@@ -30,7 +29,7 @@ class TransactionHistoryService(
       account: Address,
       fromBlocks: NumericRange[BigInt]
   ): Task[List[ExtendedTransactionData]] = {
-    val getLastCheckpoint = Task(blockchain.getLatestCheckpointBlockNumber()).memoizeOnSuccess
+    val getLastCheckpoint = Task(blockchainReader.getLatestCheckpointBlockNumber()).memoizeOnSuccess
     val txnsFromBlocks = Observable
       .from(fromBlocks.reverse)
       .mapParallelOrdered(10)(blockNr =>

--- a/src/test/scala/io/iohk/ethereum/domain/BlockchainSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/domain/BlockchainSpec.scala
@@ -91,7 +91,7 @@ class BlockchainSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyCh
     retrievedBlock.isDefined should ===(true)
     validBlock should ===(retrievedBlock.get)
 
-    blockchain.getLatestCheckpointBlockNumber() should ===(validBlock.number)
+    blockchainReader.getLatestCheckpointBlockNumber() should ===(validBlock.number)
     blockchainReader.getBestBlockNumber() should ===(validBlock.number)
   }
 
@@ -119,7 +119,7 @@ class BlockchainSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyCh
 
     blockchain.removeBlock(thirdBlock.hash)
 
-    blockchain.getLatestCheckpointBlockNumber() should ===(firstBlock.number)
+    blockchainReader.getLatestCheckpointBlockNumber() should ===(firstBlock.number)
     blockchainReader.getBestBlockNumber() should ===(secondBlock.number)
   }
 
@@ -133,7 +133,7 @@ class BlockchainSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyCh
 
     blockchain.removeBlock(validBlock.hash)
 
-    blockchain.getLatestCheckpointBlockNumber() should ===(genesis.number)
+    blockchainReader.getLatestCheckpointBlockNumber() should ===(genesis.number)
     blockchainReader.getBestBlockNumber() should ===(genesis.number)
   }
 

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/MantisServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/MantisServiceSpec.scala
@@ -79,7 +79,6 @@ class MantisServiceSpec
 
         override lazy val transactionHistoryService: TransactionHistoryService =
           new TransactionHistoryService(
-            blockchain,
             blockchainReader,
             pendingTransactionsManager,
             txPoolConfig.getTransactionFromPoolTimeout

--- a/src/test/scala/io/iohk/ethereum/transactions/LegacyTransactionHistoryServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/transactions/LegacyTransactionHistoryServiceSpec.scala
@@ -32,7 +32,7 @@ class LegacyTransactionHistoryServiceSpec
     val pendingTransactionManager: TestProbe = TestProbe()
     pendingTransactionManager.setAutoPilot(PendingTransactionsManagerAutoPilot())
     val transactionHistoryService =
-      new TransactionHistoryService(blockchain, blockchainReader, pendingTransactionManager.ref, Timeouts.normalTimeout)
+      new TransactionHistoryService(blockchainReader, pendingTransactionManager.ref, Timeouts.normalTimeout)
   }
 
   def createFixture() = new Fixture
@@ -170,7 +170,7 @@ class LegacyTransactionHistoryServiceSpec
         _ <- Task {
           blockchainWriter.save(block3, makeReceipts(block3), ChainWeight(2, block1.header.difficulty * 2), true)
         }
-        lastCheckpoint <- Task(blockchain.getLatestCheckpointBlockNumber())
+        lastCheckpoint <- Task(blockchainReader.getLatestCheckpointBlockNumber())
         response <- transactionHistoryService.getAccountTransactions(
           senderAddress,
           BigInt.apply(0) to BigInt(10)


### PR DESCRIPTION
# Description

In order to reduce the scope of the Blockchain class, getLatestCheckpointBlockNumber was moved to BlockchainReader

# Testing
Tested against ETC and also deployed in Staging