### PR TITLE
[ETCM-1077] Move saveBestKnownBlocks to BlockchainWriter

### DIFF
--- a/src/it/scala/io/iohk/ethereum/ledger/BlockImporterItSpec.scala
+++ b/src/it/scala/io/iohk/ethereum/ledger/BlockImporterItSpec.scala
@@ -108,7 +108,7 @@ class BlockImporterItSpec
     blockchainWriter.save(oldBlock3, Nil, oldWeight3, saveAsBestBlock = true)
     blockchainWriter.save(oldBlock4, Nil, oldWeight4, saveAsBestBlock = true)
     // simulation of node restart
-    blockchain.saveBestKnownBlocks(oldBlock3.header.hash, oldBlock3.number)
+    blockchainWriter.saveBestKnownBlocks(oldBlock3.header.hash, oldBlock3.number)
     blockchainWriter.save(newBlock4ParentOldBlock3, Nil, newBlock4WeightParentOldBlock3, saveAsBestBlock = true)
 
     //not reorganising anymore until oldBlock4(not part of the chain anymore), no block/ommer validation when not part of the chain, resolveBranch is returning UnknownBranch

--- a/src/it/scala/io/iohk/ethereum/txExecTest/util/DumpChainApp.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/util/DumpChainApp.scala
@@ -194,12 +194,6 @@ class BlockchainMock(genesisHash: ByteString) extends Blockchain {
 
   def getBestBlockNumber(): BigInt = ???
 
-  override def saveBestKnownBlocks(
-      bestBlockhash: ByteString,
-      bestBlockNumber: BigInt,
-      latestCheckpointNumber: Option[BigInt] = None
-  ): Unit = ???
-
   def getBestBlock(): Option[Block] = ???
 
   override def getBackingMptStorage(blockNumber: BigInt): MptStorage = ???

--- a/src/main/scala/io/iohk/ethereum/consensus/ConsensusImpl.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/ConsensusImpl.scala
@@ -275,7 +275,7 @@ class ConsensusImpl(
     }.maximumOption
 
     val bestHeader = oldBranch.last.block.header
-    blockchain.saveBestKnownBlocks(bestHeader.hash, bestHeader.number, checkpointNumber)
+    blockchainWriter.saveBestKnownBlocks(bestHeader.hash, bestHeader.number, checkpointNumber)
     executedBlocks.foreach(data => blockQueue.enqueueBlock(data.block, bestHeader.number))
 
     newBranch.diff(executedBlocks.map(_.block)).headOption.foreach { block =>

--- a/src/main/scala/io/iohk/ethereum/domain/Blockchain.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/Blockchain.scala
@@ -56,13 +56,6 @@ trait Blockchain {
   def getReadOnlyMptStorage(): MptStorage
 
   def removeBlock(hash: ByteString): Unit
-
-  def saveBestKnownBlocks(
-      bestBlockHash: ByteString,
-      bestBlockNumber: BigInt,
-      latestCheckpointNumber: Option[BigInt] = None
-  ): Unit
-
 }
 
 class BlockchainImpl(
@@ -118,31 +111,6 @@ class BlockchainImpl(
   def getBackingMptStorage(blockNumber: BigInt): MptStorage = stateStorage.getBackingStorage(blockNumber)
 
   def getReadOnlyMptStorage(): MptStorage = stateStorage.getReadOnlyStorage
-
-  override def saveBestKnownBlocks(
-      bestBlockHash: ByteString,
-      bestBlockNumber: BigInt,
-      latestCheckpointNumber: Option[BigInt] = None
-  ): Unit =
-    latestCheckpointNumber match {
-      case Some(number) =>
-        saveBestKnownBlockAndLatestCheckpointNumber(bestBlockHash, bestBlockNumber, number)
-      case None =>
-        saveBestKnownBlock(bestBlockHash, bestBlockNumber)
-    }
-
-  private def saveBestKnownBlock(bestBlockHash: ByteString, bestBlockNumber: BigInt): Unit =
-    appStateStorage.putBestBlockInfo(BlockInfo(bestBlockHash, bestBlockNumber)).commit()
-
-  private def saveBestKnownBlockAndLatestCheckpointNumber(
-      bestBlockHash: ByteString,
-      number: BigInt,
-      latestCheckpointNumber: BigInt
-  ): Unit =
-    appStateStorage
-      .putBestBlockInfo(BlockInfo(bestBlockHash, number))
-      .and(appStateStorage.putLatestCheckpointBlockNumber(latestCheckpointNumber))
-      .commit()
 
   private def removeBlockNumberMapping(number: BigInt): DataSourceBatchUpdate =
     blockNumberMappingStorage.remove(number)

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/SyncStateSchedulerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/SyncStateSchedulerSpec.scala
@@ -252,7 +252,7 @@ class SyncStateSchedulerSpec
         buildScheduler()
       val header = Fixtures.Blocks.ValidBlock.header.copy(stateRoot = worldHash, number = 1)
       schedulerBlockchainWriter.storeBlockHeader(header).commit()
-      schedulerBlockchain.saveBestKnownBlocks(header.hash, 1)
+      schedulerBlockchainWriter.saveBestKnownBlocks(header.hash, 1)
       var state = scheduler.initState(worldHash).get
       while (state.activeRequest.nonEmpty) {
         val (allMissingNodes1, state2) = scheduler.getAllMissingNodes(state)

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/regular/RegularSyncSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/regular/RegularSyncSpec.scala
@@ -747,7 +747,7 @@ class RegularSyncSpec
           goToTop()
 
           val num: BigInt = 42
-          blockchain.saveBestKnownBlocks(testBlocks.head.hash, num, Some(num))
+          blockchainWriter.saveBestKnownBlocks(testBlocks.head.hash, num, Some(num))
 
           etcPeerManager.expectMsg(GetHandshakedPeers)
           etcPeerManager.reply(HandshakedPeers(handshakedPeers))

--- a/src/test/scala/io/iohk/ethereum/consensus/pow/validators/StdOmmersValidatorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/pow/validators/StdOmmersValidatorSpec.scala
@@ -464,7 +464,7 @@ class StdOmmersValidatorSpec extends AnyFlatSpec with Matchers with ScalaCheckPr
       .and(blockchainWriter.storeBlock(block95))
       .and(blockchainWriter.storeBlock(block96))
       .commit()
-    blockchain.saveBestKnownBlocks(block96.hash, block96.number)
+    blockchainWriter.saveBestKnownBlocks(block96.hash, block96.number)
 
   }
 }

--- a/src/test/scala/io/iohk/ethereum/domain/BlockchainSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/domain/BlockchainSpec.scala
@@ -44,7 +44,7 @@ class BlockchainSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyCh
   it should "be able to store a block and retrieve it by number" in new EphemBlockchainTestSetup {
     val validBlock = Fixtures.Blocks.ValidBlock.block
     blockchainWriter.storeBlock(validBlock).commit()
-    blockchain.saveBestKnownBlocks(validBlock.hash, validBlock.number)
+    blockchainWriter.saveBestKnownBlocks(validBlock.hash, validBlock.number)
     val block = blockchainReader.getBlockByNumber(blockchainReader.getBestBranch(), validBlock.header.number)
     block.isDefined should ===(true)
     validBlock should ===(block.get)
@@ -61,7 +61,7 @@ class BlockchainSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyCh
     blockchainWriter.save(validBlock, Seq.empty, ChainWeight(100, 100), saveAsBestBlock = true)
     blockchainReader.isInChain(blockchainReader.getBestBranch(), validBlock.hash) should ===(true)
     // simulation of node restart
-    blockchain.saveBestKnownBlocks(validBlock.header.parentHash, validBlock.header.number - 1)
+    blockchainWriter.saveBestKnownBlocks(validBlock.header.parentHash, validBlock.header.number - 1)
     blockchainReader.isInChain(blockchainReader.getBestBranch(), validBlock.hash) should ===(false)
   }
 
@@ -151,7 +151,7 @@ class BlockchainSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyCh
     val headerWithAcc = validHeader.copy(stateRoot = ByteString(mptWithAcc.getRootHash))
 
     blockchainWriter.storeBlockHeader(headerWithAcc).commit()
-    blockchain.saveBestKnownBlocks(headerWithAcc.hash, headerWithAcc.number)
+    blockchainWriter.saveBestKnownBlocks(headerWithAcc.hash, headerWithAcc.number)
 
     val retrievedAccount = blockchainReader.getAccount(blockchainReader.getBestBranch(), address, headerWithAcc.number)
     retrievedAccount shouldEqual Some(account)
@@ -171,7 +171,7 @@ class BlockchainSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyCh
     val headerWithAcc = validHeader.copy(stateRoot = ByteString(mptWithAcc.getRootHash))
 
     blockchainWriter.storeBlockHeader(headerWithAcc).commit()
-    blockchain.saveBestKnownBlocks(headerWithAcc.hash, headerWithAcc.number)
+    blockchainWriter.saveBestKnownBlocks(headerWithAcc.hash, headerWithAcc.number)
 
     //unhappy path
     val wrongAddress = Address(666)
@@ -200,7 +200,7 @@ class BlockchainSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyCh
     val headerWithAcc = Fixtures.Blocks.ValidBlock.header.copy(stateRoot = ByteString(mptWithAcc.getRootHash))
 
     blockchainWriter.storeBlockHeader(headerWithAcc).commit()
-    blockchain.saveBestKnownBlocks(headerWithAcc.hash, headerWithAcc.number)
+    blockchainWriter.saveBestKnownBlocks(headerWithAcc.hash, headerWithAcc.number)
 
     val wrongAddress = Address(666)
     val retrievedAccountProofWrong =

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/EthBlocksServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/EthBlocksServiceSpec.scala
@@ -45,7 +45,7 @@ class EthBlocksServiceSpec
 
   "EthBlocksService" should "answer eth_blockNumber with the latest block number" in new TestSetup {
     val bestBlockNumber = 10
-    blockchain.saveBestKnownBlocks(ByteString.empty, bestBlockNumber)
+    blockchainWriter.saveBestKnownBlocks(ByteString.empty, bestBlockNumber)
 
     val response = ethBlocksService.bestBlockNumber(BestBlockNumberRequest()).runSyncUnsafe(Duration.Inf).toOption.get
     response.bestBlockNumber shouldEqual bestBlockNumber
@@ -153,7 +153,7 @@ class EthBlocksServiceSpec
       .storeBlock(blockToRequest)
       .and(blockchainWriter.storeChainWeight(blockToRequestHash, blockWeight))
       .commit()
-    blockchain.saveBestKnownBlocks(blockToRequest.hash, blockToRequest.header.number)
+    blockchainWriter.saveBestKnownBlocks(blockToRequest.hash, blockToRequest.header.number)
 
     (() => blockGenerator.getPendingBlockAndState).expects().returns(None)
 
@@ -173,7 +173,7 @@ class EthBlocksServiceSpec
       .storeBlock(blockToRequest)
       .and(blockchainWriter.storeChainWeight(blockToRequestHash, blockWeight))
       .commit()
-    blockchain.saveBestKnownBlocks(blockToRequest.hash, blockToRequest.number)
+    blockchainWriter.saveBestKnownBlocks(blockToRequest.hash, blockToRequest.number)
 
     val request = BlockByNumberRequest(BlockParam.WithNumber(blockToRequestNumber), fullTxs = true)
     val response = ethBlocksService.getBlockByNumber(request).runSyncUnsafe(Duration.Inf).toOption.get
@@ -191,7 +191,7 @@ class EthBlocksServiceSpec
 
   it should "answer eth_getBlockByNumber with the block response correctly when it's chain weight is not in blockchain" in new TestSetup {
     blockchainWriter.storeBlock(blockToRequest).commit()
-    blockchain.saveBestKnownBlocks(blockToRequest.hash, blockToRequest.number)
+    blockchainWriter.saveBestKnownBlocks(blockToRequest.hash, blockToRequest.number)
 
     val request = BlockByNumberRequest(BlockParam.WithNumber(blockToRequestNumber), fullTxs = true)
     val response = ethBlocksService.getBlockByNumber(request).runSyncUnsafe(Duration.Inf).toOption.get
@@ -210,7 +210,7 @@ class EthBlocksServiceSpec
       .storeBlock(blockToRequest)
       .and(blockchainWriter.storeChainWeight(blockToRequestHash, blockWeight))
       .commit()
-    blockchain.saveBestKnownBlocks(blockToRequest.hash, blockToRequest.number)
+    blockchainWriter.saveBestKnownBlocks(blockToRequest.hash, blockToRequest.number)
 
     val request = BlockByNumberRequest(BlockParam.WithNumber(blockToRequestNumber), fullTxs = true)
     val response =
@@ -225,7 +225,7 @@ class EthBlocksServiceSpec
 
   it should "get transaction count by block number" in new TestSetup {
     blockchainWriter.storeBlock(blockToRequest).commit()
-    blockchain.saveBestKnownBlocks(blockToRequest.hash, blockToRequest.number)
+    blockchainWriter.saveBestKnownBlocks(blockToRequest.hash, blockToRequest.number)
 
     val response = ethBlocksService.getBlockTransactionCountByNumber(
       GetBlockTransactionCountByNumberRequest(BlockParam.WithNumber(blockToRequest.header.number))
@@ -238,7 +238,7 @@ class EthBlocksServiceSpec
 
   it should "get transaction count by latest block number" in new TestSetup {
     blockchainWriter.storeBlock(blockToRequest).commit()
-    blockchain.saveBestKnownBlocks(blockToRequest.hash, blockToRequest.header.number)
+    blockchainWriter.saveBestKnownBlocks(blockToRequest.hash, blockToRequest.header.number)
 
     val response =
       ethBlocksService.getBlockTransactionCountByNumber(GetBlockTransactionCountByNumberRequest(BlockParam.Latest))
@@ -257,7 +257,7 @@ class EthBlocksServiceSpec
 
   it should "answer eth_getUncleByBlockHashAndIndex with None when there's no uncle" in new TestSetup {
     blockchainWriter.storeBlock(blockToRequest).commit()
-    blockchain.saveBestKnownBlocks(blockToRequest.hash, blockToRequest.number)
+    blockchainWriter.saveBestKnownBlocks(blockToRequest.hash, blockToRequest.number)
 
     val uncleIndexToRequest = 0
     val request = UncleByBlockHashAndIndexRequest(blockToRequestHash, uncleIndexToRequest)
@@ -268,7 +268,7 @@ class EthBlocksServiceSpec
 
   it should "answer eth_getUncleByBlockHashAndIndex with None when there's no uncle in the requested index" in new TestSetup {
     blockchainWriter.storeBlock(blockToRequestWithUncles).commit()
-    blockchain.saveBestKnownBlocks(blockToRequestWithUncles.hash, blockToRequestWithUncles.number)
+    blockchainWriter.saveBestKnownBlocks(blockToRequestWithUncles.hash, blockToRequestWithUncles.number)
 
     val uncleIndexToRequest = 0
     val request = UncleByBlockHashAndIndexRequest(blockToRequestHash, uncleIndexToRequest)
@@ -361,7 +361,7 @@ class EthBlocksServiceSpec
 
   it should "answer eth_getUncleByBlockNumberAndIndex correctly when the requested index has one but there's no chain weight for it" in new TestSetup {
     blockchainWriter.storeBlock(blockToRequestWithUncles).commit()
-    blockchain.saveBestKnownBlocks(blockToRequestWithUncles.hash, blockToRequestWithUncles.number)
+    blockchainWriter.saveBestKnownBlocks(blockToRequestWithUncles.hash, blockToRequestWithUncles.number)
 
     val uncleIndexToRequest = 0
     val request = UncleByBlockNumberAndIndexRequest(BlockParam.WithNumber(blockToRequestNumber), uncleIndexToRequest)
@@ -378,7 +378,7 @@ class EthBlocksServiceSpec
       .storeBlock(blockToRequestWithUncles)
       .and(blockchainWriter.storeChainWeight(uncle.hash, uncleWeight))
       .commit()
-    blockchain.saveBestKnownBlocks(blockToRequestWithUncles.hash, blockToRequestWithUncles.number)
+    blockchainWriter.saveBestKnownBlocks(blockToRequestWithUncles.hash, blockToRequestWithUncles.number)
 
     val uncleIndexToRequest = 0
     val request = UncleByBlockNumberAndIndexRequest(BlockParam.WithNumber(blockToRequestNumber), uncleIndexToRequest)
@@ -392,7 +392,7 @@ class EthBlocksServiceSpec
 
   it should "get uncle count by block number" in new TestSetup {
     blockchainWriter.storeBlock(blockToRequest).commit()
-    blockchain.saveBestKnownBlocks(blockToRequest.hash, blockToRequest.number)
+    blockchainWriter.saveBestKnownBlocks(blockToRequest.hash, blockToRequest.number)
 
     val response = ethBlocksService.getUncleCountByBlockNumber(GetUncleCountByBlockNumberRequest(BlockParam.Latest))
 

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/EthInfoServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/EthInfoServiceSpec.scala
@@ -102,7 +102,7 @@ class EthServiceSpec
 
   it should "execute call and return a value" in new TestSetup {
     blockchainWriter.storeBlock(blockToRequest).commit()
-    blockchain.saveBestKnownBlocks(blockToRequest.hash, blockToRequest.number)
+    blockchainWriter.saveBestKnownBlocks(blockToRequest.hash, blockToRequest.number)
 
     val worldStateProxy = InMemoryWorldStateProxy(
       storagesInstance.storages.evmCodeStorage,
@@ -132,7 +132,7 @@ class EthServiceSpec
 
   it should "execute estimateGas and return a value" in new TestSetup {
     blockchainWriter.storeBlock(blockToRequest).commit()
-    blockchain.saveBestKnownBlocks(blockToRequest.hash, blockToRequest.number)
+    blockchainWriter.saveBestKnownBlocks(blockToRequest.hash, blockToRequest.number)
 
     val estimatedGas = BigInt(123)
     (stxLedger.binarySearchGasEstimation _).expects(*, *, *).returning(estimatedGas)

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/EthProofServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/EthProofServiceSpec.scala
@@ -254,7 +254,7 @@ class EthProofServiceSpec
     val newBlockHeader: BlockHeader = blockToRequest.header.copy(stateRoot = ByteString(mpt.getRootHash))
     val newblock: Block = blockToRequest.copy(header = newBlockHeader)
     blockchainWriter.storeBlock(newblock).commit()
-    blockchain.saveBestKnownBlocks(newblock.hash, newblock.number)
+    blockchainWriter.saveBestKnownBlocks(newblock.hash, newblock.number)
 
     val ethGetProof =
       new EthProofService(blockchain, blockchainReader, blockGenerator, blockchainConfig.ethCompatibleStorage)

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/EthTxServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/EthTxServiceSpec.scala
@@ -179,7 +179,7 @@ class EthTxServiceSpec
     blockchainWriter
       .storeBlock(block)
       .commit()
-    blockchain.saveBestKnownBlocks(block.hash, block.number)
+    blockchainWriter.saveBestKnownBlocks(block.hash, block.number)
 
     val response = ethTxService.getGetGasPrice(GetGasPriceRequest())
     response.runSyncUnsafe() shouldEqual Right(GetGasPriceResponse(BigInt("20000000000")))
@@ -187,7 +187,7 @@ class EthTxServiceSpec
 
   it should "getTransactionByBlockNumberAndIndexRequest return transaction by index" in new TestSetup {
     blockchainWriter.storeBlock(blockToRequest).commit()
-    blockchain.saveBestKnownBlocks(blockToRequest.hash, blockToRequest.number)
+    blockchainWriter.saveBestKnownBlocks(blockToRequest.hash, blockToRequest.number)
 
     val txIndex: Int = 1
     val request = GetTransactionByBlockNumberAndIndexRequest(BlockParam.Latest, txIndex)
@@ -222,7 +222,7 @@ class EthTxServiceSpec
 
   it should "getRawTransactionByBlockNumberAndIndex return transaction by index" in new TestSetup {
     blockchainWriter.storeBlock(blockToRequest).commit()
-    blockchain.saveBestKnownBlocks(blockToRequest.hash, blockToRequest.number)
+    blockchainWriter.saveBestKnownBlocks(blockToRequest.hash, blockToRequest.number)
 
     val txIndex: Int = 1
     val request = GetTransactionByBlockNumberAndIndexRequest(BlockParam.Latest, txIndex)

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/EthUserServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/EthUserServiceSpec.scala
@@ -49,7 +49,7 @@ class EthUserServiceSpec
     val newBlockHeader = blockToRequest.header.copy(stateRoot = ByteString(mpt.getRootHash))
     val newblock = blockToRequest.copy(header = newBlockHeader)
     blockchainWriter.storeBlock(newblock).commit()
-    blockchain.saveBestKnownBlocks(newblock.hash, newblock.number)
+    blockchainWriter.saveBestKnownBlocks(newblock.hash, newblock.number)
 
     val response = ethUserService.getCode(GetCodeRequest(address, BlockParam.Latest))
 
@@ -71,7 +71,7 @@ class EthUserServiceSpec
     val newBlockHeader = blockToRequest.header.copy(stateRoot = ByteString(mpt.getRootHash))
     val newblock = blockToRequest.copy(header = newBlockHeader)
     blockchainWriter.storeBlock(newblock).commit()
-    blockchain.saveBestKnownBlocks(newblock.hash, newblock.number)
+    blockchainWriter.saveBestKnownBlocks(newblock.hash, newblock.number)
 
     val response = ethUserService.getBalance(GetBalanceRequest(address, BlockParam.Latest))
 
@@ -84,7 +84,7 @@ class EthUserServiceSpec
     val newBlockHeader = blockToRequest.header
     val newblock = blockToRequest.copy(header = newBlockHeader)
     blockchainWriter.storeBlock(newblock).commit()
-    blockchain.saveBestKnownBlocks(newblock.hash, newblock.header.number)
+    blockchainWriter.saveBestKnownBlocks(newblock.hash, newblock.header.number)
 
     val response = ethUserService.getBalance(GetBalanceRequest(address, BlockParam.Latest))
 
@@ -114,7 +114,7 @@ class EthUserServiceSpec
     val newBlockHeader = blockToRequest.header.copy(stateRoot = ByteString(mpt.getRootHash))
     val newblock = blockToRequest.copy(header = newBlockHeader)
     blockchainWriter.storeBlock(newblock).commit()
-    blockchain.saveBestKnownBlocks(newblock.hash, newblock.number)
+    blockchainWriter.saveBestKnownBlocks(newblock.hash, newblock.number)
 
     val response = ethUserService.getStorageAt(GetStorageAtRequest(address, 333, BlockParam.Latest))
     response.runSyncUnsafe().map(v => UInt256(v.value)) shouldEqual Right(UInt256(123))
@@ -132,7 +132,7 @@ class EthUserServiceSpec
     val newBlockHeader = blockToRequest.header.copy(stateRoot = ByteString(mpt.getRootHash))
     val newblock = blockToRequest.copy(header = newBlockHeader)
     blockchainWriter.storeBlock(newblock).commit()
-    blockchain.saveBestKnownBlocks(newblock.hash, newblock.number)
+    blockchainWriter.saveBestKnownBlocks(newblock.hash, newblock.number)
 
     val response = ethUserService.getTransactionCount(GetTransactionCountRequest(address, BlockParam.Latest))
 

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerEthLegacyTransactionSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerEthLegacyTransactionSpec.scala
@@ -54,7 +54,7 @@ class JsonRpcControllerEthLegacyTransactionSpec
     val txIndexToRequest = blockToRequest.body.transactionList.size / 2
 
     blockchainWriter.storeBlock(blockToRequest).commit()
-    blockchain.saveBestKnownBlocks(blockToRequest.hash, blockToRequest.number)
+    blockchainWriter.saveBestKnownBlocks(blockToRequest.hash, blockToRequest.number)
 
     val request: JsonRpcRequest = newJsonRpcRequest(
       "eth_getTransactionByBlockHashAndIndex",
@@ -77,7 +77,7 @@ class JsonRpcControllerEthLegacyTransactionSpec
     val txIndexToRequest = blockToRequest.body.transactionList.size / 2
 
     blockchainWriter.storeBlock(blockToRequest).commit()
-    blockchain.saveBestKnownBlocks(blockToRequest.hash, blockToRequest.number)
+    blockchainWriter.saveBestKnownBlocks(blockToRequest.hash, blockToRequest.number)
 
     val request: JsonRpcRequest = newJsonRpcRequest(
       "eth_getRawTransactionByBlockHashAndIndex",
@@ -137,7 +137,7 @@ class JsonRpcControllerEthLegacyTransactionSpec
     val txIndex = 1
 
     blockchainWriter.storeBlock(blockToRequest).commit()
-    blockchain.saveBestKnownBlocks(blockToRequest.hash, blockToRequest.number)
+    blockchainWriter.saveBestKnownBlocks(blockToRequest.hash, blockToRequest.number)
 
     val request: JsonRpcRequest = newJsonRpcRequest(
       "eth_getTransactionByBlockNumberAndIndex",
@@ -161,7 +161,7 @@ class JsonRpcControllerEthLegacyTransactionSpec
     val txIndex = 1
 
     blockchainWriter.storeBlock(blockToRequest).commit()
-    blockchain.saveBestKnownBlocks(blockToRequest.hash, blockToRequest.number)
+    blockchainWriter.saveBestKnownBlocks(blockToRequest.hash, blockToRequest.number)
 
     val request: JsonRpcRequest = newJsonRpcRequest(
       "eth_getTransactionByBlockNumberAndIndex",
@@ -184,7 +184,7 @@ class JsonRpcControllerEthLegacyTransactionSpec
     val txIndex = 1
 
     blockchainWriter.storeBlock(blockToRequest).commit()
-    blockchain.saveBestKnownBlocks(blockToRequest.hash, blockToRequest.number)
+    blockchainWriter.saveBestKnownBlocks(blockToRequest.hash, blockToRequest.number)
 
     val request: JsonRpcRequest = newJsonRpcRequest(
       "eth_getTransactionByBlockNumberAndIndex",
@@ -208,7 +208,7 @@ class JsonRpcControllerEthLegacyTransactionSpec
     val txIndex = 1
 
     blockchainWriter.storeBlock(blockToRequest).commit()
-    blockchain.saveBestKnownBlocks(blockToRequest.hash, blockToRequest.number)
+    blockchainWriter.saveBestKnownBlocks(blockToRequest.hash, blockToRequest.number)
 
     val request: JsonRpcRequest = newJsonRpcRequest(
       "eth_getRawTransactionByBlockNumberAndIndex",
@@ -234,7 +234,7 @@ class JsonRpcControllerEthLegacyTransactionSpec
     val txIndex = 1
 
     blockchainWriter.storeBlock(blockToRequest).commit()
-    blockchain.saveBestKnownBlocks(blockToRequest.hash, blockToRequest.number)
+    blockchainWriter.saveBestKnownBlocks(blockToRequest.hash, blockToRequest.number)
 
     val request: JsonRpcRequest = newJsonRpcRequest(
       "eth_getRawTransactionByBlockNumberAndIndex",
@@ -258,7 +258,7 @@ class JsonRpcControllerEthLegacyTransactionSpec
     val txIndex = 1
 
     blockchainWriter.storeBlock(blockToRequest).commit()
-    blockchain.saveBestKnownBlocks(blockToRequest.hash, blockToRequest.number)
+    blockchainWriter.saveBestKnownBlocks(blockToRequest.hash, blockToRequest.number)
 
     val request: JsonRpcRequest = newJsonRpcRequest(
       "eth_getRawTransactionByBlockNumberAndIndex",
@@ -336,7 +336,7 @@ class JsonRpcControllerEthLegacyTransactionSpec
     val blockToRequest = Block(Fixtures.Blocks.Block3125369.header, Fixtures.Blocks.Block3125369.body)
 
     blockchainWriter.storeBlock(blockToRequest).commit()
-    blockchain.saveBestKnownBlocks(blockToRequest.hash, blockToRequest.number)
+    blockchainWriter.saveBestKnownBlocks(blockToRequest.hash, blockToRequest.number)
 
     val rpcRequest = newJsonRpcRequest(
       "eth_getBlockTransactionCountByHash",

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerEthSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerEthSpec.scala
@@ -80,7 +80,7 @@ class JsonRpcControllerEthSpec
 
   it should "handle eth_blockNumber request" in new JsonRpcControllerFixture {
     val bestBlockNumber = 10
-    blockchain.saveBestKnownBlocks(ByteString.empty, bestBlockNumber)
+    blockchainWriter.saveBestKnownBlocks(ByteString.empty, bestBlockNumber)
 
     val rpcRequest = newJsonRpcRequest("eth_blockNumber")
     val response = jsonRpcController.handleRequest(rpcRequest).runSyncUnsafe()
@@ -177,7 +177,7 @@ class JsonRpcControllerEthSpec
       .storeBlock(blockToRequest)
       .and(blockchainWriter.storeChainWeight(blockToRequest.header.hash, blockWeight))
       .commit()
-    blockchain.saveBestKnownBlocks(blockToRequest.hash, blockToRequest.number)
+    blockchainWriter.saveBestKnownBlocks(blockToRequest.hash, blockToRequest.number)
 
     val request = newJsonRpcRequest(
       "eth_getBlockByNumber",
@@ -199,7 +199,7 @@ class JsonRpcControllerEthSpec
       .storeBlock(blockToRequest)
       .and(blockchainWriter.storeChainWeight(blockToRequest.header.hash, blockWeight))
       .commit()
-    blockchain.saveBestKnownBlocks(blockToRequest.hash, blockToRequest.number)
+    blockchainWriter.saveBestKnownBlocks(blockToRequest.hash, blockToRequest.number)
 
     val request = newJsonRpcRequest(
       "eth_getBlockByNumber",
@@ -221,7 +221,7 @@ class JsonRpcControllerEthSpec
       .storeBlock(blockToRequest)
       .and(blockchainWriter.storeChainWeight(blockToRequest.header.hash, blockWeight))
       .commit()
-    blockchain.saveBestKnownBlocks(blockToRequest.hash, blockToRequest.number)
+    blockchainWriter.saveBestKnownBlocks(blockToRequest.hash, blockToRequest.number)
 
     val request = newJsonRpcRequest(
       "eth_getBlockByNumber",
@@ -265,7 +265,7 @@ class JsonRpcControllerEthSpec
     val blockToRequest = Block(Fixtures.Blocks.Block3125369.header, BlockBody(Nil, Seq(uncle)))
 
     blockchainWriter.storeBlock(blockToRequest).commit()
-    blockchain.saveBestKnownBlocks(blockToRequest.hash, blockToRequest.number)
+    blockchainWriter.saveBestKnownBlocks(blockToRequest.hash, blockToRequest.number)
 
     val request: JsonRpcRequest = newJsonRpcRequest(
       "eth_getUncleByBlockNumberAndIndex",
@@ -416,7 +416,7 @@ class JsonRpcControllerEthSpec
     private val block: Block =
       Block(Fixtures.Blocks.Block3125369.header.copy(number = 42), Fixtures.Blocks.Block3125369.body)
     blockchainWriter.storeBlock(block).commit()
-    blockchain.saveBestKnownBlocks(block.hash, block.number)
+    blockchainWriter.saveBestKnownBlocks(block.hash, block.number)
 
     val request: JsonRpcRequest = newJsonRpcRequest("eth_gasPrice")
 

--- a/src/test/scala/io/iohk/ethereum/transactions/LegacyTransactionHistoryServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/transactions/LegacyTransactionHistoryServiceSpec.scala
@@ -87,7 +87,7 @@ class LegacyTransactionHistoryServiceSpec
           .and(blockchainWriter.storeBlock(blockWithTxs2and3))
           .and(blockchainWriter.storeReceipts(blockWithTxs2and3.hash, blockTx2And3Receipts))
           .commit()
-        blockchain.saveBestKnownBlocks(blockWithTxs2and3.hash, blockWithTxs2and3.number)
+        blockchainWriter.saveBestKnownBlocks(blockWithTxs2and3.hash, blockWithTxs2and3.number)
       }
       response <- transactionHistoryService.getAccountTransactions(address, BigInt(3125360) to BigInt(3125370))
     } yield assert(response === expectedTxs)


### PR DESCRIPTION
# Description
In order to reduce the scope of the Blockchain class, saveBestKnownBlocks was moved to BlockchainWriter

# Testing
Tested against ETC and also deployed in Staging

