### PR TITLE
Etcm 1055 Adjust PeersClient.nextBestBlock()

### DIFF
--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/PeerComparator.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/PeerComparator.scala
@@ -1,0 +1,9 @@
+package io.iohk.ethereum.blockchain
+
+import io.iohk.ethereum.network.EtcPeerManagerActor.PeerInfo
+
+object PeerComparator {
+
+  def doPeersHaveSameBestBlock(peerInfo1: PeerInfo, peerInfo2: PeerInfo): Boolean =
+    peerInfo1.bestBlockHash == peerInfo2.bestBlockHash
+}

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/PeersClientSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/PeersClientSpec.scala
@@ -18,6 +18,7 @@ import io.iohk.ethereum.network.EtcPeerManagerActor.RemoteStatus
 import io.iohk.ethereum.network.Peer
 import io.iohk.ethereum.network.PeerId
 import io.iohk.ethereum.network.p2p.messages.Capability
+import org.scalatest.prop.TableFor3
 
 class PeersClientSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyChecks {
 

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/PeersClientSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/PeersClientSpec.scala
@@ -6,6 +6,8 @@ import akka.actor.ActorSystem
 import akka.testkit.TestProbe
 import akka.util.ByteString
 
+import scala.collection.mutable
+
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableFor3
@@ -18,55 +20,55 @@ import io.iohk.ethereum.network.EtcPeerManagerActor.RemoteStatus
 import io.iohk.ethereum.network.Peer
 import io.iohk.ethereum.network.PeerId
 import io.iohk.ethereum.network.p2p.messages.Capability
-import org.scalatest.prop.TableFor3
 
 class PeersClientSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyChecks {
 
   import Peers._
-  val table: TableFor3[Map[PeerId,PeerWithInfo],Option[Peer],String] = Table[Map[PeerId, PeerWithInfo], Option[Peer], String](
-    ("PeerInfo map", "Expected best peer", "Scenario info (selected peer)"),
-    (
-      Map(),
-      None,
-      "No peers"
-    ),
-    (
-      Map(peer1.id -> PeerWithInfo(peer1, peerInfo(0, 100, fork = false))),
-      None,
-      "Single peer"
-    ),
-    (
-      Map(
-        peer1.id -> PeerWithInfo(peer1, peerInfo(0, 100, fork = false)),
-        peer2.id -> PeerWithInfo(peer2, peerInfo(0, 50, fork = true))
+  val table: TableFor3[Map[PeerId, PeerWithInfo], Option[Peer], String] =
+    Table[Map[PeerId, PeerWithInfo], Option[Peer], String](
+      ("PeerInfo map", "Expected best peer", "Scenario info (selected peer)"),
+      (
+        Map(),
+        None,
+        "No peers"
       ),
-      Some(peer2),
-      "Peer2 with lower TD but following the ETC fork"
-    ),
-    (
-      Map(peer1.id -> PeerWithInfo(peer1, peerInfo(0, 100)), peer2.id -> PeerWithInfo(peer2, peerInfo(0, 101))),
-      Some(peer2),
-      "Peer2 with higher TD"
-    ),
-    (
-      Map(
-        peer1.id -> PeerWithInfo(peer1, peerInfo(0, 100)),
-        peer2.id -> PeerWithInfo(peer2, peerInfo(0, 101)),
-        peer3.id -> PeerWithInfo(peer3, peerInfo(1, 50))
+      (
+        Map(peer1.id -> PeerWithInfo(peer1, peerInfo(0, 100, fork = false))),
+        None,
+        "Single peer"
       ),
-      Some(peer3),
-      "Peer3 with lower TD but higher checkpoint number"
-    ),
-    (
-      Map(
-        peer1.id -> PeerWithInfo(peer1, peerInfo(0, 100)),
-        peer2.id -> PeerWithInfo(peer2, peerInfo(4, 101)),
-        peer3.id -> PeerWithInfo(peer3, peerInfo(4, 50))
+      (
+        Map(
+          peer1.id -> PeerWithInfo(peer1, peerInfo(0, 100, fork = false)),
+          peer2.id -> PeerWithInfo(peer2, peerInfo(0, 50, fork = true))
+        ),
+        Some(peer2),
+        "Peer2 with lower TD but following the ETC fork"
       ),
-      Some(peer2),
-      "Peer2 with equal checkpoint number and higher TD"
+      (
+        Map(peer1.id -> PeerWithInfo(peer1, peerInfo(0, 100)), peer2.id -> PeerWithInfo(peer2, peerInfo(0, 101))),
+        Some(peer2),
+        "Peer2 with higher TD"
+      ),
+      (
+        Map(
+          peer1.id -> PeerWithInfo(peer1, peerInfo(0, 100)),
+          peer2.id -> PeerWithInfo(peer2, peerInfo(0, 101)),
+          peer3.id -> PeerWithInfo(peer3, peerInfo(1, 50))
+        ),
+        Some(peer3),
+        "Peer3 with lower TD but higher checkpoint number"
+      ),
+      (
+        Map(
+          peer1.id -> PeerWithInfo(peer1, peerInfo(0, 100)),
+          peer2.id -> PeerWithInfo(peer2, peerInfo(4, 101)),
+          peer3.id -> PeerWithInfo(peer3, peerInfo(4, 50))
+        ),
+        Some(peer2),
+        "Peer2 with equal checkpoint number and higher TD"
+      )
     )
-  )
 
   "PeerClient" should "determine the best peer based on its latest checkpoint number and total difficulty" in {
     forAll(table) { (peerInfoMap, expectedPeer, _) =>
@@ -74,14 +76,14 @@ class PeersClientSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyC
     }
   }
 
-  it should "determine the next best peer (same as  bestPeer when lru set is empty)" in {
+  it should "determine the next best peer (same as bestPeer when lru set is empty)" in {
     forAll(table) { (peerInfoMap, expectedPeer, _) =>
-      PeersClient.nextBestPeer(peerInfoMap) shouldEqual expectedPeer
+      PeersClient.nextBestPeer(peerInfoMap, Set.empty) shouldEqual expectedPeer
     }
   }
 
-  it should "determine the next best peer when lru is used" in {
-    val table = Table[Map[PeerId, PeerWithInfo], Option[Peer], Option[Peer], String](
+  it should "determine the next best peer with a different best block each time" in {
+    val table = Table[Map[PeerId, PeerWithInfo], Option[PeerWithInfo], Option[Peer], String](
       ("PeerInfo map", "Used best peer", "Expected best peer", "Scenario info (selected peer)"),
       (
         Map(),
@@ -100,40 +102,31 @@ class PeersClientSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyC
           peer1.id -> PeerWithInfo(peer1, peerInfo(0, 100, fork = false)),
           peer2.id -> PeerWithInfo(peer2, peerInfo(0, 50, fork = true))
         ),
-        Some(peer2),
+        Some(PeerWithInfo(peer2, peerInfo(0, 50, fork = true))),
         None,
-        "Peer2 with lower TD but following the ETC fork"
+        "Peer2 with lower TD but following the ETC fork, peer2 is already used"
       ),
       (
         Map(peer1.id -> PeerWithInfo(peer1, peerInfo(0, 100)), peer2.id -> PeerWithInfo(peer2, peerInfo(0, 101))),
-        Some(peer2),
-        Some(peer1),
-        "Peer2 with higher TD"
+        Some(PeerWithInfo(peer2, peerInfo(0, 101))),
+        None,
+        "Both peer are used"
       ),
       (
         Map(
           peer1.id -> PeerWithInfo(peer1, peerInfo(0, 100)),
-          peer2.id -> PeerWithInfo(peer2, peerInfo(0, 101)),
-          peer3.id -> PeerWithInfo(peer3, peerInfo(1, 50))
+          peer2.id -> PeerWithInfo(peer2, peerInfo(1, 50)),
+          peer3.id -> PeerWithInfo(peer3, peerInfo(0, 80).copy(bestBlockHash = ByteString("differenthash")))
         ),
+        Some(PeerWithInfo(peer2, peerInfo(1, 50))),
         Some(peer3),
-        Some(peer2),
-        "Peer3 with lower TD but higher checkpoint number"
-      ),
-      (
-        Map(
-          peer1.id -> PeerWithInfo(peer1, peerInfo(0, 100)),
-          peer2.id -> PeerWithInfo(peer2, peerInfo(4, 101)),
-          peer3.id -> PeerWithInfo(peer3, peerInfo(4, 50))
-        ),
-        Some(peer2),
-        Some(peer3),
-        "Peer2 with equal checkpoint number and higher TD"
+        "Peer2 with lower TD but higher checkpoint number, peer 1 and 2 are used"
       )
     )
-    forAll(table) { (peerInfoMap, usedPeer, expectedPeer, _) =>
-      usedPeer.map(PeersClient.activeFetchingNodes.add)
-      PeersClient.nextBestPeer(peerInfoMap) shouldEqual expectedPeer
+    val activeFetchingNodes: mutable.Set[PeerWithInfo] = mutable.Set.empty
+    forAll(table) { (peerInfoMap, usedPeerWithInfo, expectedPeer, _) =>
+      usedPeerWithInfo.map(activeFetchingNodes.add)
+      PeersClient.nextBestPeer(peerInfoMap, activeFetchingNodes.toSet) shouldEqual expectedPeer
     }
   }
 

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/PeersClientSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/PeersClientSpec.scala
@@ -22,51 +22,50 @@ import io.iohk.ethereum.network.p2p.messages.Capability
 class PeersClientSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyChecks {
 
   import Peers._
-  val table: TableFor3[Map[PeerId, PeerWithInfo], Option[Peer], String] =
-    Table[Map[PeerId, PeerWithInfo], Option[Peer], String](
-      ("PeerInfo map", "Expected best peer", "Scenario info (selected peer)"),
-      (
-        Map(),
-        None,
-        "No peers"
+  val table: TableFor3[Map[PeerId,PeerWithInfo],Option[Peer],String] = Table[Map[PeerId, PeerWithInfo], Option[Peer], String](
+    ("PeerInfo map", "Expected best peer", "Scenario info (selected peer)"),
+    (
+      Map(),
+      None,
+      "No peers"
+    ),
+    (
+      Map(peer1.id -> PeerWithInfo(peer1, peerInfo(0, 100, fork = false))),
+      None,
+      "Single peer"
+    ),
+    (
+      Map(
+        peer1.id -> PeerWithInfo(peer1, peerInfo(0, 100, fork = false)),
+        peer2.id -> PeerWithInfo(peer2, peerInfo(0, 50, fork = true))
       ),
-      (
-        Map(peer1.id -> PeerWithInfo(peer1, peerInfo(0, 100, fork = false))),
-        None,
-        "Single peer"
+      Some(peer2),
+      "Peer2 with lower TD but following the ETC fork"
+    ),
+    (
+      Map(peer1.id -> PeerWithInfo(peer1, peerInfo(0, 100)), peer2.id -> PeerWithInfo(peer2, peerInfo(0, 101))),
+      Some(peer2),
+      "Peer2 with higher TD"
+    ),
+    (
+      Map(
+        peer1.id -> PeerWithInfo(peer1, peerInfo(0, 100)),
+        peer2.id -> PeerWithInfo(peer2, peerInfo(0, 101)),
+        peer3.id -> PeerWithInfo(peer3, peerInfo(1, 50))
       ),
-      (
-        Map(
-          peer1.id -> PeerWithInfo(peer1, peerInfo(0, 100, fork = false)),
-          peer2.id -> PeerWithInfo(peer2, peerInfo(0, 50, fork = true))
-        ),
-        Some(peer2),
-        "Peer2 with lower TD but following the ETC fork"
+      Some(peer3),
+      "Peer3 with lower TD but higher checkpoint number"
+    ),
+    (
+      Map(
+        peer1.id -> PeerWithInfo(peer1, peerInfo(0, 100)),
+        peer2.id -> PeerWithInfo(peer2, peerInfo(4, 101)),
+        peer3.id -> PeerWithInfo(peer3, peerInfo(4, 50))
       ),
-      (
-        Map(peer1.id -> PeerWithInfo(peer1, peerInfo(0, 100)), peer2.id -> PeerWithInfo(peer2, peerInfo(0, 101))),
-        Some(peer2),
-        "Peer2 with higher TD"
-      ),
-      (
-        Map(
-          peer1.id -> PeerWithInfo(peer1, peerInfo(0, 100)),
-          peer2.id -> PeerWithInfo(peer2, peerInfo(0, 101)),
-          peer3.id -> PeerWithInfo(peer3, peerInfo(1, 50))
-        ),
-        Some(peer3),
-        "Peer3 with lower TD but higher checkpoint number"
-      ),
-      (
-        Map(
-          peer1.id -> PeerWithInfo(peer1, peerInfo(0, 100)),
-          peer2.id -> PeerWithInfo(peer2, peerInfo(4, 101)),
-          peer3.id -> PeerWithInfo(peer3, peerInfo(4, 50))
-        ),
-        Some(peer2),
-        "Peer2 with equal checkpoint number and higher TD"
-      )
+      Some(peer2),
+      "Peer2 with equal checkpoint number and higher TD"
     )
+  )
 
   "PeerClient" should "determine the best peer based on its latest checkpoint number and total difficulty" in {
     forAll(table) { (peerInfoMap, expectedPeer, _) =>


### PR DESCRIPTION
# Description

Adjust PeersClient.nextBestBlock(). It should be able to make sure the next best peer has a different best block, so we don't fetch in parallel identical branches
