### PR TITLE
Prevent retesteth from hanging the CI build

### DIFF
--- a/test-ets.sh
+++ b/test-ets.sh
@@ -14,7 +14,7 @@ final_exit_code=0
 
 function run_and_annotate {
   echo "running retesteth $1"
-  ets/retesteth -t "$1" 2>&1 | tee "retesteth-$1-log.txt"
+  ets/retesteth -t "$1" -- --verbosity 3 2>&1 | tee "retesteth-$1-log.txt"
   exit_code=$?
   echo "retesteth $1 exit code: $exit_code"
 

--- a/test-ets.sh
+++ b/test-ets.sh
@@ -14,7 +14,7 @@ final_exit_code=0
 
 function run_and_annotate {
   echo "running retesteth $1"
-  ets/retesteth -t "$1" &> "retesteth-$1-log.txt"
+  ets/retesteth -t "$1" 2>&1 | tee "retesteth-$1-log.txt"
   exit_code=$?
   echo "retesteth $1 exit code: $exit_code"
 

--- a/test-ets.sh
+++ b/test-ets.sh
@@ -14,7 +14,7 @@ final_exit_code=0
 
 function run_and_annotate {
   echo "running retesteth $1"
-  ets/retesteth -t "$1" -- --verbosity 3 2>&1 | tee "retesteth-$1-log.txt"
+  timeout 5m ets/retesteth -t "$1" -- --verbosity 3 2>&1 | tee "retesteth-$1-log.txt"
   exit_code=$?
   echo "retesteth $1 exit code: $exit_code"
 

--- a/test-ets.sh
+++ b/test-ets.sh
@@ -14,7 +14,7 @@ final_exit_code=0
 
 function run_and_annotate {
   echo "running retesteth $1"
-  timeout 5m ets/retesteth -t "$1" -- --verbosity 3 2>&1 | tee "retesteth-$1-log.txt"
+  timeout 5m ets/retesteth -t "$1" -- --verbosity 3 &> "retesteth-$1-log.txt"
   exit_code=$?
   echo "retesteth $1 exit code: $exit_code"
 

--- a/test-ets.sh
+++ b/test-ets.sh
@@ -14,7 +14,7 @@ final_exit_code=0
 
 function run_and_annotate {
   echo "running retesteth $1"
-  timeout 5m ets/retesteth -t "$1" -- --verbosity 3 &> "retesteth-$1-log.txt"
+  timeout 15m ets/retesteth -t "$1" -- --verbosity 3 &> "retesteth-$1-log.txt"
   exit_code=$?
   echo "retesteth $1 exit code: $exit_code"
 


### PR DESCRIPTION
Basically by wrapping it with `timeout 5m`. In addition I bumped the verbosity so it will be easier to see in the logs what's going on.