### PR TITLE
[ETCM-1066] Add EIP-2929 VM integration tests

### DIFF
--- a/src/main/scala/io/iohk/ethereum/vm/OpCode.scala
+++ b/src/main/scala/io/iohk/ethereum/vm/OpCode.scala
@@ -257,7 +257,7 @@ trait AddrAccessGas { self: OpCode =>
 
 trait StorageAccessGas { self: OpCode =>
 
-  private def coldGasFn: FeeSchedule => BigInt = _.G_cold_account_access
+  private def coldGasFn: FeeSchedule => BigInt = _.G_cold_sload
   private def warmGasFn: FeeSchedule => BigInt = _.G_warm_storage_read
 
   override protected def baseGas[W <: WorldStateProxy[W, S], S <: Storage[S]](state: ProgramState[W, S]): BigInt = {
@@ -769,7 +769,7 @@ case object SSTORE extends OpCode(0x55, 2, 0, _.G_zero) {
         state.config.feeSchedule.G_sreset
     }
 
-    originalCharge + OpCode.storageAccessCost(state, state.ownAddress, offset)(_ => 0, _.G_cold_account_access, _ => 0)
+    originalCharge + OpCode.storageAccessCost(state, state.ownAddress, offset)(_ => 0, _.G_cold_sload, _ => 0)
   }
 
   override protected def availableInContext[W <: WorldStateProxy[W, S], S <: Storage[S]]

--- a/src/test/scala/io/iohk/ethereum/vm/CallOpcodesPostEip2929Spec.scala
+++ b/src/test/scala/io/iohk/ethereum/vm/CallOpcodesPostEip2929Spec.scala
@@ -24,7 +24,7 @@ class MagnetoCallOpFixture(config: EvmConfig)
     BlockFixtures.ValidBlock.header.copy(number = Fixtures.MagnetoBlockNumber, unixTimestamp = 0)
 
   override val requiredGas: BigInt = {
-    val storageCost = 3 * (config.feeSchedule.G_sset + config.feeSchedule.G_cold_account_access)
+    val storageCost = 3 * (config.feeSchedule.G_sset + config.feeSchedule.G_cold_sload)
     val memCost = config.calcMemCost(0, 0, 32)
     val copyCost = config.feeSchedule.G_copy * wordsForBytes(32)
 


### PR DESCRIPTION
# Description
Adds tests for gas changes introduced in EIP-2929 that span across multiple opcodes

Also fixes a bug in which `G_cold_account_access` was charged incorrectly for storage access instead of `G_cold_sload`