### PR TITLE
[KAIZEN] Clarify mpt, vm and ledger packages

### DIFF
--- a/src/it/scala/io/iohk/ethereum/txExecTest/util/DumpChainApp.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/util/DumpChainApp.scala
@@ -29,8 +29,6 @@ import io.iohk.ethereum.domain._
 import io.iohk.ethereum.jsonrpc.ProofService.EmptyStorageValueProof
 import io.iohk.ethereum.jsonrpc.ProofService.StorageProof
 import io.iohk.ethereum.jsonrpc.ProofService.StorageProofKey
-import io.iohk.ethereum.ledger.InMemoryWorldStateProxy
-import io.iohk.ethereum.ledger.InMemoryWorldStateProxyStorage
 import io.iohk.ethereum.network.EtcPeerManagerActor.PeerInfo
 import io.iohk.ethereum.network.ForkResolver
 import io.iohk.ethereum.network.PeerEventBusActor
@@ -188,9 +186,6 @@ class BlockchainMock(genesisHash: ByteString) extends Blockchain {
 
   override def getAccountStorageAt(rootHash: ByteString, position: BigInt, ethCompatibleStorage: Boolean): ByteString =
     ???
-
-  override type S = InMemoryWorldStateProxyStorage
-  override type WS = InMemoryWorldStateProxy
 
   def getBestBlockNumber(): BigInt = ???
 

--- a/src/main/scala/io/iohk/ethereum/db/storage/ArchiveNodeStorage.scala
+++ b/src/main/scala/io/iohk/ethereum/db/storage/ArchiveNodeStorage.scala
@@ -1,8 +1,6 @@
 package io.iohk.ethereum.db.storage
 
-import io.iohk.ethereum.db.storage.NodeStorage.NodeEncoded
-import io.iohk.ethereum.db.storage.NodeStorage.NodeHash
-import io.iohk.ethereum.mpt.NodesKeyValueStorage
+import io.iohk.ethereum.db.storage.NodeStorage.{NodeEncoded, NodeHash}
 
 /** This class is used to store Nodes (defined in mpt/Node.scala), by using:
   * Key: hash of the RLP encoded node

--- a/src/main/scala/io/iohk/ethereum/db/storage/ArchiveNodeStorage.scala
+++ b/src/main/scala/io/iohk/ethereum/db/storage/ArchiveNodeStorage.scala
@@ -1,6 +1,7 @@
 package io.iohk.ethereum.db.storage
 
-import io.iohk.ethereum.db.storage.NodeStorage.{NodeEncoded, NodeHash}
+import io.iohk.ethereum.db.storage.NodeStorage.NodeEncoded
+import io.iohk.ethereum.db.storage.NodeStorage.NodeHash
 
 /** This class is used to store Nodes (defined in mpt/Node.scala), by using:
   * Key: hash of the RLP encoded node

--- a/src/main/scala/io/iohk/ethereum/db/storage/CachedReferenceCountedStorage.scala
+++ b/src/main/scala/io/iohk/ethereum/db/storage/CachedReferenceCountedStorage.scala
@@ -13,7 +13,6 @@ import io.iohk.ethereum.db.cache.Cache
 import io.iohk.ethereum.db.storage.NodeStorage.NodeEncoded
 import io.iohk.ethereum.db.storage.NodeStorage.NodeHash
 import io.iohk.ethereum.mpt.ByteArraySerializable
-import io.iohk.ethereum.mpt.NodesKeyValueStorage
 
 /** In-memory pruner - All pruning is done in LRU cache, which means all mpt nodes saved to db, are there permanently.
   * There are two occasions where node is saved to disk:

--- a/src/main/scala/io/iohk/ethereum/db/storage/MptStorage.scala
+++ b/src/main/scala/io/iohk/ethereum/db/storage/MptStorage.scala
@@ -6,7 +6,6 @@ import io.iohk.ethereum.db.storage.NodeStorage.NodeEncoded
 import io.iohk.ethereum.mpt.MerklePatriciaTrie.MissingRootNodeException
 import io.iohk.ethereum.mpt.MptNode
 import io.iohk.ethereum.mpt.MptTraversals
-import io.iohk.ethereum.mpt.NodesKeyValueStorage
 
 trait MptStorage {
   def get(nodeId: Array[Byte]): MptNode

--- a/src/main/scala/io/iohk/ethereum/db/storage/NodeStorage.scala
+++ b/src/main/scala/io/iohk/ethereum/db/storage/NodeStorage.scala
@@ -11,7 +11,8 @@ import io.iohk.ethereum.db.dataSource.RocksDbDataSource.IterationError
 import io.iohk.ethereum.db.storage.NodeStorage.NodeEncoded
 import io.iohk.ethereum.db.storage.NodeStorage.NodeHash
 
-sealed trait NodesStorage extends {
+/** Data Access Object */
+sealed trait NodesStorage {
   def get(key: NodeHash): Option[NodeEncoded]
   def update(toRemove: Seq[NodeHash], toUpsert: Seq[(NodeHash, NodeEncoded)]): NodesStorage
   def updateCond(toRemove: Seq[NodeHash], toUpsert: Seq[(NodeHash, NodeEncoded)], inMemory: Boolean): NodesStorage

--- a/src/main/scala/io/iohk/ethereum/db/storage/NodesKeyValueStorage.scala
+++ b/src/main/scala/io/iohk/ethereum/db/storage/NodesKeyValueStorage.scala
@@ -1,0 +1,9 @@
+package io.iohk.ethereum.db.storage
+
+import io.iohk.ethereum.common.SimpleMap
+import io.iohk.ethereum.db.storage.NodeStorage.{NodeEncoded, NodeHash}
+
+/** Storage of serialized nodes, materialized as key-value store */
+trait NodesKeyValueStorage extends SimpleMap[NodeHash, NodeEncoded, NodesKeyValueStorage] {
+  def persist(): Unit
+}

--- a/src/main/scala/io/iohk/ethereum/db/storage/NodesKeyValueStorage.scala
+++ b/src/main/scala/io/iohk/ethereum/db/storage/NodesKeyValueStorage.scala
@@ -1,7 +1,8 @@
 package io.iohk.ethereum.db.storage
 
 import io.iohk.ethereum.common.SimpleMap
-import io.iohk.ethereum.db.storage.NodeStorage.{NodeEncoded, NodeHash}
+import io.iohk.ethereum.db.storage.NodeStorage.NodeEncoded
+import io.iohk.ethereum.db.storage.NodeStorage.NodeHash
 
 /** Storage of serialized nodes, materialized as key-value store */
 trait NodesKeyValueStorage extends SimpleMap[NodeHash, NodeEncoded, NodesKeyValueStorage] {

--- a/src/main/scala/io/iohk/ethereum/db/storage/ReadOnlyNodeStorage.scala
+++ b/src/main/scala/io/iohk/ethereum/db/storage/ReadOnlyNodeStorage.scala
@@ -4,7 +4,6 @@ import scala.collection.mutable
 
 import io.iohk.ethereum.db.storage.NodeStorage.NodeEncoded
 import io.iohk.ethereum.db.storage.NodeStorage.NodeHash
-import io.iohk.ethereum.mpt.NodesKeyValueStorage
 
 /** This storage allows to read from another NodesKeyValueStorage but doesn't remove or upsert into database.
   * To do so, it uses an internal in memory cache to apply all the changes.

--- a/src/main/scala/io/iohk/ethereum/db/storage/ReferenceCountNodeStorage.scala
+++ b/src/main/scala/io/iohk/ethereum/db/storage/ReferenceCountNodeStorage.scala
@@ -5,7 +5,6 @@ import akka.util.ByteString
 import io.iohk.ethereum.db.storage.NodeStorage.NodeEncoded
 import io.iohk.ethereum.db.storage.NodeStorage.NodeHash
 import io.iohk.ethereum.db.storage.pruning.PruneSupport
-import io.iohk.ethereum.mpt.NodesKeyValueStorage
 import io.iohk.ethereum.utils.Logger
 
 import encoding._

--- a/src/main/scala/io/iohk/ethereum/domain/Blockchain.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/Blockchain.scala
@@ -9,21 +9,14 @@ import io.iohk.ethereum.db.storage._
 import io.iohk.ethereum.domain
 import io.iohk.ethereum.domain.appstate.BlockInfo
 import io.iohk.ethereum.jsonrpc.ProofService.StorageProof
-import io.iohk.ethereum.ledger.InMemoryWorldStateProxy
-import io.iohk.ethereum.ledger.InMemoryWorldStateProxyStorage
 import io.iohk.ethereum.mpt.MerklePatriciaTrie
 import io.iohk.ethereum.mpt.MptNode
 import io.iohk.ethereum.utils.ByteStringUtils
 import io.iohk.ethereum.utils.Logger
-import io.iohk.ethereum.vm.Storage
-import io.iohk.ethereum.vm.WorldStateProxy
 
 /** Entity to be used to persist and query  Blockchain related objects (blocks, transactions, ommers)
   */
 trait Blockchain {
-
-  type S <: Storage[S]
-  type WS <: WorldStateProxy[WS, S]
 
   /** Get account storage at given position
     *
@@ -215,9 +208,6 @@ class BlockchainImpl(
     stxs.map(_.hash).foldLeft(transactionMappingStorage.emptyBatchUpdate) { case (updates, hash) =>
       updates.and(transactionMappingStorage.remove(hash))
     }
-
-  override type S = InMemoryWorldStateProxyStorage
-  override type WS = InMemoryWorldStateProxy
 }
 
 trait BlockchainStorages {

--- a/src/main/scala/io/iohk/ethereum/extvm/VMClient.scala
+++ b/src/main/scala/io/iohk/ethereum/extvm/VMClient.scala
@@ -95,7 +95,7 @@ class VMClient(externalVmConfig: VmConfig.ExternalConfig, messageHandler: Messag
         messageLoop[W, S](world)
 
       case msg =>
-        log.warn(s"Client received unexpected message: ${msg}!")
+        log.warn(s"Client received unexpected message: $msg!")
         messageLoop[W, S](world)
     }
   }

--- a/src/main/scala/io/iohk/ethereum/ledger/InMemorySimpleMapProxy.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/InMemorySimpleMapProxy.scala
@@ -41,7 +41,7 @@ class InMemorySimpleMapProxy[K, V, I <: SimpleMap[K, V, I]] private (val inner: 
     */
   def rollback: InMemorySimpleMapProxy[K, V, I] = new InMemorySimpleMapProxy[K, V, I](inner, Map.empty)
 
-  /** This function obtains the value asociated with the key passed, if there exists one.
+  /** This function obtains the value associated with the key passed, if there exists one.
     *
     * @param key
     * @return Option object with value if there exists one.

--- a/src/main/scala/io/iohk/ethereum/ledger/InMemoryWorldStateProxyStorage.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/InMemoryWorldStateProxyStorage.scala
@@ -1,0 +1,22 @@
+package io.iohk.ethereum.ledger
+
+import io.iohk.ethereum.mpt.MerklePatriciaTrie
+import io.iohk.ethereum.vm.Storage
+
+/** Storage content of an account (ex: stores smart-contract values)
+  *
+  * @param wrapped a key-value (kec key -> rlp value) based on an MPT
+  */
+class InMemoryWorldStateProxyStorage(
+    val wrapped: InMemorySimpleMapProxy[BigInt, BigInt, MerklePatriciaTrie[BigInt, BigInt]]
+) extends Storage[InMemoryWorldStateProxyStorage] {
+
+  override def store(addr: BigInt, value: BigInt): InMemoryWorldStateProxyStorage = {
+    val newWrapped =
+      if (value == 0) wrapped - addr
+      else wrapped + (addr -> value)
+    new InMemoryWorldStateProxyStorage(newWrapped)
+  }
+
+  override def load(addr: BigInt): BigInt = wrapped.get(addr).getOrElse(0)
+}

--- a/src/main/scala/io/iohk/ethereum/mpt/MerklePatriciaTrie.scala
+++ b/src/main/scala/io/iohk/ethereum/mpt/MerklePatriciaTrie.scala
@@ -8,8 +8,6 @@ import org.bouncycastle.util.encoders.Hex
 
 import io.iohk.ethereum.common.SimpleMap
 import io.iohk.ethereum.db.storage.MptStorage
-import io.iohk.ethereum.db.storage.NodeStorage.NodeEncoded
-import io.iohk.ethereum.db.storage.NodeStorage.NodeHash
 import io.iohk.ethereum.mpt
 import io.iohk.ethereum.rlp.RLPImplicits._
 import io.iohk.ethereum.rlp.{encode => encodeRLP}
@@ -61,10 +59,6 @@ object MerklePatriciaTrie {
     else {
       new MerklePatriciaTrie[K, V](Some(mpt.HashNode(rootHash)), source)(kSerializer, vSerializer)
     }
-}
-
-trait NodesKeyValueStorage extends SimpleMap[NodeHash, NodeEncoded, NodesKeyValueStorage] {
-  def persist(): Unit
 }
 
 class MerklePatriciaTrie[K, V] private (private[mpt] val rootNode: Option[MptNode], val nodeStorage: MptStorage)(

--- a/src/main/scala/io/iohk/ethereum/mpt/MptTraversals.scala
+++ b/src/main/scala/io/iohk/ethereum/mpt/MptTraversals.scala
@@ -97,7 +97,7 @@ object MptTraversals {
         val vistResult = visitor.visitHash(hashNode)
         vistResult.next(visitor)(dispatch)
 
-      case nullNode: NullNode.type =>
+      case _: NullNode.type =>
         visitor.visitNull()
     }
 }

--- a/src/main/scala/io/iohk/ethereum/network/p2p/messages/BaseETH6XMessages.scala
+++ b/src/main/scala/io/iohk/ethereum/network/p2p/messages/BaseETH6XMessages.scala
@@ -10,11 +10,9 @@ import io.iohk.ethereum.network.p2p.Message
 import io.iohk.ethereum.network.p2p.MessageSerializableImplicit
 import io.iohk.ethereum.rlp.RLPCodec.Ops
 import io.iohk.ethereum.rlp.RLPImplicitConversions._
-import io.iohk.ethereum.rlp.RLPImplicitDerivations.RLPListDecoder
 import io.iohk.ethereum.rlp.RLPImplicits._
 import io.iohk.ethereum.rlp._
 import io.iohk.ethereum.utils.ByteStringUtils.ByteStringOps
-import io.iohk.ethereum.utils.Config
 
 object BaseETH6XMessages {
   object Status {

--- a/src/main/scala/io/iohk/ethereum/transactions/PendingTransactionsManager.scala
+++ b/src/main/scala/io/iohk/ethereum/transactions/PendingTransactionsManager.scala
@@ -44,11 +44,11 @@ object PendingTransactionsManager {
 
   case class AddTransactions(signedTransactions: Set[SignedTransactionWithSender])
 
-  case class AddUncheckedTransactions(signedTransactions: Seq[SignedTransaction])
-
   object AddTransactions {
     def apply(txs: SignedTransactionWithSender*): AddTransactions = AddTransactions(txs.toSet)
   }
+
+  case class AddUncheckedTransactions(signedTransactions: Seq[SignedTransaction])
 
   case class AddOrOverrideTransaction(signedTransaction: SignedTransaction)
 
@@ -72,7 +72,6 @@ class PendingTransactionsManager(
 ) extends Actor
     with MetricsContainer
     with ActorLogging {
-
   import PendingTransactionsManager._
   import akka.pattern.ask
 

--- a/src/main/scala/io/iohk/ethereum/vm/ProgramResult.scala
+++ b/src/main/scala/io/iohk/ethereum/vm/ProgramResult.scala
@@ -5,7 +5,7 @@ import akka.util.ByteString
 import io.iohk.ethereum.domain.Address
 import io.iohk.ethereum.domain.TxLogEntry
 
-/** Represenation of the result of execution of a contract
+/** Representation of the result of execution of a contract
   *
   * @param returnData bytes returned by the executed contract (set by [[RETURN]] opcode)
   * @param gasRemaining amount of gas remaining after execution

--- a/src/main/scala/io/iohk/ethereum/vm/VM.scala
+++ b/src/main/scala/io/iohk/ethereum/vm/VM.scala
@@ -1,11 +1,11 @@
 package io.iohk.ethereum.vm
 
 import akka.util.ByteString
-
 import scala.annotation.tailrec
 
 import io.iohk.ethereum.domain.Address
 import io.iohk.ethereum.domain.UInt256
+import io.iohk.ethereum.utils.ByteStringUtils.ByteStringOps
 import io.iohk.ethereum.utils.Logger
 
 class VM[W <: WorldStateProxy[W, S], S <: Storage[S]] extends Logger {
@@ -21,10 +21,8 @@ class VM[W <: WorldStateProxy[W, S], S <: Storage[S]] extends Logger {
   def run(context: ProgramContext[W, S]): ProgramResult[W, S] = {
     {
       import context._
-      import org.bouncycastle.util.encoders.Hex
       log.trace(
-        s"caller:  $callerAddr | recipient: $recipientAddr | gasPrice: $gasPrice | value: $value | inputData: ${Hex
-          .toHexString(inputData.toArray)}"
+        s"caller:  $callerAddr | recipient: $recipientAddr | gasPrice: $gasPrice | value: $value | inputData: ${inputData.toHex}"
       )
     }
 

--- a/src/main/scala/io/iohk/ethereum/vm/VM.scala
+++ b/src/main/scala/io/iohk/ethereum/vm/VM.scala
@@ -1,6 +1,7 @@
 package io.iohk.ethereum.vm
 
 import akka.util.ByteString
+
 import scala.annotation.tailrec
 
 import io.iohk.ethereum.domain.Address

--- a/src/test/scala/io/iohk/ethereum/consensus/ConsensusAdapterSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/ConsensusAdapterSpec.scala
@@ -1,14 +1,12 @@
 package io.iohk.ethereum.consensus
 
 import akka.util.ByteString
-
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-
 import io.iohk.ethereum.Mocks
 import io.iohk.ethereum.Mocks.MockValidatorsAlwaysSucceed
 import io.iohk.ethereum.blockchain.sync.regular.BlockEnqueued
@@ -20,7 +18,7 @@ import io.iohk.ethereum.consensus.mining._
 import io.iohk.ethereum.consensus.validators.BlockHeaderError.HeaderDifficultyError
 import io.iohk.ethereum.consensus.validators.BlockHeaderError.HeaderParentNotFoundError
 import io.iohk.ethereum.consensus.validators._
-import io.iohk.ethereum.db.storage.MptStorage
+import io.iohk.ethereum.db.storage.{MptStorage, SerializingMptStorage}
 import io.iohk.ethereum.domain._
 import io.iohk.ethereum.ledger.BlockData
 import io.iohk.ethereum.ledger.BlockExecution
@@ -98,7 +96,7 @@ class ConsensusAdapterSpec extends AnyFlatSpec with Matchers with ScalaFutures {
       .returning(Some(Leaf(hash, currentWeight.increase(block.header))))
     (blockQueue.getBranch _).expects(hash, true).returning(List(block))
 
-    val mptStorage = mock[MptStorage]
+    val mptStorage = mock[SerializingMptStorage]
     val mptNode = LeafNode(
       ByteString(MerklePatriciaTrie.EmptyRootHash),
       ByteString(MerklePatriciaTrie.EmptyRootHash),

--- a/src/test/scala/io/iohk/ethereum/consensus/ConsensusAdapterSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/ConsensusAdapterSpec.scala
@@ -1,12 +1,14 @@
 package io.iohk.ethereum.consensus
 
 import akka.util.ByteString
+
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+
 import io.iohk.ethereum.Mocks
 import io.iohk.ethereum.Mocks.MockValidatorsAlwaysSucceed
 import io.iohk.ethereum.blockchain.sync.regular.BlockEnqueued
@@ -18,7 +20,7 @@ import io.iohk.ethereum.consensus.mining._
 import io.iohk.ethereum.consensus.validators.BlockHeaderError.HeaderDifficultyError
 import io.iohk.ethereum.consensus.validators.BlockHeaderError.HeaderParentNotFoundError
 import io.iohk.ethereum.consensus.validators._
-import io.iohk.ethereum.db.storage.{MptStorage, SerializingMptStorage}
+import io.iohk.ethereum.db.storage.SerializingMptStorage
 import io.iohk.ethereum.domain._
 import io.iohk.ethereum.ledger.BlockData
 import io.iohk.ethereum.ledger.BlockExecution

--- a/src/test/scala/io/iohk/ethereum/db/storage/CachedReferenceCountedStorageSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/db/storage/CachedReferenceCountedStorageSpec.scala
@@ -14,7 +14,6 @@ import io.iohk.ethereum.ObjectGenerators
 import io.iohk.ethereum.crypto.kec256
 import io.iohk.ethereum.db.cache.LruCache
 import io.iohk.ethereum.db.dataSource.EphemDataSource
-import io.iohk.ethereum.mpt.NodesKeyValueStorage
 import io.iohk.ethereum.utils.Config.NodeCacheConfig
 
 // scalastyle:off magic.number

--- a/src/test/scala/io/iohk/ethereum/db/storage/ReadOnlyNodeStorageSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/db/storage/ReadOnlyNodeStorageSpec.scala
@@ -29,7 +29,7 @@ class ReadOnlyNodeStorageSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "be able to persist to underlying storage when needed" in new TestSetup {
-    val (nodeKey, _) = MptStorage.collapseNode(Some(newLeaf))._2.head
+    val (nodeKey, _) = SerializingMptStorage.collapseNode(Some(newLeaf))._2.head
     val readOnlyNodeStorage = archiveStateStorage.getReadOnlyStorage
 
     readOnlyNodeStorage.updateNodesInStorage(Some(newLeaf), Nil)
@@ -45,7 +45,7 @@ class ReadOnlyNodeStorageSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "be able to persist to underlying storage when Genesis loading" in new TestSetup {
-    val (nodeKey, _) = MptStorage.collapseNode(Some(newLeaf))._2.head
+    val (nodeKey, _) = SerializingMptStorage.collapseNode(Some(newLeaf))._2.head
     val readOnlyNodeStorage = cachedStateStorage.getReadOnlyStorage
 
     readOnlyNodeStorage.updateNodesInStorage(Some(newLeaf), Nil)

--- a/src/test/scala/io/iohk/ethereum/db/storage/ReferenceCountNodeStorageSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/db/storage/ReferenceCountNodeStorageSpec.scala
@@ -13,7 +13,6 @@ import org.scalatest.matchers.should.Matchers
 import io.iohk.ethereum.crypto.kec256
 import io.iohk.ethereum.db.cache.MapCache
 import io.iohk.ethereum.db.dataSource.EphemDataSource
-import io.iohk.ethereum.mpt.NodesKeyValueStorage
 import io.iohk.ethereum.utils.Config.NodeCacheConfig
 
 class ReferenceCountNodeStorageSpec extends AnyFlatSpec with Matchers {

--- a/src/test/scala/io/iohk/ethereum/db/storage/StateStorageSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/db/storage/StateStorageSpec.scala
@@ -20,7 +20,6 @@ import io.iohk.ethereum.db.storage.NodeStorage.NodeHash
 import io.iohk.ethereum.db.storage.pruning.ArchivePruning
 import io.iohk.ethereum.db.storage.pruning.BasicPruning
 import io.iohk.ethereum.db.storage.pruning.InMemoryPruning
-import io.iohk.ethereum.mpt.NodesKeyValueStorage
 import io.iohk.ethereum.utils.Config.NodeCacheConfig
 
 class StateStorageSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyChecks with ObjectGenerators {

--- a/src/test/scala/io/iohk/ethereum/domain/TransactionSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/domain/TransactionSpec.scala
@@ -14,7 +14,6 @@ import io.iohk.ethereum.crypto.pubKeyFromKeyPair
 import io.iohk.ethereum.domain.SignedTransaction.getSender
 import io.iohk.ethereum.network.p2p.messages.BaseETH6XMessages.SignedTransactions
 import io.iohk.ethereum.security.SecureRandomBuilder
-import io.iohk.ethereum.utils.Config
 import io.iohk.ethereum.utils.Hex
 
 class TransactionSpec


### PR DESCRIPTION
# Description

- Move `NodeKeyValueStorage` to `storage.db`
- Remove unused dependency on `InMemoryWorldStateStorage` in `Blockchain`
- Improve readability with `final` and `private` modifiers
- Add scaladoc, comments and typos

