### PR TITLE
[ETCM-1082] Add block metadata storage 

### DIFF
--- a/src/it/scala/io/iohk/ethereum/ledger/BlockImporterItSpec.scala
+++ b/src/it/scala/io/iohk/ethereum/ledger/BlockImporterItSpec.scala
@@ -246,9 +246,8 @@ class TestFixture extends TestSetupWithVmAndValidators {
         mining.blockPreparator,
         new BlockValidation(mining, blockchainReader, blockQueue)
       ) {
-        override def executeAndValidateBlock(
-            block: Block,
-            alreadyValidated: Boolean = false
+        override def executeAndBlock(
+            block: Block
         )(implicit blockchainConfig: BlockchainConfig): Either[BlockExecutionError, Seq[Receipt]] =
           Right(BlockResult(emptyWorld).receipts)
       }

--- a/src/it/scala/io/iohk/ethereum/sync/util/CommonFakePeer.scala
+++ b/src/it/scala/io/iohk/ethereum/sync/util/CommonFakePeer.scala
@@ -5,16 +5,20 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.time.Clock
 import java.util.concurrent.atomic.AtomicReference
+
 import akka.actor.ActorRef
 import akka.actor.ActorSystem
 import akka.testkit.TestProbe
 import akka.util.ByteString
 import akka.util.Timeout
+
 import monix.eval.Task
 
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.duration._
+
 import org.bouncycastle.crypto.AsymmetricCipherKeyPair
+
 import io.iohk.ethereum.Fixtures
 import io.iohk.ethereum.Timeouts
 import io.iohk.ethereum.blockchain.sync.BlockchainHostActor
@@ -32,15 +36,13 @@ import io.iohk.ethereum.db.storage.AppStateStorage
 import io.iohk.ethereum.db.storage.Namespaces
 import io.iohk.ethereum.db.storage.pruning.ArchivePruning
 import io.iohk.ethereum.db.storage.pruning.PruningMode
-import io.iohk.ethereum.domain.{
-  Block,
-  BlockMetadataProxy,
-  Blockchain,
-  BlockchainImpl,
-  BlockchainReader,
-  BlockchainWriter,
-  ChainWeight
-}
+import io.iohk.ethereum.domain.Block
+import io.iohk.ethereum.domain.BlockMetadataProxy
+import io.iohk.ethereum.domain.Blockchain
+import io.iohk.ethereum.domain.BlockchainImpl
+import io.iohk.ethereum.domain.BlockchainReader
+import io.iohk.ethereum.domain.BlockchainWriter
+import io.iohk.ethereum.domain.ChainWeight
 import io.iohk.ethereum.ledger.InMemoryWorldStateProxy
 import io.iohk.ethereum.mpt.MerklePatriciaTrie
 import io.iohk.ethereum.network.EtcPeerManagerActor

--- a/src/it/scala/io/iohk/ethereum/sync/util/CommonFakePeer.scala
+++ b/src/it/scala/io/iohk/ethereum/sync/util/CommonFakePeer.scala
@@ -5,20 +5,16 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.time.Clock
 import java.util.concurrent.atomic.AtomicReference
-
 import akka.actor.ActorRef
 import akka.actor.ActorSystem
 import akka.testkit.TestProbe
 import akka.util.ByteString
 import akka.util.Timeout
-
 import monix.eval.Task
 
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.duration._
-
 import org.bouncycastle.crypto.AsymmetricCipherKeyPair
-
 import io.iohk.ethereum.Fixtures
 import io.iohk.ethereum.Timeouts
 import io.iohk.ethereum.blockchain.sync.BlockchainHostActor
@@ -36,12 +32,15 @@ import io.iohk.ethereum.db.storage.AppStateStorage
 import io.iohk.ethereum.db.storage.Namespaces
 import io.iohk.ethereum.db.storage.pruning.ArchivePruning
 import io.iohk.ethereum.db.storage.pruning.PruningMode
-import io.iohk.ethereum.domain.Block
-import io.iohk.ethereum.domain.Blockchain
-import io.iohk.ethereum.domain.BlockchainImpl
-import io.iohk.ethereum.domain.BlockchainReader
-import io.iohk.ethereum.domain.BlockchainWriter
-import io.iohk.ethereum.domain.ChainWeight
+import io.iohk.ethereum.domain.{
+  Block,
+  BlockMetadataProxy,
+  Blockchain,
+  BlockchainImpl,
+  BlockchainReader,
+  BlockchainWriter,
+  ChainWeight
+}
 import io.iohk.ethereum.ledger.InMemoryWorldStateProxy
 import io.iohk.ethereum.mpt.MerklePatriciaTrie
 import io.iohk.ethereum.network.EtcPeerManagerActor
@@ -137,6 +136,7 @@ abstract class CommonFakePeer(peerName: String, fakePeerCustomConfig: FakePeerCu
     )
   )
 
+  val blockMetadataProxy: BlockMetadataProxy = new BlockMetadataProxy(storagesInstance.storages.blockMetadataStorage)
   val blockchainReader: BlockchainReader = BlockchainReader(storagesInstance.storages)
   val blockchainWriter: BlockchainWriter = BlockchainWriter(storagesInstance.storages)
   val bl: BlockchainImpl = BlockchainImpl(storagesInstance.storages, blockchainReader)

--- a/src/it/scala/io/iohk/ethereum/sync/util/RegularSyncItSpecUtils.scala
+++ b/src/it/scala/io/iohk/ethereum/sync/util/RegularSyncItSpecUtils.scala
@@ -109,6 +109,7 @@ object RegularSyncItSpecUtils {
     lazy val consensus: Consensus =
       new ConsensusImpl(
         bl,
+        blockMetadataProxy,
         blockchainReader,
         blockchainWriter,
         blockExecution

--- a/src/it/scala/io/iohk/ethereum/txExecTest/ContractTest.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/ContractTest.scala
@@ -32,13 +32,13 @@ class ContractTest extends AnyFlatSpec with Matchers {
         mining.blockPreparator,
         blockValidation
       )
-    blockExecution.executeAndValidateBlock(fixtures.blockByNumber(1)) shouldBe noErrors
+    blockExecution.executeAndBlock(fixtures.blockByNumber(1)) shouldBe noErrors
 
     // deploy contract
-    blockExecution.executeAndValidateBlock(fixtures.blockByNumber(2)) shouldBe noErrors
+    blockExecution.executeAndBlock(fixtures.blockByNumber(2)) shouldBe noErrors
 
     // execute contract call
     // execute contract that pays 2 accounts
-    blockExecution.executeAndValidateBlock(fixtures.blockByNumber(3)) shouldBe noErrors
+    blockExecution.executeAndBlock(fixtures.blockByNumber(3)) shouldBe noErrors
   }
 }

--- a/src/it/scala/io/iohk/ethereum/txExecTest/ECIP1017Test.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/ECIP1017Test.scala
@@ -77,7 +77,7 @@ class ECIP1017Test extends AnyFlatSpec with Matchers {
           mining.blockPreparator,
           blockValidation
         )
-      blockExecution.executeAndValidateBlock(fixtures.blockByNumber(blockToExecute)) shouldBe noErrors
+      blockExecution.executeAndBlock(fixtures.blockByNumber(blockToExecute)) shouldBe noErrors
     }
   }
 

--- a/src/it/scala/io/iohk/ethereum/txExecTest/ForksTest.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/ForksTest.scala
@@ -70,7 +70,7 @@ class ForksTest extends AnyFlatSpec with Matchers {
           mining.blockPreparator,
           blockValidation
         )
-      blockExecution.executeAndValidateBlock(fixtures.blockByNumber(blockToExecute)) shouldBe noErrors
+      blockExecution.executeAndBlock(fixtures.blockByNumber(blockToExecute)) shouldBe noErrors
     }
   }
 

--- a/src/it/scala/io/iohk/ethereum/txExecTest/util/DumpChainApp.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/util/DumpChainApp.scala
@@ -20,7 +20,7 @@ import io.iohk.ethereum.db.components.Storages
 import io.iohk.ethereum.db.components.Storages.PruningModeComponent
 import io.iohk.ethereum.db.storage.AppStateStorage
 import io.iohk.ethereum.db.storage.MptStorage
-import io.iohk.ethereum.db.storage.NodeStorage.NodeHash
+import io.iohk.ethereum.db.storage.StorageTypes.NodeHash
 import io.iohk.ethereum.db.storage.pruning.ArchivePruning
 import io.iohk.ethereum.db.storage.pruning.PruningMode
 import io.iohk.ethereum.domain.BlockHeader.HeaderExtraFields.HefEmpty

--- a/src/it/scala/io/iohk/ethereum/txExecTest/util/FixtureProvider.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/util/FixtureProvider.scala
@@ -12,7 +12,7 @@ import org.bouncycastle.util.encoders.Hex
 import io.iohk.ethereum.db.cache.AppCaches
 import io.iohk.ethereum.db.cache.LruCache
 import io.iohk.ethereum.db.components.EphemDataSourceComponent
-import io.iohk.ethereum.db.storage.NodeStorage.NodeHash
+import io.iohk.ethereum.db.storage.StorageTypes.NodeHash
 import io.iohk.ethereum.db.storage._
 import io.iohk.ethereum.db.storage.pruning.ArchivePruning
 import io.iohk.ethereum.db.storage.pruning.PruningMode

--- a/src/main/scala/io/iohk/ethereum/consensus/ConsensusAdapter.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/ConsensusAdapter.scala
@@ -1,10 +1,8 @@
 package io.iohk.ethereum.consensus
 
 import cats.data.NonEmptyList
-
 import monix.eval.Task
 import monix.execution.Scheduler
-
 import io.iohk.ethereum.blockchain.sync.regular.BlockEnqueued
 import io.iohk.ethereum.blockchain.sync.regular.BlockImportFailed
 import io.iohk.ethereum.blockchain.sync.regular.BlockImportFailedDueToMissingNode
@@ -19,9 +17,7 @@ import io.iohk.ethereum.consensus.Consensus.ExtendedCurrentBestBranch
 import io.iohk.ethereum.consensus.Consensus.ExtendedCurrentBestBranchPartially
 import io.iohk.ethereum.consensus.Consensus.KeptCurrentBestBranch
 import io.iohk.ethereum.consensus.Consensus.SelectedNewBestBranch
-import io.iohk.ethereum.domain.Block
-import io.iohk.ethereum.domain.BlockHeader
-import io.iohk.ethereum.domain.BlockchainReader
+import io.iohk.ethereum.domain.{Block, BlockHeader, BlockchainReader}
 import io.iohk.ethereum.ledger.BlockExecutionError.ValidationBeforeExecError
 import io.iohk.ethereum.ledger.BlockExecutionSuccess
 import io.iohk.ethereum.ledger.BlockQueue

--- a/src/main/scala/io/iohk/ethereum/consensus/ConsensusAdapter.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/ConsensusAdapter.scala
@@ -1,8 +1,10 @@
 package io.iohk.ethereum.consensus
 
 import cats.data.NonEmptyList
+
 import monix.eval.Task
 import monix.execution.Scheduler
+
 import io.iohk.ethereum.blockchain.sync.regular.BlockEnqueued
 import io.iohk.ethereum.blockchain.sync.regular.BlockImportFailed
 import io.iohk.ethereum.blockchain.sync.regular.BlockImportFailedDueToMissingNode
@@ -17,7 +19,9 @@ import io.iohk.ethereum.consensus.Consensus.ExtendedCurrentBestBranch
 import io.iohk.ethereum.consensus.Consensus.ExtendedCurrentBestBranchPartially
 import io.iohk.ethereum.consensus.Consensus.KeptCurrentBestBranch
 import io.iohk.ethereum.consensus.Consensus.SelectedNewBestBranch
-import io.iohk.ethereum.domain.{Block, BlockHeader, BlockchainReader}
+import io.iohk.ethereum.domain.Block
+import io.iohk.ethereum.domain.BlockHeader
+import io.iohk.ethereum.domain.BlockchainReader
 import io.iohk.ethereum.ledger.BlockExecutionError.ValidationBeforeExecError
 import io.iohk.ethereum.ledger.BlockExecutionSuccess
 import io.iohk.ethereum.ledger.BlockQueue

--- a/src/main/scala/io/iohk/ethereum/consensus/ConsensusImpl.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/ConsensusImpl.scala
@@ -1,22 +1,23 @@
 package io.iohk.ethereum.consensus
 
 import akka.util.ByteString
+
 import cats.data.NonEmptyList
 import cats.implicits._
+
 import monix.eval.Task
 import monix.execution.Scheduler
 
 import scala.annotation.tailrec
+
 import io.iohk.ethereum.consensus.Consensus._
 import io.iohk.ethereum.db.storage.BlockMetadata
-import io.iohk.ethereum.domain.{
-  Block,
-  BlockMetadataProxy,
-  BlockchainImpl,
-  BlockchainReader,
-  BlockchainWriter,
-  ChainWeight
-}
+import io.iohk.ethereum.domain.Block
+import io.iohk.ethereum.domain.BlockMetadataProxy
+import io.iohk.ethereum.domain.BlockchainImpl
+import io.iohk.ethereum.domain.BlockchainReader
+import io.iohk.ethereum.domain.BlockchainWriter
+import io.iohk.ethereum.domain.ChainWeight
 import io.iohk.ethereum.ledger.BlockData
 import io.iohk.ethereum.ledger.BlockExecution
 import io.iohk.ethereum.ledger.BlockExecutionError

--- a/src/main/scala/io/iohk/ethereum/consensus/ConsensusImpl.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/ConsensusImpl.scala
@@ -144,10 +144,12 @@ class ConsensusImpl(
   }
 
   private def setBlocksMetadata(blocks: List[BlockData]): Unit =
-    blocks
-      .map(block => blockMetadataProxy.putBlockMetadata(block.block.hash, BlockMetadata(isExecuted = true)))
-      .reduce((batchUpdate1, batchUpdate2) => batchUpdate1.and(batchUpdate2))
-      .commit()
+    if (blocks.nonEmpty) {
+      blocks
+        .map(block => blockMetadataProxy.putBlockMetadata(block.block.hash, BlockMetadata(isExecuted = true)))
+        .reduce((batchUpdate1, batchUpdate2) => batchUpdate1.and(batchUpdate2))
+        .commit()
+    }
 
   private def saveLastBlock(blocks: List[BlockData]): Unit = blocks.lastOption.foreach(b =>
     blockchainWriter.saveBestKnownBlocks(

--- a/src/main/scala/io/iohk/ethereum/consensus/ConsensusImpl.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/ConsensusImpl.scala
@@ -109,7 +109,7 @@ class ConsensusImpl(
   private def importToTop(branch: NonEmptyList[Block], currentBestBlockWeight: ChainWeight)(implicit
       blockchainConfig: BlockchainConfig
   ): ConsensusResult =
-    blockExecution.executeAndValidateBlocks(branch.toList, currentBestBlockWeight) match {
+    blockExecution.executeBlocks(branch.toList, currentBestBlockWeight) match {
       case (importedBlocks, None) =>
         saveLastBlock(importedBlocks)
         ExtendedCurrentBestBranch(importedBlocks)
@@ -205,7 +205,7 @@ class ConsensusImpl(
   )(implicit
       blockchainConfig: BlockchainConfig
   ): Either[(List[BlockData], BlockExecutionError), (List[Block], List[Block], List[ChainWeight])] = {
-    val (executedBlocks, maybeError) = blockExecution.executeAndValidateBlocks(newBranch, parentWeight)
+    val (executedBlocks, maybeError) = blockExecution.executeBlocks(newBranch, parentWeight)
     executedBlocks.lastOption.foreach(b =>
       blockchainWriter.saveBestKnownBlocks(
         b.block.hash,

--- a/src/main/scala/io/iohk/ethereum/consensus/mining/TestMiningBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/mining/TestMiningBuilder.scala
@@ -18,6 +18,7 @@ trait StdTestMiningBuilder
     with VmBuilder
     with VmConfigBuilder
     with ActorSystemBuilder
+    with BlockMetadataProxyBuilder
     with BlockchainBuilder
     with BlockQueueBuilder
     with ConsensusBuilder

--- a/src/main/scala/io/iohk/ethereum/db/cache/AppCaches.scala
+++ b/src/main/scala/io/iohk/ethereum/db/cache/AppCaches.scala
@@ -1,7 +1,7 @@
 package io.iohk.ethereum.db.cache
 
-import io.iohk.ethereum.db.storage.NodeStorage.NodeEncoded
-import io.iohk.ethereum.db.storage.NodeStorage.NodeHash
+import io.iohk.ethereum.db.storage.StorageTypes.NodeEncoded
+import io.iohk.ethereum.db.storage.StorageTypes.NodeHash
 import io.iohk.ethereum.utils.Config
 
 trait AppCaches extends CacheComponent {

--- a/src/main/scala/io/iohk/ethereum/db/cache/CacheComponent.scala
+++ b/src/main/scala/io/iohk/ethereum/db/cache/CacheComponent.scala
@@ -1,11 +1,12 @@
 package io.iohk.ethereum.db.cache
 
-import io.iohk.ethereum.db.storage.NodeStorage
+import io.iohk.ethereum.db.storage.StorageTypes.NodeEncoded
+import io.iohk.ethereum.db.storage.StorageTypes.NodeHash
 
 trait CacheComponent {
   val caches: Caches
 
   trait Caches {
-    val nodeCache: Cache[NodeStorage.NodeHash, NodeStorage.NodeEncoded]
+    val nodeCache: Cache[NodeHash, NodeEncoded]
   }
 }

--- a/src/main/scala/io/iohk/ethereum/db/components/Storages.scala
+++ b/src/main/scala/io/iohk/ethereum/db/components/Storages.scala
@@ -2,7 +2,7 @@ package io.iohk.ethereum.db.components
 
 import io.iohk.ethereum.db.cache.AppCaches
 import io.iohk.ethereum.db.cache.LruCache
-import io.iohk.ethereum.db.storage.NodeStorage.NodeHash
+import io.iohk.ethereum.db.storage.StorageTypes.NodeHash
 import io.iohk.ethereum.db.storage._
 import io.iohk.ethereum.db.storage.pruning.PruningMode
 import io.iohk.ethereum.utils.Config

--- a/src/main/scala/io/iohk/ethereum/db/components/Storages.scala
+++ b/src/main/scala/io/iohk/ethereum/db/components/Storages.scala
@@ -54,6 +54,7 @@ object Storages {
           )
         )
 
+      override val blockMetadataStorage: BlockMetadataStorage = new BlockMetadataStorage(dataSource)
     }
   }
 }

--- a/src/main/scala/io/iohk/ethereum/db/components/StoragesComponent.scala
+++ b/src/main/scala/io/iohk/ethereum/db/components/StoragesComponent.scala
@@ -10,6 +10,8 @@ trait StoragesComponent {
 
   trait Storages extends BlockchainStorages {
 
+    val blockMetadataStorage: BlockMetadataStorage
+
     val blockHeadersStorage: BlockHeadersStorage
 
     val blockBodiesStorage: BlockBodiesStorage

--- a/src/main/scala/io/iohk/ethereum/db/storage/ArchiveNodeStorage.scala
+++ b/src/main/scala/io/iohk/ethereum/db/storage/ArchiveNodeStorage.scala
@@ -1,7 +1,7 @@
 package io.iohk.ethereum.db.storage
 
-import io.iohk.ethereum.db.storage.NodeStorage.NodeEncoded
-import io.iohk.ethereum.db.storage.NodeStorage.NodeHash
+import io.iohk.ethereum.db.storage.StorageTypes.NodeEncoded
+import io.iohk.ethereum.db.storage.StorageTypes.NodeHash
 import io.iohk.ethereum.mpt.NodesKeyValueStorage
 
 /** This class is used to store Nodes (defined in mpt/Node.scala), by using:

--- a/src/main/scala/io/iohk/ethereum/db/storage/BlockBodiesStorage.scala
+++ b/src/main/scala/io/iohk/ethereum/db/storage/BlockBodiesStorage.scala
@@ -6,7 +6,7 @@ import boopickle.Default.Pickle
 import boopickle.Default.Unpickle
 
 import io.iohk.ethereum.db.dataSource.DataSource
-import io.iohk.ethereum.db.storage.BlockBodiesStorage.BlockBodyHash
+import io.iohk.ethereum.db.storage.StorageTypes.BlockBodyHash
 import io.iohk.ethereum.domain.BlockBody
 import io.iohk.ethereum.utils.ByteUtils.byteSequenceToBuffer
 import io.iohk.ethereum.utils.ByteUtils.compactPickledBytes
@@ -17,7 +17,6 @@ import io.iohk.ethereum.utils.Picklers._
   *   Value: the block body
   */
 class BlockBodiesStorage(val dataSource: DataSource) extends TransactionalKeyValueStorage[BlockBodyHash, BlockBody] {
-  import BlockBodiesStorage._
 
   override val namespace: IndexedSeq[Byte] = Namespaces.BodyNamespace
 
@@ -30,8 +29,4 @@ class BlockBodiesStorage(val dataSource: DataSource) extends TransactionalKeyVal
 
   override def valueDeserializer: IndexedSeq[Byte] => BlockBody =
     (byteSequenceToBuffer _).andThen(Unpickle[BlockBody].fromBytes)
-}
-
-object BlockBodiesStorage {
-  type BlockBodyHash = ByteString
 }

--- a/src/main/scala/io/iohk/ethereum/db/storage/BlockHeadersStorage.scala
+++ b/src/main/scala/io/iohk/ethereum/db/storage/BlockHeadersStorage.scala
@@ -6,7 +6,7 @@ import boopickle.Default.Pickle
 import boopickle.Default.Unpickle
 
 import io.iohk.ethereum.db.dataSource.DataSource
-import io.iohk.ethereum.db.storage.BlockHeadersStorage.BlockHeaderHash
+import io.iohk.ethereum.db.storage.StorageTypes.BlockHeaderHash
 import io.iohk.ethereum.domain.BlockHeader
 import io.iohk.ethereum.utils.ByteUtils.byteSequenceToBuffer
 import io.iohk.ethereum.utils.ByteUtils.compactPickledBytes
@@ -18,8 +18,6 @@ import io.iohk.ethereum.utils.Picklers._
   */
 class BlockHeadersStorage(val dataSource: DataSource)
     extends TransactionalKeyValueStorage[BlockHeaderHash, BlockHeader] {
-
-  import BlockHeadersStorage._
 
   override val namespace: IndexedSeq[Byte] = Namespaces.HeaderNamespace
 
@@ -33,8 +31,4 @@ class BlockHeadersStorage(val dataSource: DataSource)
   override def valueDeserializer: IndexedSeq[Byte] => BlockHeader =
     // TODO: consider reusing this formula in other storages: ETCM-322
     (byteSequenceToBuffer _).andThen(Unpickle[BlockHeader].fromBytes)
-}
-
-object BlockHeadersStorage {
-  type BlockHeaderHash = ByteString
 }

--- a/src/main/scala/io/iohk/ethereum/db/storage/BlockMetadataStorage.scala
+++ b/src/main/scala/io/iohk/ethereum/db/storage/BlockMetadataStorage.scala
@@ -1,10 +1,13 @@
 package io.iohk.ethereum.db.storage
 
 import akka.util.ByteString
+
 import boopickle.Default._
+
 import io.iohk.ethereum.db.dataSource.DataSource
 import io.iohk.ethereum.db.storage.StorageTypes.BlockHash
-import io.iohk.ethereum.utils.ByteUtils.{byteSequenceToBuffer, compactPickledBytes}
+import io.iohk.ethereum.utils.ByteUtils.byteSequenceToBuffer
+import io.iohk.ethereum.utils.ByteUtils.compactPickledBytes
 
 case class BlockMetadata(isExecuted: Boolean)
 

--- a/src/main/scala/io/iohk/ethereum/db/storage/BlockMetadataStorage.scala
+++ b/src/main/scala/io/iohk/ethereum/db/storage/BlockMetadataStorage.scala
@@ -1,0 +1,23 @@
+package io.iohk.ethereum.db.storage
+
+import akka.util.ByteString
+import boopickle.Default._
+import io.iohk.ethereum.db.dataSource.DataSource
+import io.iohk.ethereum.db.storage.StorageTypes.BlockHash
+import io.iohk.ethereum.utils.ByteUtils.{byteSequenceToBuffer, compactPickledBytes}
+
+case class BlockMetadata(isExecuted: Boolean)
+
+class BlockMetadataStorage(val dataSource: DataSource) extends TransactionalKeyValueStorage[BlockHash, BlockMetadata] {
+  override val namespace: IndexedSeq[Byte] = Namespaces.HeightsNamespace
+
+  override def keySerializer: BlockHash => IndexedSeq[Byte] = identity
+
+  override def keyDeserializer: IndexedSeq[Byte] => BlockHash = bytes => ByteString(bytes.toArray[Byte])
+
+  override def valueSerializer: BlockMetadata => IndexedSeq[Byte] =
+    (Pickle.intoBytes[BlockMetadata] _).andThen(compactPickledBytes)
+
+  override def valueDeserializer: IndexedSeq[Byte] => BlockMetadata =
+    (byteSequenceToBuffer _).andThen(Unpickle[BlockMetadata].fromBytes)
+}

--- a/src/main/scala/io/iohk/ethereum/db/storage/BlockNumberMappingStorage.scala
+++ b/src/main/scala/io/iohk/ethereum/db/storage/BlockNumberMappingStorage.scala
@@ -7,17 +7,16 @@ import akka.util.ByteString
 import scala.collection.immutable.ArraySeq
 
 import io.iohk.ethereum.db.dataSource.DataSource
-import io.iohk.ethereum.db.storage.BlockHeadersStorage.BlockHeaderHash
+import io.iohk.ethereum.db.storage.StorageTypes.BlockHash
 
-class BlockNumberMappingStorage(val dataSource: DataSource)
-    extends TransactionalKeyValueStorage[BigInt, BlockHeaderHash] {
+class BlockNumberMappingStorage(val dataSource: DataSource) extends TransactionalKeyValueStorage[BigInt, BlockHash] {
   override val namespace: IndexedSeq[Byte] = Namespaces.HeightsNamespace
 
-  override def keySerializer: (BigInt) => IndexedSeq[Byte] = index => ArraySeq.unsafeWrapArray(index.toByteArray)
+  override def keySerializer: BigInt => IndexedSeq[Byte] = index => ArraySeq.unsafeWrapArray(index.toByteArray)
 
   override def keyDeserializer: IndexedSeq[Byte] => BigInt = bytes => new BigInt(new BigInteger(bytes.toArray))
 
-  override def valueSerializer: (BlockHeaderHash) => IndexedSeq[Byte] = identity
+  override def valueSerializer: BlockHash => IndexedSeq[Byte] = identity
 
-  override def valueDeserializer: (IndexedSeq[Byte]) => BlockHeaderHash = arr => ByteString(arr.toArray[Byte])
+  override def valueDeserializer: IndexedSeq[Byte] => BlockHash = arr => ByteString(arr.toArray[Byte])
 }

--- a/src/main/scala/io/iohk/ethereum/db/storage/CachedReferenceCountedStorage.scala
+++ b/src/main/scala/io/iohk/ethereum/db/storage/CachedReferenceCountedStorage.scala
@@ -10,8 +10,8 @@ import boopickle.Default._
 import com.google.common.cache.RemovalNotification
 
 import io.iohk.ethereum.db.cache.Cache
-import io.iohk.ethereum.db.storage.NodeStorage.NodeEncoded
-import io.iohk.ethereum.db.storage.NodeStorage.NodeHash
+import io.iohk.ethereum.db.storage.StorageTypes.NodeEncoded
+import io.iohk.ethereum.db.storage.StorageTypes.NodeHash
 import io.iohk.ethereum.mpt.ByteArraySerializable
 import io.iohk.ethereum.mpt.NodesKeyValueStorage
 

--- a/src/main/scala/io/iohk/ethereum/db/storage/ChainWeightStorage.scala
+++ b/src/main/scala/io/iohk/ethereum/db/storage/ChainWeightStorage.scala
@@ -5,7 +5,7 @@ import akka.util.ByteString
 import boopickle.Default._
 
 import io.iohk.ethereum.db.dataSource.DataSource
-import io.iohk.ethereum.db.storage.ChainWeightStorage._
+import io.iohk.ethereum.db.storage.StorageTypes.BlockHash
 import io.iohk.ethereum.domain.ChainWeight
 import io.iohk.ethereum.utils.ByteUtils.byteSequenceToBuffer
 import io.iohk.ethereum.utils.ByteUtils.compactPickledBytes
@@ -21,8 +21,4 @@ class ChainWeightStorage(val dataSource: DataSource) extends TransactionalKeyVal
   val valueSerializer: ChainWeight => IndexedSeq[Byte] = (Pickle.intoBytes[ChainWeight] _).andThen(compactPickledBytes)
   val valueDeserializer: IndexedSeq[Byte] => ChainWeight =
     (byteSequenceToBuffer _).andThen(Unpickle[ChainWeight].fromBytes)
-}
-
-object ChainWeightStorage {
-  type BlockHash = ByteString
 }

--- a/src/main/scala/io/iohk/ethereum/db/storage/FastSyncNodeStorage.scala
+++ b/src/main/scala/io/iohk/ethereum/db/storage/FastSyncNodeStorage.scala
@@ -2,8 +2,8 @@ package io.iohk.ethereum.db.storage
 
 import akka.util.ByteString
 
-import io.iohk.ethereum.db.storage.NodeStorage.NodeEncoded
-import io.iohk.ethereum.db.storage.NodeStorage.NodeHash
+import io.iohk.ethereum.db.storage.StorageTypes.NodeEncoded
+import io.iohk.ethereum.db.storage.StorageTypes.NodeHash
 import io.iohk.ethereum.db.storage.encoding._
 
 /** This class is specialization of ReferenceCountNodeStorage.

--- a/src/main/scala/io/iohk/ethereum/db/storage/MptStorage.scala
+++ b/src/main/scala/io/iohk/ethereum/db/storage/MptStorage.scala
@@ -2,7 +2,7 @@ package io.iohk.ethereum.db.storage
 
 import akka.util.ByteString
 
-import io.iohk.ethereum.db.storage.NodeStorage.NodeEncoded
+import io.iohk.ethereum.db.storage.StorageTypes.NodeEncoded
 import io.iohk.ethereum.mpt.MerklePatriciaTrie.MissingRootNodeException
 import io.iohk.ethereum.mpt.MptNode
 import io.iohk.ethereum.mpt.MptTraversals

--- a/src/main/scala/io/iohk/ethereum/db/storage/NodeStorage.scala
+++ b/src/main/scala/io/iohk/ethereum/db/storage/NodeStorage.scala
@@ -8,8 +8,8 @@ import io.iohk.ethereum.db.cache.Cache
 import io.iohk.ethereum.db.dataSource.DataSource
 import io.iohk.ethereum.db.dataSource.DataSourceUpdateOptimized
 import io.iohk.ethereum.db.dataSource.RocksDbDataSource.IterationError
-import io.iohk.ethereum.db.storage.NodeStorage.NodeEncoded
-import io.iohk.ethereum.db.storage.NodeStorage.NodeHash
+import io.iohk.ethereum.db.storage.StorageTypes.NodeEncoded
+import io.iohk.ethereum.db.storage.StorageTypes.NodeHash
 
 sealed trait NodesStorage extends {
   def get(key: NodeHash): Option[NodeEncoded]
@@ -71,9 +71,4 @@ class CachedNodeStorage(val storage: NodeStorage, val cache: Cache[NodeHash, Nod
   override type I = NodeStorage
   override def apply(cache: Cache[NodeHash, NodeEncoded], storage: NodeStorage): CachedNodeStorage =
     new CachedNodeStorage(storage, cache)
-}
-
-object NodeStorage {
-  type NodeHash = ByteString
-  type NodeEncoded = Array[Byte]
 }

--- a/src/main/scala/io/iohk/ethereum/db/storage/ReadOnlyNodeStorage.scala
+++ b/src/main/scala/io/iohk/ethereum/db/storage/ReadOnlyNodeStorage.scala
@@ -2,8 +2,8 @@ package io.iohk.ethereum.db.storage
 
 import scala.collection.mutable
 
-import io.iohk.ethereum.db.storage.NodeStorage.NodeEncoded
-import io.iohk.ethereum.db.storage.NodeStorage.NodeHash
+import io.iohk.ethereum.db.storage.StorageTypes.NodeEncoded
+import io.iohk.ethereum.db.storage.StorageTypes.NodeHash
 import io.iohk.ethereum.mpt.NodesKeyValueStorage
 
 /** This storage allows to read from another NodesKeyValueStorage but doesn't remove or upsert into database.

--- a/src/main/scala/io/iohk/ethereum/db/storage/ReceiptStorage.scala
+++ b/src/main/scala/io/iohk/ethereum/db/storage/ReceiptStorage.scala
@@ -7,7 +7,7 @@ import boopickle.Default.Unpickle
 import boopickle.DefaultBasic._
 
 import io.iohk.ethereum.db.dataSource.DataSource
-import io.iohk.ethereum.db.storage.ReceiptStorage._
+import io.iohk.ethereum.db.storage.StorageTypes.BlockHash
 import io.iohk.ethereum.domain.Address
 import io.iohk.ethereum.domain.SuccessOutcome
 import io.iohk.ethereum.domain._
@@ -29,17 +29,14 @@ class ReceiptStorage(val dataSource: DataSource) extends TransactionalKeyValueSt
   // FIXME: perhaps we should just operate on ByteString to avoid such strange conversions: ETCM-322
   override def keyDeserializer: IndexedSeq[Byte] => BlockHash = k => ByteString.fromArrayUnsafe(k.toArray)
 
-  override def valueSerializer: ReceiptSeq => IndexedSeq[Byte] = receipts =>
+  override def valueSerializer: Seq[Receipt] => IndexedSeq[Byte] = receipts =>
     compactPickledBytes(Pickle.intoBytes(receipts))
 
-  override def valueDeserializer: IndexedSeq[Byte] => ReceiptSeq =
+  override def valueDeserializer: IndexedSeq[Byte] => Seq[Receipt] =
     (byteSequenceToBuffer _).andThen(Unpickle[Seq[Receipt]].fromBytes)
 }
 
 object ReceiptStorage {
-  type BlockHash = ByteString
-  type ReceiptSeq = Seq[Receipt]
-
   implicit val byteStringPickler: Pickler[ByteString] =
     transformPickler[ByteString, Array[Byte]](ByteString(_))(_.toArray[Byte])
   implicit val hashOutcomePickler: Pickler[HashOutcome] = transformPickler[HashOutcome, ByteString] { hash =>

--- a/src/main/scala/io/iohk/ethereum/db/storage/ReferenceCountNodeStorage.scala
+++ b/src/main/scala/io/iohk/ethereum/db/storage/ReferenceCountNodeStorage.scala
@@ -2,8 +2,8 @@ package io.iohk.ethereum.db.storage
 
 import akka.util.ByteString
 
-import io.iohk.ethereum.db.storage.NodeStorage.NodeEncoded
-import io.iohk.ethereum.db.storage.NodeStorage.NodeHash
+import io.iohk.ethereum.db.storage.StorageTypes.NodeEncoded
+import io.iohk.ethereum.db.storage.StorageTypes.NodeHash
 import io.iohk.ethereum.db.storage.pruning.PruneSupport
 import io.iohk.ethereum.mpt.NodesKeyValueStorage
 import io.iohk.ethereum.utils.Logger

--- a/src/main/scala/io/iohk/ethereum/db/storage/StateStorage.scala
+++ b/src/main/scala/io/iohk/ethereum/db/storage/StateStorage.scala
@@ -8,10 +8,10 @@ import io.iohk.ethereum.db.cache.LruCache
 import io.iohk.ethereum.db.cache.MapCache
 import io.iohk.ethereum.db.dataSource.DataSource
 import io.iohk.ethereum.db.dataSource.EphemDataSource
-import io.iohk.ethereum.db.storage.NodeStorage.NodeEncoded
-import io.iohk.ethereum.db.storage.NodeStorage.NodeHash
 import io.iohk.ethereum.db.storage.StateStorage.FlushSituation
 import io.iohk.ethereum.db.storage.StateStorage.GenesisDataLoad
+import io.iohk.ethereum.db.storage.StorageTypes.NodeEncoded
+import io.iohk.ethereum.db.storage.StorageTypes.NodeHash
 import io.iohk.ethereum.db.storage.pruning.ArchivePruning
 import io.iohk.ethereum.db.storage.pruning.PruningMode
 import io.iohk.ethereum.mpt.MptNode

--- a/src/main/scala/io/iohk/ethereum/db/storage/StorageTypes.scala
+++ b/src/main/scala/io/iohk/ethereum/db/storage/StorageTypes.scala
@@ -1,0 +1,11 @@
+package io.iohk.ethereum.db.storage
+
+import akka.util.ByteString
+
+object StorageTypes {
+  type BlockHash = ByteString
+  type BlockHeaderHash = ByteString
+  type BlockBodyHash = ByteString
+  type NodeHash = ByteString
+  type NodeEncoded = Array[Byte]
+}

--- a/src/main/scala/io/iohk/ethereum/domain/BlockMetadataProxy.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/BlockMetadataProxy.scala
@@ -1,0 +1,29 @@
+package io.iohk.ethereum.domain
+
+import io.iohk.ethereum.db.dataSource.DataSourceBatchUpdate
+import io.iohk.ethereum.db.storage
+import io.iohk.ethereum.db.storage.{BlockMetadata, BlockMetadataStorage}
+import io.iohk.ethereum.db.storage.StorageTypes.BlockHash
+
+/** Proxy with the BlockMetadataStorage
+  * When calling a put method a call to commit() is needed in order to persist the data
+  * @param blockMetadataStorage BlockMetadataStorage instance
+  */
+class BlockMetadataProxy(blockMetadataStorage: BlockMetadataStorage) {
+
+  def getBlockMetadata(blockHash: BlockHash): Option[storage.BlockMetadata] = blockMetadataStorage.get(blockHash)
+
+  def putBlockMetadata(blockHash: BlockHash, blockMetadata: BlockMetadata): DataSourceBatchUpdate =
+    blockMetadataStorage.put(blockHash, blockMetadata)
+
+  def getBlockIsExecuted(blockHash: BlockHash): Boolean =
+    blockMetadataStorage.get(blockHash).exists(_.isExecuted)
+
+  def putBlockIsExecuted(blockHash: BlockHash, isExecuted: Boolean): DataSourceBatchUpdate =
+    blockMetadataStorage
+      .get(blockHash)
+      .fold(
+        blockMetadataStorage
+          .put(blockHash, BlockMetadata(isExecuted = isExecuted))
+      )(metadata => blockMetadataStorage.put(blockHash, metadata.copy(isExecuted = isExecuted)))
+}

--- a/src/main/scala/io/iohk/ethereum/domain/BlockMetadataProxy.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/BlockMetadataProxy.scala
@@ -2,7 +2,8 @@ package io.iohk.ethereum.domain
 
 import io.iohk.ethereum.db.dataSource.DataSourceBatchUpdate
 import io.iohk.ethereum.db.storage
-import io.iohk.ethereum.db.storage.{BlockMetadata, BlockMetadataStorage}
+import io.iohk.ethereum.db.storage.BlockMetadata
+import io.iohk.ethereum.db.storage.BlockMetadataStorage
 import io.iohk.ethereum.db.storage.StorageTypes.BlockHash
 
 /** Proxy with the BlockMetadataStorage

--- a/src/main/scala/io/iohk/ethereum/domain/BlockchainReader.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/BlockchainReader.scala
@@ -1,7 +1,6 @@
 package io.iohk.ethereum.domain
 
 import akka.util.ByteString
-
 import io.iohk.ethereum.db.storage.AppStateStorage
 import io.iohk.ethereum.db.storage.BlockBodiesStorage
 import io.iohk.ethereum.db.storage.BlockHeadersStorage
@@ -12,6 +11,7 @@ import io.iohk.ethereum.db.storage.StateStorage
 import io.iohk.ethereum.domain.branch.BestBranch
 import io.iohk.ethereum.domain.branch.Branch
 import io.iohk.ethereum.domain.branch.EmptyBranch
+import io.iohk.ethereum.ledger.BlockData
 import io.iohk.ethereum.mpt.MerklePatriciaTrie
 import io.iohk.ethereum.mpt.MptNode
 import io.iohk.ethereum.utils.Hex
@@ -26,6 +26,17 @@ class BlockchainReader(
     appStateStorage: AppStateStorage,
     chainWeightStorage: ChainWeightStorage
 ) extends Logger {
+
+  /** Assemble the BlockData that should be available after a block gets executed
+    * @param block block to get the BlockData from
+    * @return
+    */
+  def getBlockData(block: Block): BlockData =
+    BlockData(
+      block,
+      receiptStorage.get(block.hash).getOrElse(Seq.empty),
+      chainWeightStorage.get(block.hash).getOrElse(ChainWeight.zero)
+    )
 
   /** Allows to query a blockHeader by block hash
     *

--- a/src/main/scala/io/iohk/ethereum/domain/BlockchainReader.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/BlockchainReader.scala
@@ -1,6 +1,7 @@
 package io.iohk.ethereum.domain
 
 import akka.util.ByteString
+
 import io.iohk.ethereum.db.storage.AppStateStorage
 import io.iohk.ethereum.db.storage.BlockBodiesStorage
 import io.iohk.ethereum.db.storage.BlockHeadersStorage

--- a/src/main/scala/io/iohk/ethereum/ledger/BlockExecution.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/BlockExecution.scala
@@ -22,26 +22,18 @@ class BlockExecution(
     blockValidation: BlockValidation
 ) extends Logger {
 
-  /** Executes and validate a block
-    *
-    * @param alreadyValidated should we skip pre-execution validation (if the block has already been validated,
-    *                         eg. in the importBlock method)
+  /** Executes a block
     */
-  def executeAndValidateBlock(
-      block: Block,
-      alreadyValidated: Boolean = false
+  def executeAndBlock(
+      block: Block
   )(implicit blockchainConfig: BlockchainConfig): Either[BlockExecutionError, Seq[Receipt]] = {
-    val preExecValidationResult =
-      if (alreadyValidated) Right(block) else blockValidation.validateBlockBeforeExecution(block)
-
     val blockExecResult = {
       if (block.hasCheckpoint) {
         // block with checkpoint is not executed normally - it's not need to do after execution validation
-        preExecValidationResult.map(_ => Seq.empty[Receipt])
+        Right(Seq.empty[Receipt])
       } else {
         for {
-          _ <- preExecValidationResult
-          result <- executeBlock(block)
+          result <- doBlockExecution(block)
           _ <- blockValidation.validateBlockAfterExecution(
             block,
             result.worldState.stateRootHash,
@@ -60,7 +52,7 @@ class BlockExecution(
   }
 
   /** Executes a block (executes transactions and pays rewards) */
-  private def executeBlock(
+  private def doBlockExecution(
       block: Block
   )(implicit blockchainConfig: BlockchainConfig): Either[BlockExecutionError, BlockResult] =
     for {
@@ -146,7 +138,7 @@ class BlockExecution(
       case None => worldState
     }
 
-  /** Executes and validates a list of blocks, storing the results in the blockchain.
+  /** Executes a list of blocks, storing the results in the blockchain.
     *
     * @param blocks   blocks to be executed
     * @param parentChainWeight parent weight
@@ -154,7 +146,7 @@ class BlockExecution(
     * @return a list of blocks in incremental order that were correctly executed and an optional
     *         [[io.iohk.ethereum.ledger.BlockExecutionError]]
     */
-  def executeAndValidateBlocks(
+  def executeBlocks(
       blocks: List[Block],
       parentChainWeight: ChainWeight
   )(implicit blockchainConfig: BlockchainConfig): (List[BlockData], Option[BlockExecutionError]) = {
@@ -168,7 +160,7 @@ class BlockExecution(
         (executedBlocksDecOrder.reverse, None)
       } else {
         val blockToExecute = remainingBlocksIncOrder.head
-        executeAndValidateBlock(blockToExecute, alreadyValidated = true) match {
+        executeAndBlock(blockToExecute) match {
           case Right(receipts) =>
             val newWeight = parentWeight.increase(blockToExecute.header)
             val newBlockData = BlockData(blockToExecute, receipts, newWeight)

--- a/src/main/scala/io/iohk/ethereum/mpt/MerklePatriciaTrie.scala
+++ b/src/main/scala/io/iohk/ethereum/mpt/MerklePatriciaTrie.scala
@@ -8,8 +8,8 @@ import org.bouncycastle.util.encoders.Hex
 
 import io.iohk.ethereum.common.SimpleMap
 import io.iohk.ethereum.db.storage.MptStorage
-import io.iohk.ethereum.db.storage.NodeStorage.NodeEncoded
-import io.iohk.ethereum.db.storage.NodeStorage.NodeHash
+import io.iohk.ethereum.db.storage.StorageTypes.NodeEncoded
+import io.iohk.ethereum.db.storage.StorageTypes.NodeHash
 import io.iohk.ethereum.mpt
 import io.iohk.ethereum.rlp.RLPImplicits._
 import io.iohk.ethereum.rlp.{encode => encodeRLP}

--- a/src/main/scala/io/iohk/ethereum/mpt/MptTraversals.scala
+++ b/src/main/scala/io/iohk/ethereum/mpt/MptTraversals.scala
@@ -3,7 +3,7 @@ package io.iohk.ethereum.mpt
 import akka.util.ByteString
 
 import io.iohk.ethereum.db.storage.MptStorage
-import io.iohk.ethereum.db.storage.NodeStorage.NodeEncoded
+import io.iohk.ethereum.db.storage.StorageTypes.NodeEncoded
 import io.iohk.ethereum.mpt.MerklePatriciaTrie.MPTException
 import io.iohk.ethereum.mpt.MptVisitors._
 import io.iohk.ethereum.rlp.RLPEncodeable

--- a/src/main/scala/io/iohk/ethereum/mpt/MptVisitors/MptConstructionVisitor.scala
+++ b/src/main/scala/io/iohk/ethereum/mpt/MptVisitors/MptConstructionVisitor.scala
@@ -1,7 +1,7 @@
 package io.iohk.ethereum.mpt.MptVisitors
 
 import io.iohk.ethereum.db.storage.MptStorage
-import io.iohk.ethereum.db.storage.NodeStorage.NodeHash
+import io.iohk.ethereum.db.storage.StorageTypes.NodeHash
 import io.iohk.ethereum.mpt.BranchNode
 import io.iohk.ethereum.mpt.ExtensionNode
 import io.iohk.ethereum.mpt.HashNode

--- a/src/main/scala/io/iohk/ethereum/mpt/MptVisitors/RlpEncVisitor.scala
+++ b/src/main/scala/io/iohk/ethereum/mpt/MptVisitors/RlpEncVisitor.scala
@@ -4,7 +4,7 @@ import java.util
 
 import scala.collection.immutable.ArraySeq
 
-import io.iohk.ethereum.db.storage.NodeStorage.NodeHash
+import io.iohk.ethereum.db.storage.StorageTypes.NodeHash
 import io.iohk.ethereum.mpt.BranchNode
 import io.iohk.ethereum.mpt.ExtensionNode
 import io.iohk.ethereum.mpt.HashNode

--- a/src/main/scala/io/iohk/ethereum/mpt/MptVisitors/RlpHashingVisitor.scala
+++ b/src/main/scala/io/iohk/ethereum/mpt/MptVisitors/RlpHashingVisitor.scala
@@ -2,8 +2,8 @@ package io.iohk.ethereum.mpt.MptVisitors
 
 import akka.util.ByteString
 
-import io.iohk.ethereum.db.storage.NodeStorage.NodeEncoded
-import io.iohk.ethereum.db.storage.NodeStorage.NodeHash
+import io.iohk.ethereum.db.storage.StorageTypes.NodeEncoded
+import io.iohk.ethereum.db.storage.StorageTypes.NodeHash
 import io.iohk.ethereum.mpt.BranchNode
 import io.iohk.ethereum.mpt.ExtensionNode
 import io.iohk.ethereum.mpt.HashNode

--- a/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
@@ -173,6 +173,14 @@ trait NodeStatusBuilder {
   lazy val nodeStatusHolder = new AtomicReference(nodeStatus)
 }
 
+trait BlockMetadataProxyBuilder {
+  self: StorageBuilder =>
+
+  lazy val blockMetadataProxy: BlockMetadataProxy = new BlockMetadataProxy(
+    storagesInstance.storages.blockMetadataStorage
+  )
+}
+
 trait BlockchainBuilder {
   self: StorageBuilder =>
 
@@ -188,7 +196,12 @@ trait BlockQueueBuilder {
 }
 
 trait ConsensusBuilder {
-  self: BlockchainBuilder with BlockQueueBuilder with MiningBuilder with ActorSystemBuilder with StorageBuilder =>
+  self: BlockMetadataProxyBuilder
+    with BlockchainBuilder
+    with BlockQueueBuilder
+    with MiningBuilder
+    with ActorSystemBuilder
+    with StorageBuilder =>
 
   lazy val blockValidation = new BlockValidation(mining, blockchainReader, blockQueue)
   lazy val blockExecution = new BlockExecution(
@@ -203,6 +216,7 @@ trait ConsensusBuilder {
   lazy val consensus: Consensus =
     new ConsensusImpl(
       blockchain,
+      blockMetadataProxy,
       blockchainReader,
       blockchainWriter,
       blockExecution
@@ -851,6 +865,7 @@ trait Node
     with NodeKeyBuilder
     with ActorSystemBuilder
     with StorageBuilder
+    with BlockMetadataProxyBuilder
     with BlockchainBuilder
     with BlockQueueBuilder
     with ConsensusBuilder

--- a/src/main/scala/io/iohk/ethereum/nodebuilder/TestNode.scala
+++ b/src/main/scala/io/iohk/ethereum/nodebuilder/TestNode.scala
@@ -18,6 +18,7 @@ class TestNode extends BaseNode {
   lazy val testModeComponentsProvider: TestModeComponentsProvider =
     new TestModeComponentsProvider(
       blockchain,
+      blockMetadataProxy,
       blockchainReader,
       blockchainWriter,
       storagesInstance.storages.evmCodeStorage,

--- a/src/main/scala/io/iohk/ethereum/testmode/TestModeComponentsProvider.scala
+++ b/src/main/scala/io/iohk/ethereum/testmode/TestModeComponentsProvider.scala
@@ -1,18 +1,13 @@
 package io.iohk.ethereum.testmode
 
 import akka.util.ByteString
-
 import monix.execution.Scheduler
-
 import io.iohk.ethereum.consensus.ConsensusAdapter
 import io.iohk.ethereum.consensus.ConsensusImpl
 import io.iohk.ethereum.consensus.mining.MiningConfig
 import io.iohk.ethereum.crypto
 import io.iohk.ethereum.db.storage.EvmCodeStorage
-import io.iohk.ethereum.domain.BlockchainImpl
-import io.iohk.ethereum.domain.BlockchainReader
-import io.iohk.ethereum.domain.BlockchainWriter
-import io.iohk.ethereum.domain.UInt256
+import io.iohk.ethereum.domain.{BlockMetadataProxy, BlockchainImpl, BlockchainReader, BlockchainWriter, UInt256}
 import io.iohk.ethereum.ledger.BlockValidation
 import io.iohk.ethereum.ledger.VMImpl
 import io.iohk.ethereum.nodebuilder.TestNode
@@ -20,6 +15,7 @@ import io.iohk.ethereum.nodebuilder.TestNode
 /** Provides a ledger or consensus instances with modifiable blockchain config (used in test mode). */
 class TestModeComponentsProvider(
     blockchain: BlockchainImpl,
+    blockMetadataProxy: BlockMetadataProxy,
     blockchainReader: BlockchainReader,
     blockchainWriter: BlockchainWriter,
     evmCodeStorage: EvmCodeStorage,
@@ -48,6 +44,7 @@ class TestModeComponentsProvider(
     new ConsensusAdapter(
       new ConsensusImpl(
         blockchain,
+        blockMetadataProxy,
         blockchainReader,
         blockchainWriter,
         blockExecution

--- a/src/main/scala/io/iohk/ethereum/testmode/TestModeComponentsProvider.scala
+++ b/src/main/scala/io/iohk/ethereum/testmode/TestModeComponentsProvider.scala
@@ -1,13 +1,19 @@
 package io.iohk.ethereum.testmode
 
 import akka.util.ByteString
+
 import monix.execution.Scheduler
+
 import io.iohk.ethereum.consensus.ConsensusAdapter
 import io.iohk.ethereum.consensus.ConsensusImpl
 import io.iohk.ethereum.consensus.mining.MiningConfig
 import io.iohk.ethereum.crypto
 import io.iohk.ethereum.db.storage.EvmCodeStorage
-import io.iohk.ethereum.domain.{BlockMetadataProxy, BlockchainImpl, BlockchainReader, BlockchainWriter, UInt256}
+import io.iohk.ethereum.domain.BlockMetadataProxy
+import io.iohk.ethereum.domain.BlockchainImpl
+import io.iohk.ethereum.domain.BlockchainReader
+import io.iohk.ethereum.domain.BlockchainWriter
+import io.iohk.ethereum.domain.UInt256
 import io.iohk.ethereum.ledger.BlockValidation
 import io.iohk.ethereum.ledger.VMImpl
 import io.iohk.ethereum.nodebuilder.TestNode

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/ScenarioSetup.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/ScenarioSetup.scala
@@ -95,6 +95,7 @@ trait ScenarioSetup extends StdTestMiningBuilder with StxLedgerBuilder {
     new ConsensusAdapter(
       new ConsensusImpl(
         blockchain,
+        blockMetadataProxy,
         blockchainReader,
         blockchainWriter,
         blockExecutionOpt.getOrElse(mkBlockExecution(validators))

--- a/src/test/scala/io/iohk/ethereum/consensus/ConsensusAdapterSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/ConsensusAdapterSpec.scala
@@ -176,7 +176,7 @@ class ConsensusAdapterSpec extends AnyFlatSpec with Matchers with ScalaFutures {
 
     val mockExecution = mock[BlockExecution]
     (mockExecution
-      .executeAndValidateBlocks(_: List[Block], _: ChainWeight)(_: BlockchainConfig))
+      .executeBlocks(_: List[Block], _: ChainWeight)(_: BlockchainConfig))
       .expects(newBranch, *, *)
       .returning((List(blockData2, blockData3), None))
 
@@ -224,7 +224,7 @@ class ConsensusAdapterSpec extends AnyFlatSpec with Matchers with ScalaFutures {
 
     val mockExecution = mock[BlockExecution]
     (mockExecution
-      .executeAndValidateBlocks(_: List[Block], _: ChainWeight)(_: BlockchainConfig))
+      .executeBlocks(_: List[Block], _: ChainWeight)(_: BlockchainConfig))
       .expects(newBranch, *, *)
       .returning((List(blockData2), Some(execError)))
 
@@ -328,7 +328,7 @@ class ConsensusAdapterSpec extends AnyFlatSpec with Matchers with ScalaFutures {
 
     val mockExecution = mock[BlockExecution]
     (mockExecution
-      .executeAndValidateBlocks(_: List[Block], _: ChainWeight)(_: BlockchainConfig))
+      .executeBlocks(_: List[Block], _: ChainWeight)(_: BlockchainConfig))
       .expects(newBranch, *, *)
       .returning((List(blockData2, blockData3), None))
 
@@ -359,7 +359,7 @@ class ConsensusAdapterSpec extends AnyFlatSpec with Matchers with ScalaFutures {
     val newBlock2: Block = getBlock(bestNum, difficulty = 105, parent = newBlock1.header.hash)
 
     (mockExecution
-      .executeAndValidateBlocks(_: List[Block], _: ChainWeight)(_: BlockchainConfig))
+      .executeBlocks(_: List[Block], _: ChainWeight)(_: BlockchainConfig))
       .expects(List(newBlock1, newBlock2), *, *)
       .returning((Nil, Some(execError)))
     val consensusAdapterWithFailingExecution = blockImportWithMockedBlockExecution(mockExecution)
@@ -388,7 +388,7 @@ class ConsensusAdapterSpec extends AnyFlatSpec with Matchers with ScalaFutures {
     val newBlock2bis: Block = getBlock(bestNum + 2, difficulty = 50, parent = newBlock1.header.hash)
 
     (mockExecution
-      .executeAndValidateBlocks(_: List[Block], _: ChainWeight)(_: BlockchainConfig))
+      .executeBlocks(_: List[Block], _: ChainWeight)(_: BlockchainConfig))
       .expects(List(newBlock1, newBlock2), *, *)
       .returning((Nil, Some(execError)))
     val consensusAdapterWithFailingExecution = blockImportWithMockedBlockExecution(mockExecution)
@@ -424,7 +424,7 @@ class ConsensusAdapterSpec extends AnyFlatSpec with Matchers with ScalaFutures {
     val newBlock3bis: Block = getBlock(bestNum + 3, difficulty = 50, parent = newBlock2.header.hash)
 
     (mockExecution
-      .executeAndValidateBlocks(_: List[Block], _: ChainWeight)(_: BlockchainConfig))
+      .executeBlocks(_: List[Block], _: ChainWeight)(_: BlockchainConfig))
       .expects(List(newBlock1, newBlock2, newBlock3), *, *)
       .returning((List(BlockData(newBlock1, Nil, currentWeight.increase(newBlock1.header))), Some(execError)))
     val consensusAdapterWithFailingExecution = blockImportWithMockedBlockExecution(mockExecution)
@@ -465,7 +465,7 @@ class ConsensusAdapterSpec extends AnyFlatSpec with Matchers with ScalaFutures {
     val newBlock3bis: Block = getBlock(bestNum + 3, difficulty = 10, parent = badBlock.header.hash)
 
     (mockExecution
-      .executeAndValidateBlocks(_: List[Block], _: ChainWeight)(_: BlockchainConfig))
+      .executeBlocks(_: List[Block], _: ChainWeight)(_: BlockchainConfig))
       .expects(List(badBlock, newBlock3), *, *)
       .returning((Nil, Some(execError)))
     val consensusAdapterWithFailingExecution = blockImportWithMockedBlockExecution(mockExecution)
@@ -501,7 +501,7 @@ class ConsensusAdapterSpec extends AnyFlatSpec with Matchers with ScalaFutures {
 
     val mockExecution = mock[BlockExecution]
     (mockExecution
-      .executeAndValidateBlocks(_: List[Block], _: ChainWeight)(_: BlockchainConfig))
+      .executeBlocks(_: List[Block], _: ChainWeight)(_: BlockchainConfig))
       .expects(List(checkpointBlock), *, *)
       .returning((List(BlockData(checkpointBlock, Nil, weightCheckpoint)), None))
 

--- a/src/test/scala/io/iohk/ethereum/consensus/ConsensusImplSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/ConsensusImplSpec.scala
@@ -90,7 +90,7 @@ object ConsensusImplSpec {
     private val testSetup = new EphemBlockchainTestSetup with MockFactory {
       override lazy val blockExecution: BlockExecution = stub[BlockExecution]
       (blockExecution
-        .executeAndValidateBlocks(_: List[Block], _: ChainWeight)(_: BlockchainConfig))
+        .executeBlocks(_: List[Block], _: ChainWeight)(_: BlockchainConfig))
         .when(*, *, *)
         .anyNumberOfTimes()
         .onCall { (blocks, _, _) =>

--- a/src/test/scala/io/iohk/ethereum/consensus/ConsensusImplSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/ConsensusImplSpec.scala
@@ -1,12 +1,16 @@
 package io.iohk.ethereum.consensus
 
 import akka.util.ByteString
+
 import cats.data.NonEmptyList
+
 import monix.execution.Scheduler
+
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+
 import io.iohk.ethereum.BlockHelpers
 import io.iohk.ethereum.NormalPatience
 import io.iohk.ethereum.blockchain.sync.EphemBlockchainTestSetup

--- a/src/test/scala/io/iohk/ethereum/consensus/blocks/BlockGeneratorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/blocks/BlockGeneratorSpec.scala
@@ -57,7 +57,7 @@ class BlockGeneratorSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
       fullBlock.header,
       blockchainReader.getBlockHeaderByHash
     ) shouldBe Right(BlockHeaderValid)
-    blockExecution.executeAndValidateBlock(fullBlock) shouldBe a[Right[_, Seq[Receipt]]]
+    blockExecution.executeAndBlock(fullBlock) shouldBe a[Right[_, Seq[Receipt]]]
     fullBlock.header.extraData shouldBe headerExtraData
   }
 
@@ -84,7 +84,7 @@ class BlockGeneratorSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
       fullBlock.header,
       blockchainReader.getBlockHeaderByHash
     ) shouldBe Right(BlockHeaderValid)
-    blockExecution.executeAndValidateBlock(fullBlock) shouldBe a[Right[_, Seq[Receipt]]]
+    blockExecution.executeAndBlock(fullBlock) shouldBe a[Right[_, Seq[Receipt]]]
     fullBlock.header.extraData shouldBe headerExtraData
   }
 
@@ -166,7 +166,7 @@ class BlockGeneratorSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
       blockchainReader.getBlockHeaderByHash
     ) shouldBe Right(BlockHeaderValid)
 
-    blockExecution.executeAndValidateBlock(fullBlock) shouldBe a[Right[_, Seq[Receipt]]]
+    blockExecution.executeAndBlock(fullBlock) shouldBe a[Right[_, Seq[Receipt]]]
     fullBlock.body.transactionList shouldBe Seq(signedTransaction)
     fullBlock.header.extraData shouldBe headerExtraData
   }
@@ -203,7 +203,7 @@ class BlockGeneratorSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
       fullBlock.header,
       blockchainReader.getBlockHeaderByHash
     ) shouldBe Right(BlockHeaderValid)
-    blockExecution.executeAndValidateBlock(fullBlock) shouldBe a[Right[_, Seq[Receipt]]]
+    blockExecution.executeAndBlock(fullBlock) shouldBe a[Right[_, Seq[Receipt]]]
     fullBlock.body.transactionList shouldBe Seq(signedTransaction)
     fullBlock.header.extraData shouldBe headerExtraData
   }
@@ -269,7 +269,7 @@ class BlockGeneratorSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
       fullBlock.header,
       blockchainReader.getBlockHeaderByHash
     ) shouldBe Right(BlockHeaderValid)
-    blockExecution.executeAndValidateBlock(fullBlock) shouldBe a[Right[_, Seq[Receipt]]]
+    blockExecution.executeAndBlock(fullBlock) shouldBe a[Right[_, Seq[Receipt]]]
     fullBlock.body.transactionList shouldBe Seq(generalTx)
     fullBlock.header.extraData shouldBe headerExtraData
   }
@@ -325,7 +325,7 @@ class BlockGeneratorSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
         .generateBlock(bestBlock.get, Seq(generalTx), Address(testAddress), blockGenerator.emptyX, None)
         .pendingBlock
 
-    blockExecution.executeAndValidateBlock(generatedBlock.block, true) shouldBe a[Right[_, Seq[Receipt]]]
+    blockExecution.executeAndBlock(generatedBlock.block) shouldBe a[Right[_, Seq[Receipt]]]
   }
 
   it should "generate block after eip155 and allow both chain specific and general transactions" in new TestSetup {
@@ -359,7 +359,7 @@ class BlockGeneratorSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
     validators.blockHeaderValidator.validate(fullBlock.header, blockchainReader.getBlockHeaderByHash) shouldBe Right(
       BlockHeaderValid
     )
-    blockExecution.executeAndValidateBlock(fullBlock) shouldBe a[Right[_, Seq[Receipt]]]
+    blockExecution.executeAndBlock(fullBlock) shouldBe a[Right[_, Seq[Receipt]]]
     fullBlock.body.transactionList shouldBe Seq(signedTransaction, generalTx)
     fullBlock.header.extraData shouldBe headerExtraData
   }
@@ -396,7 +396,7 @@ class BlockGeneratorSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
     validators.blockHeaderValidator.validate(fullBlock.header, blockchainReader.getBlockHeaderByHash) shouldBe Right(
       BlockHeaderValid
     )
-    blockExecution.executeAndValidateBlock(fullBlock) shouldBe a[Right[_, Seq[Receipt]]]
+    blockExecution.executeAndBlock(fullBlock) shouldBe a[Right[_, Seq[Receipt]]]
     fullBlock.body.transactionList shouldBe Seq(signedTransaction, nextTransaction)
     fullBlock.header.extraData shouldBe headerExtraData
   }
@@ -446,7 +446,7 @@ class BlockGeneratorSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
     validators.blockHeaderValidator.validate(fullBlock.header, blockchainReader.getBlockHeaderByHash) shouldBe Right(
       BlockHeaderValid
     )
-    blockExecution.executeAndValidateBlock(fullBlock) shouldBe a[Right[_, Seq[Receipt]]]
+    blockExecution.executeAndBlock(fullBlock) shouldBe a[Right[_, Seq[Receipt]]]
     fullBlock.body.transactionList shouldBe Seq(signedTransaction, nextTransaction)
     fullBlock.header.extraData shouldBe headerExtraData
   }
@@ -482,7 +482,7 @@ class BlockGeneratorSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
     validators.blockHeaderValidator.validate(fullBlock.header, blockchainReader.getBlockHeaderByHash) shouldBe Right(
       BlockHeaderValid
     )
-    blockExecution.executeAndValidateBlock(fullBlock) shouldBe a[Right[_, Seq[Receipt]]]
+    blockExecution.executeAndBlock(fullBlock) shouldBe a[Right[_, Seq[Receipt]]]
     fullBlock.body.transactionList shouldBe Seq(signedTransaction)
     fullBlock.header.extraData shouldBe headerExtraData
   }
@@ -564,7 +564,7 @@ class BlockGeneratorSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
     {
       import validator._
 
-      blockExecution.executeAndValidateBlock(block.block, alreadyValidated = true) shouldBe
+      blockExecution.executeAndBlock(block.block) shouldBe
         Left(
           ValidationAfterExecError(
             "Block has invalid state root hash, expected 47344722e6c52a85685f9c1bb1e0fe66cfaf6be00c1a752f43cc835fb7415e81 but got 41b63e59d34b5b35a040d496582fc587887af79f762210f6cf55c24d2c307d61"
@@ -602,7 +602,7 @@ class BlockGeneratorSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
 
     {
       import validator._
-      blockExecution.executeAndValidateBlock(block.block, alreadyValidated = true) shouldBe
+      blockExecution.executeAndBlock(block.block) shouldBe
         Left(
           ValidationAfterExecError(
             "Block has invalid state root hash, expected 5bfc811dfee1fecaefbaef2dba502082a8cc72e52260368d83ed6e4ebcecae75 but got 41b63e59d34b5b35a040d496582fc587887af79f762210f6cf55c24d2c307d61"

--- a/src/test/scala/io/iohk/ethereum/db/storage/BlockMetadataStorageSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/db/storage/BlockMetadataStorageSpec.scala
@@ -1,0 +1,58 @@
+package io.iohk.ethereum.db.storage
+
+import io.iohk.ethereum.ObjectGenerators
+import io.iohk.ethereum.db.dataSource.EphemDataSource
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+
+class BlockMetadataStorageSpec extends AnyFunSuite with ScalaCheckPropertyChecks with ObjectGenerators {
+  test("BlockMetadataStorage insert") {
+    forAll(Gen.listOf(byteStringOfLengthNGen(32))) { blockByteArrayHashes =>
+      val blockHashes = blockByteArrayHashes.distinct
+      val metadataList = Gen.listOf(blockMetadataGen).sample.get
+      val hashesMetadataPairs = blockHashes.zip(metadataList)
+
+      val storage = new BlockMetadataStorage(EphemDataSource())
+      val batchUpdates = hashesMetadataPairs.foldLeft(storage.emptyBatchUpdate) {
+        case (updates, (blockHash, metadata)) => updates.and(storage.put(blockHash, metadata))
+      }
+      batchUpdates.commit()
+
+      hashesMetadataPairs.foreach { case (blockHash, metadata) =>
+        assert(storage.get(blockHash).contains(metadata))
+      }
+    }
+  }
+
+  test("BlockMetadataStorage delete") {
+    forAll(Gen.listOf(byteStringOfLengthNGen(32))) { blockByteArrayHashes =>
+      val blockHashes = blockByteArrayHashes.distinct
+      val metadataList = Gen.listOf(blockMetadataGen).sample.get
+      val hashesMetadataPairs = blockHashes.zip(metadataList)
+
+      // insert data
+      val storage = new BlockMetadataStorage(EphemDataSource())
+      val batchUpdates = hashesMetadataPairs.foldLeft(storage.emptyBatchUpdate) {
+        case (updates, (blockHash, metadata)) => updates.and(storage.put(blockHash, metadata))
+      }
+      batchUpdates.commit()
+
+      //delete data
+      val (toDelete, toLeave) = hashesMetadataPairs.splitAt(Gen.choose(0, hashesMetadataPairs.size).sample.get)
+      val storageDeletions = toDelete.foldLeft(storage.emptyBatchUpdate) { case (updates, (blockHash, _)) =>
+        updates.and(storage.remove(blockHash))
+      }
+      storageDeletions.commit()
+
+      toLeave.foreach { case (hash, metadata) =>
+        assert(storage.get(hash).contains(metadata))
+      }
+      toDelete.foreach { case (hash, _) => assert(storage.get(hash).isEmpty) }
+    }
+  }
+
+  val blockMetadataGen: Gen[BlockMetadata] = for {
+    isExecuted <- Arbitrary.arbitrary[Boolean]
+  } yield BlockMetadata(isExecuted)
+}

--- a/src/test/scala/io/iohk/ethereum/db/storage/BlockMetadataStorageSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/db/storage/BlockMetadataStorageSpec.scala
@@ -1,10 +1,12 @@
 package io.iohk.ethereum.db.storage
 
-import io.iohk.ethereum.ObjectGenerators
-import io.iohk.ethereum.db.dataSource.EphemDataSource
-import org.scalacheck.{Arbitrary, Gen}
+import org.scalacheck.Arbitrary
+import org.scalacheck.Gen
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+
+import io.iohk.ethereum.ObjectGenerators
+import io.iohk.ethereum.db.dataSource.EphemDataSource
 
 class BlockMetadataStorageSpec extends AnyFunSuite with ScalaCheckPropertyChecks with ObjectGenerators {
   test("BlockMetadataStorage insert") {

--- a/src/test/scala/io/iohk/ethereum/db/storage/CachedNodeStorageSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/db/storage/CachedNodeStorageSpec.scala
@@ -15,8 +15,8 @@ import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import io.iohk.ethereum.ObjectGenerators
 import io.iohk.ethereum.db.cache.MapCache
 import io.iohk.ethereum.db.dataSource.EphemDataSource
-import io.iohk.ethereum.db.storage.NodeStorage.NodeEncoded
-import io.iohk.ethereum.db.storage.NodeStorage.NodeHash
+import io.iohk.ethereum.db.storage.StorageTypes.NodeEncoded
+import io.iohk.ethereum.db.storage.StorageTypes.NodeHash
 import io.iohk.ethereum.utils.Config.NodeCacheConfig
 
 class CachedNodeStorageSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyChecks with ObjectGenerators {

--- a/src/test/scala/io/iohk/ethereum/db/storage/ReadOnlyNodeStorageSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/db/storage/ReadOnlyNodeStorageSpec.scala
@@ -13,9 +13,9 @@ import io.iohk.ethereum.db.cache.Cache
 import io.iohk.ethereum.db.cache.LruCache
 import io.iohk.ethereum.db.cache.MapCache
 import io.iohk.ethereum.db.dataSource.EphemDataSource
-import io.iohk.ethereum.db.storage.NodeStorage.NodeEncoded
-import io.iohk.ethereum.db.storage.NodeStorage.NodeHash
 import io.iohk.ethereum.db.storage.StateStorage.GenesisDataLoad
+import io.iohk.ethereum.db.storage.StorageTypes.NodeEncoded
+import io.iohk.ethereum.db.storage.StorageTypes.NodeHash
 import io.iohk.ethereum.db.storage.pruning.InMemoryPruning
 import io.iohk.ethereum.mpt.LeafNode
 import io.iohk.ethereum.utils.Config.NodeCacheConfig

--- a/src/test/scala/io/iohk/ethereum/db/storage/StateStorageSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/db/storage/StateStorageSpec.scala
@@ -15,8 +15,8 @@ import io.iohk.ethereum.db.cache.Cache
 import io.iohk.ethereum.db.cache.LruCache
 import io.iohk.ethereum.db.cache.MapCache
 import io.iohk.ethereum.db.dataSource.EphemDataSource
-import io.iohk.ethereum.db.storage.NodeStorage.NodeEncoded
-import io.iohk.ethereum.db.storage.NodeStorage.NodeHash
+import io.iohk.ethereum.db.storage.StorageTypes.NodeEncoded
+import io.iohk.ethereum.db.storage.StorageTypes.NodeHash
 import io.iohk.ethereum.db.storage.pruning.ArchivePruning
 import io.iohk.ethereum.db.storage.pruning.BasicPruning
 import io.iohk.ethereum.db.storage.pruning.InMemoryPruning

--- a/src/test/scala/io/iohk/ethereum/ledger/BlockExecutionSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/BlockExecutionSpec.scala
@@ -73,7 +73,7 @@ class BlockExecutionSpec extends AnyWordSpec with Matchers with ScalaCheckProper
             blockValidation
           )
 
-        val (blocks, error) = blockExecution.executeAndValidateBlocks(List(block1, block2), defaultChainWeight)
+        val (blocks, error) = blockExecution.executeBlocks(List(block1, block2), defaultChainWeight)
 
         // No block should be executed if first one has invalid transactions
         blocks.isEmpty shouldBe true
@@ -115,7 +115,7 @@ class BlockExecutionSpec extends AnyWordSpec with Matchers with ScalaCheckProper
             blockValidation
           )
 
-        val (blocks, error) = blockExecution.executeAndValidateBlocks(List(block1, block2), defaultChainWeight)
+        val (blocks, error) = blockExecution.executeBlocks(List(block1, block2), defaultChainWeight)
 
         // Only first block should be executed
         blocks.size shouldBe 1
@@ -150,7 +150,7 @@ class BlockExecutionSpec extends AnyWordSpec with Matchers with ScalaCheckProper
             blockValidation
           )
 
-        val (blocks, error) = blockExecution.executeAndValidateBlocks(chain, defaultChainWeight)
+        val (blocks, error) = blockExecution.executeBlocks(chain, defaultChainWeight)
 
         // All blocks but the last should be executed, and they should be returned in incremental order
         blocks.map(_.block) shouldBe chain.init
@@ -182,7 +182,7 @@ class BlockExecutionSpec extends AnyWordSpec with Matchers with ScalaCheckProper
           )
 
         val (blocks, error) =
-          blockExecution.executeAndValidateBlocks(List(blockWithCheckpoint), defaultChainWeight)
+          blockExecution.executeBlocks(List(blockWithCheckpoint), defaultChainWeight)
         val beneficiaryAccount =
           blockchainReader.getAccount(
             blockchainReader.getBestBranch(),
@@ -434,7 +434,7 @@ class BlockExecutionSpec extends AnyWordSpec with Matchers with ScalaCheckProper
         )
         val block = Block(blockHeader, blockBodyWithOmmers)
 
-        val blockExecResult = blockExecution.executeAndValidateBlock(block)
+        val blockExecResult = blockExecution.executeAndBlock(block)
         assert(blockExecResult.isRight)
       }
     }
@@ -481,7 +481,7 @@ class BlockExecutionSpec extends AnyWordSpec with Matchers with ScalaCheckProper
       val block = Block(blockHeader, validBlockBodyWithNoTxs)
 
       assert(seqFailingValidators.forall { _ =>
-        val blockExecResult = blockExecution.executeAndValidateBlock(block)
+        val blockExecResult = blockExecution.executeAndBlock(block)
 
         blockExecResult.left.forall {
           case _: BlockExecutionError.ValidationBeforeExecError => true
@@ -535,7 +535,7 @@ class BlockExecutionSpec extends AnyWordSpec with Matchers with ScalaCheckProper
           validBlockHeader.copy(gasUsed = cumulativeGasUsedBlock, stateRoot = stateRootHash)
         val block = Block(blockHeader, validBlockBodyWithNoTxs)
 
-        val blockExecResult = blockExecution.executeAndValidateBlock(block)
+        val blockExecResult = blockExecution.executeAndBlock(block)
 
         assert(blockExecResult match {
           case Left(_: BlockExecutionError.ValidationAfterExecError) => true
@@ -641,7 +641,7 @@ class BlockExecutionSpec extends AnyWordSpec with Matchers with ScalaCheckProper
         val blockWithCorrectStateAndGasUsed = block.copy(
           header = block.header.copy(stateRoot = blockExpectedStateRoot, gasUsed = gasUsedReceipt2)
         )
-        assert(blockExecution.executeAndValidateBlock(blockWithCorrectStateAndGasUsed).isRight)
+        assert(blockExecution.executeAndBlock(blockWithCorrectStateAndGasUsed).isRight)
       }
     }
 

--- a/src/test/scala/io/iohk/ethereum/ledger/LedgerTestSetup.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/LedgerTestSetup.scala
@@ -380,6 +380,7 @@ trait TestSetupWithVmAndValidators extends EphemBlockchainTestSetup {
     val blockValidation = new BlockValidation(testMining, blockchainReader, blockQueue)
     val consensus = new ConsensusImpl(
       blockchain,
+      blockMetadataProxy,
       blockchainReader,
       blockchainWriter,
       new BlockExecution(

--- a/src/test/scala/io/iohk/ethereum/ledger/LedgerTestSetup.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/LedgerTestSetup.scala
@@ -390,9 +390,8 @@ trait TestSetupWithVmAndValidators extends EphemBlockchainTestSetup {
         testMining.blockPreparator,
         blockValidation
       ) {
-        override def executeAndValidateBlock(
-            block: Block,
-            alreadyValidated: Boolean = false
+        override def executeAndBlock(
+            block: Block
         )(implicit blockchainConfig: BlockchainConfig): Either[BlockExecutionError, Seq[Receipt]] = {
           val emptyWorld = InMemoryWorldStateProxy(
             storagesInstance.storages.evmCodeStorage,


### PR DESCRIPTION
# Description

In order to have explicit and easily queryable information on whether blocks have already been successfully executed, a new storage  `BlockMetadaStorage`  (and `BlockMetadataProxy` ) was added. 
This storage can easily be extended in the future if we need more metadata block information.


# Proposed Solution
Added BlockMetadaStorage, BlockMetadataProxy and modified ConsensusImpl to first check for already executed blocks and only executed those blocks not yet executed.
A small step of this implementation is missing, which is to add the initial block metadata with `isExecuted=false`, because it can only be done once saving blocks is extracted from BlockExecutions and done in a chains manager layers. Follow-up ticket created ETCM-1138
The PR is divided into several commits, that help on the review. 

# Testing
Tested again ETC mainnet 

