### PR TITLE
[ETCM-1152] Remove double call to appStateStorage.getBestBlockNumber() in getBestBranch()

### DIFF
--- a/src/main/scala/io/iohk/ethereum/domain/BlockchainReader.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/BlockchainReader.scala
@@ -78,7 +78,6 @@ class BlockchainReader(
     val number = getBestBlockNumber()
     blockNumberMappingStorage
       .get(number)
-      .orElse(blockNumberMappingStorage.get(appStateStorage.getBestBlockNumber()))
       .map(hash => BestBranch(hash, number))
       .getOrElse(EmptyBranch)
   }


### PR DESCRIPTION

# Description

In BlochchainReader, in method getBestBranch() a double call to appStateStorage.getBestBlockNumber() was being made and can just be removed

