### PR TITLE
[ETCM-1152] Populate berlin fork block number in test config

### DIFF
--- a/src/main/scala/io/iohk/ethereum/jsonrpc/TestJsonMethodsImplicits.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/TestJsonMethodsImplicits.scala
@@ -100,6 +100,7 @@ object TestJsonMethodsImplicits extends JsonMethodsImplicits {
           homesteadForkBlock <- optionalQuantity(blockchainParamsJson \ "homesteadForkBlock")
           constantinopleForkBlock <- optionalQuantity(blockchainParamsJson \ "constantinopleForkBlock")
           istanbulForkBlock <- optionalQuantity(blockchainParamsJson \ "istanbulForkBlock")
+          berlinForkBlock <- optionalQuantity(blockchainParamsJson \ "berlinForkBlock")
         } yield BlockchainParams(
           EIP150ForkBlock = eIP150ForkBlock,
           EIP158ForkBlock = eIP158ForkBlock,
@@ -110,7 +111,8 @@ object TestJsonMethodsImplicits extends JsonMethodsImplicits {
           homesteadForkBlock = homesteadForkBlock,
           maximumExtraDataSize = 0,
           constantinopleForkBlock = constantinopleForkBlock,
-          istanbulForkBlock = istanbulForkBlock
+          istanbulForkBlock = istanbulForkBlock,
+          berlinForkBlock = berlinForkBlock
         )
 
       override def encodeJson(t: SetChainParamsResponse): JValue = true

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/TestService.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/TestService.scala
@@ -70,7 +70,8 @@ object TestService {
       homesteadForkBlock: Option[BigInt],
       maximumExtraDataSize: BigInt,
       constantinopleForkBlock: Option[BigInt],
-      istanbulForkBlock: Option[BigInt]
+      istanbulForkBlock: Option[BigInt],
+      berlinForkBlock: Option[BigInt]
   )
 
   case class ChainParams(
@@ -215,6 +216,7 @@ class TestService(
   private def buildNewConfig(blockchainParams: BlockchainParams) = {
     val byzantiumBlockNumber: BigInt = blockchainParams.byzantiumForkBlock.getOrElse(neverOccurringBlock)
     val istanbulForkBlockNumber: BigInt = blockchainParams.istanbulForkBlock.getOrElse(neverOccurringBlock)
+    val berlinForkBlockNumber: BigInt = blockchainParams.berlinForkBlock.getOrElse(neverOccurringBlock)
 
     // For block number which are not specified by retesteth, we try to align the number to another fork
     node.blockchainConfig.copy(
@@ -230,7 +232,8 @@ class TestService(
         aghartaBlockNumber = istanbulForkBlockNumber,
         istanbulBlockNumber = istanbulForkBlockNumber,
         atlantisBlockNumber = istanbulForkBlockNumber,
-        phoenixBlockNumber = istanbulForkBlockNumber
+        phoenixBlockNumber = istanbulForkBlockNumber,
+        berlinBlockNumber = berlinForkBlockNumber
       ),
       accountStartNonce = UInt256(blockchainParams.accountStartNonce),
       networkId = 1,


### PR DESCRIPTION
# Description

ETS call setChainParams for every tests.
Berlin fork block number should be used and populate mantis config.
